### PR TITLE
command 中密码添加单引号

### DIFF
--- a/sql/instance.py
+++ b/sql/instance.py
@@ -96,8 +96,8 @@ def schemasync(request):
     timestamp = int(time.time())
     output_directory = os.path.join(settings.BASE_DIR, 'downloads/schemasync/')
 
-    command = path + ' %s --output-directory=%s --tag=%s \
-            mysql://%s:%s@%s:%d/%s  mysql://%s:%s@%s:%d/%s' % (options,
+    command = path + " %s --output-directory=%s --tag=%s \
+            mysql://%s:'%s'@%s:%d/%s  mysql://%s:'%s'@%s:%d/%s" % (options,
                                                                output_directory,
                                                                timestamp,
                                                                instance_info.user,


### PR DESCRIPTION
修改 schemasync 对比时，实例用户密码包含特殊字符报错