### PR TITLE
修复用户密码含有特殊字符时 schemasync 对比报错

### DIFF
--- a/sql/instance.py
+++ b/sql/instance.py
@@ -96,8 +96,8 @@ def schemasync(request):
     timestamp = int(time.time())
     output_directory = os.path.join(settings.BASE_DIR, 'downloads/schemasync/')
 
-    command = path + ' %s --output-directory=%s --tag=%s \
-            mysql://%s:%s@%s:%d/%s  mysql://%s:%s@%s:%d/%s' % (options,
+    command = path + " %s --output-directory=%s --tag=%s \
+            mysql://%s:'%s'@%s:%d/%s  mysql://%s:'%s'@%s:%d/%s" % (options,
                                                                output_directory,
                                                                timestamp,
                                                                instance_info.user,


### PR DESCRIPTION
command 中 raw_password 添加单引号