### PR TITLE
清理工单上线内和engines无关的代码，各方法在engines中实现，工单只负责状态流转，方便接入不同数据库

### DIFF
--- a/sql/engines/__init__.py
+++ b/sql/engines/__init__.py
@@ -32,15 +32,15 @@ class EngineBase:
         """获取数据库列表, 返回一个list"""
         return []
 
-    def get_all_tables(self, db_name, schema_name=None):
+    def get_all_tables(self, db_name):
         """获取table 列表, 返回一个list"""
         return []
 
-    def get_all_columns_by_tb(self, db_name, tb_name, schema_name=None):
+    def get_all_columns_by_tb(self, db_name, tb_name):
         """获取所有字段, 返回一个list"""
         return []
 
-    def describe_table(self, db_name, tb_name, schema_name=None):
+    def describe_table(self, db_name, tb_name):
         """获取表结构, 返回一个 ResultSet"""
         return ResultSet()
 

--- a/sql/engines/inception.py
+++ b/sql/engines/inception.py
@@ -72,13 +72,14 @@ class InceptionEngine(EngineBase):
                             inception_magic_commit;"""
         inception_engine = InceptionEngine()
         inception_result = inception_engine.query(sql=inception_sql)
+        check_result.syntax_type = 2  # TODO 工单类型 1、DDL，2、DML 仅适用于MySQL，待调整
         for r in inception_result.rows:
             check_result.rows += [ReviewResult(inception_result=r)]
             if r[2] == 1:  # 警告
                 check_result.warning_count += 1
             elif r[2] == 2 or re.match(r"\w*comments\w*", r[4], re.I):  # 错误
                 check_result.error_count += 1
-            if get_syntax_type(r[5]) == 'DDL':  # 工单类型 1、DDL，2、DML
+            if get_syntax_type(r[5]) == 'DDL':
                 check_result.syntax_type = 1
         check_result.column_list = inception_result.column_list
         check_result.checked = True

--- a/sql/engines/inception.py
+++ b/sql/engines/inception.py
@@ -4,24 +4,30 @@ import re
 import traceback
 import MySQLdb
 import simplejson as json
+import sqlparse
+from django.db import connection, OperationalError
+
 from common.config import SysConfig
 from sql.models import SqlWorkflow
-
+from sql.utils.sql_utils import get_syntax_type
 from . import EngineBase
-from .models import ResultSet
+from .models import ResultSet, ReviewSet, ReviewResult
 
 logger = logging.getLogger('default')
 
 
 class InceptionEngine(EngineBase):
     def get_connection(self, db_name=None):
+        if self.conn:
+            return self.conn
         archer_config = SysConfig()
         inception_host = archer_config.get('inception_host')
         inception_port = int(archer_config.get('inception_port', 6669))
-        conn = MySQLdb.connect(host=inception_host, port=inception_port, charset='utf8')
-        return conn
+        self.conn = MySQLdb.connect(host=inception_host, port=inception_port, charset='utf8')
+        return self.conn
 
-    def get_backup_connection(self):
+    @staticmethod
+    def get_backup_connection():
         archer_config = SysConfig()
         backup_host = archer_config.get('inception_remote_backup_host')
         backup_port = int(archer_config.get('inception_remote_backup_port', 3306))
@@ -32,6 +38,115 @@ class InceptionEngine(EngineBase):
                                user=backup_user,
                                passwd=backup_password,
                                charset='utf8')
+
+    def execute_check(self, instance=None, db_name=None, sql=''):
+        """inception check"""
+        check_result = ReviewSet(full_sql=sql)
+        # 检查 inception 不支持的函数
+        check_result.rows = []
+        line = 1
+        for statement in sqlparse.split(sql):
+            # 删除注释语句
+            statement = sqlparse.format(statement, strip_comments=True)
+            if re.match(r"(\s*)alter(\s+)table(\s+)(\S+)(\s*);|(\s*)alter(\s+)table(\s+)(\S+)\.(\S+)(\s*);",
+                        statement.lower() + ";"):
+                result = ReviewSet(
+                    id=line, errlevel=2, stagestatus='SQL语法错误',
+                    errormessage='ALTER TABLE 必须带有选项',
+                    sql=statement)
+                check_result.is_critical = True
+            else:
+                result = ReviewSet(id=line, errlevel=0, sql=statement)
+            check_result.rows += [result]
+            line += 1
+        if check_result.is_critical:
+            return check_result
+
+        # inception 校验
+        check_result.rows = []
+        inception_sql = f"""/*--user={instance.user};--password={instance.raw_password};--host={instance.host};
+                            --port={instance.port};--enable-check=1;*/
+                            inception_magic_start;
+                            use {db_name};
+                            {sql}
+                            inception_magic_commit;"""
+        inception_engine = InceptionEngine()
+        inception_result = inception_engine.query(sql=inception_sql)
+        for r in inception_result.rows:
+            check_result.rows += [ReviewResult(inception_result=r)]
+            if r[2] == 1:  # 警告
+                check_result.warning_count += 1
+            elif r[2] == 2 or re.match(r"\w*comments\w*", r[4], re.I):  # 错误
+                check_result.error_count += 1
+            if get_syntax_type(r[5]) == 'DDL':  # 工单类型 1、DDL，2、DML
+                check_result.syntax_type = 1
+        check_result.column_list = inception_result.column_list
+        check_result.checked = True
+        return check_result
+
+    def execute(self, workflow=None):
+        """执行上线单"""
+        instance = workflow.instance
+        execute_result = ReviewSet(full_sql=workflow.sqlworkflowcontent.sql_content)
+        inception_engine = InceptionEngine()
+        if workflow.is_backup == '是':
+            str_backup = "--enable-remote-backup"
+        else:
+            str_backup = "--disable-remote-backup"
+        # 根据inception的要求，执行之前最好先split一下
+        sql_split = f"""/*--user={instance.user};--password={instance.raw_password};--host={instance.host}; 
+                         --port={instance.port};--enable-ignore-warnings;--enable-split;*/
+                         inception_magic_start;
+                         use {workflow.db_name};
+                         {workflow.sqlworkflowcontent.sql_content}
+                         inception_magic_commit;"""
+        split_result = inception_engine.query(sql=sql_split)
+
+        execute_result.rows = []
+        # 对于split好的结果，再次交给inception执行，保持长连接里执行.
+        for splitRow in split_result.rows:
+            sql_tmp = splitRow[1]
+            sql_execute = f"""/*--user={instance.user};--password={instance.raw_password};--host={instance.host};
+                                --port={instance.port};--enable-execute;--enable-ignore-warnings;{str_backup};*/\
+                                inception_magic_start;\
+                                {sql_tmp}\
+                                inception_magic_commit;"""
+            one_line_execute_result = inception_engine.query(sql=sql_execute, close_conn=False)
+            # 执行, 把结果转换为ReviewSet
+            for sqlRow in one_line_execute_result.to_dict():
+                execute_result.rows.append(ReviewResult(
+                    id=sqlRow['ID'],
+                    stage=sqlRow['stage'],
+                    errlevel=sqlRow['errlevel'],
+                    stagestatus=sqlRow['stagestatus'],
+                    errormessage=sqlRow['errormessage'],
+                    sql=sqlRow['SQL'],
+                    affected_rows=sqlRow['Affected_rows'],
+                    actual_affected_rows=sqlRow['Affected_rows'],
+                    sequence=sqlRow['sequence'],
+                    backup_dbname=sqlRow['backup_dbname'],
+                    execute_time=sqlRow['execute_time'],
+                    sqlsha1=sqlRow['sqlsha1']))
+
+            # 每执行一次，就将执行结果更新到工单的execute_result，便于展示执行进度和保存执行信息
+            workflow.sqlworkflowcontent.execute_result = execute_result.json()
+            try:
+                workflow.sqlworkflowcontent.save()
+                workflow.save()
+            # 防止执行超时
+            except OperationalError:
+                connection.close()
+                workflow.sqlworkflowcontent.save()
+                workflow.save()
+
+        # 如果发现任何一个行执行结果里有errLevel为1或2，并且stagestatus列没有包含Execute Successfully字样，则最终执行结果为有异常.
+        execute_result.status = "workflow_finish"
+        for sqlRow in execute_result.rows:
+            if sqlRow.errlevel in (1, 2) and re.match(r"\w*Execute Successfully\w*", sqlRow.stagestatus) is None:
+                execute_result.status = "workflow_exception"
+                execute_result.error = "Line {0} has error/warning: {1}".format(sqlRow.id, sqlRow.errormessage)
+                break
+        return execute_result
 
     def query(self, db_name=None, sql='', limit_num=0, close_conn=True):
         """返回 ResultSet """
@@ -52,23 +167,20 @@ class InceptionEngine(EngineBase):
             result_set.column_list = column_list
             result_set.rows = rows
             result_set.affected_rows = effect_row
-        conn.close()
+        if close_conn:
+            self.close()
         return result_set
 
     def query_print(self, instance, db_name=None, sql=''):
         """
         将sql交给inception打印语法树。
         """
-        sql = "/*--user=%s;--password=%s;--host=%s;--port=%d;--enable-query-print;*/\
+        sql = f"""/*--user={instance.user};--password={instance.raw_password};--host={instance.host};
+                          --port={instance.port};--enable-query-print;*/
                           inception_magic_start;\
-                          use %s;\
-                          %s\
-                          inception_magic_commit;" % (instance.user,
-                                                      instance.raw_password,
-                                                      instance.host,
-                                                      instance.port,
-                                                      db_name,
-                                                      sql)
+                          use {db_name};
+                          {sql}
+                          inception_magic_commit;"""
         print_info = self.query(db_name=db_name, sql=sql).to_dict()[0]
         # 兼容语法错误时errlevel=0的场景
         if print_info['errlevel'] == 0 and print_info['errmsg'] == 'None':
@@ -105,14 +217,16 @@ class InceptionEngine(EngineBase):
                     sequence = row.get('sequence')
                     sql = row.get('sql')
                 opid_time = sequence.replace("'", "")
-                sql_table = "select tablename from {}.$_$Inception_backup_information$_$ where opid_time='{}';".format(
-                    backup_db_name, opid_time)
+                sql_table = f"""select tablename 
+                                    from {backup_db_name}.$_$Inception_backup_information$_$ 
+                                 where opid_time='{opid_time}';"""
                 cur.execute(sql_table)
                 list_tables = cur.fetchall()
                 if list_tables:
                     table_name = list_tables[0][0]
-                    sql_back = "select rollback_statement from {}.{} where opid_time='{}'".format(
-                        backup_db_name, table_name, opid_time)
+                    sql_back = f"""select rollback_statement 
+                                       from {backup_db_name}.{table_name} 
+                                    where opid_time='{opid_time}'"""
                     cur.execute(sql_back)
                     list_backup = cur.fetchall()
                     block_rollback_sql_list = [sql]
@@ -120,9 +234,14 @@ class InceptionEngine(EngineBase):
                     block_rollback_sql_list.append(block_rollback_sql)
                     list_backup_sql.append(block_rollback_sql_list)
             except Exception as e:
-                logger.error(traceback.format_exc())
+                logger.error(f"获取回滚语句报错，异常信息{traceback.format_exc()}")
                 raise Exception(e)
         return list_backup_sql
+
+    def close(self):
+        if self.conn:
+            self.conn.close()
+            self.conn = None
 
 
 def _repair_json_str(json_str):

--- a/sql/engines/models.py
+++ b/sql/engines/models.py
@@ -47,7 +47,10 @@ class ReviewSet:
         self.checked = None
         self.warning = None
         self.error = None
+        self.warning_count = 0  # 检测结果警告数
+        self.error_count = 0  # 检测结果错误数
         self.is_critical = False
+        self.syntax_type = 0  # 语法类型
         # rows 为普通列表
         if rows is None:
             self.rows = []

--- a/sql/engines/mssql.py
+++ b/sql/engines/mssql.py
@@ -38,13 +38,13 @@ class MssqlEngine(EngineBase):
         tb_list = [row[0] for row in result.rows if row[0] not in ['test']]
         return tb_list
 
-    def get_all_columns_by_tb(self, db_name, tb_name, schema_name=None):
+    def get_all_columns_by_tb(self, db_name, tb_name):
         """return list [columns]"""
         result = self.describe_table(db_name, tb_name)
         column_list = [row[0] for row in result.rows]
         return column_list
 
-    def describe_table(self, db_name, tb_name, schema_name=None):
+    def describe_table(self, db_name, tb_name):
         """return ResultSet"""
         sql = r"""select
         c.name ColumnName,

--- a/sql/models.py
+++ b/sql/models.py
@@ -131,7 +131,7 @@ class SqlWorkflow(models.Model):
     group_name = models.CharField('组名称', max_length=100)
     instance = models.ForeignKey(Instance, on_delete=models.CASCADE)
     db_name = models.CharField('数据库', max_length=64)
-    syntax_type = models.IntegerField('工单类型 1、DDL，2、DML', choices=((1, 'DDL'), (2, 'DML')))
+    syntax_type = models.IntegerField('工单类型 0、未知，1、DDL，2、DML', choices=((0, '未知'), (1, 'DDL'), (2, 'DML')), default=0)
     is_backup = models.CharField('是否备份', choices=(('否', '否'), ('是', '是')), max_length=20)
     engineer = models.CharField('发起人', max_length=30)
     engineer_display = models.CharField('发起人中文名', max_length=50, default='')

--- a/sql/query.py
+++ b/sql/query.py
@@ -7,7 +7,7 @@ import traceback
 import simplejson as json
 from django.contrib.auth.decorators import permission_required
 from django.core import serializers
-from django.db import connection
+from django.db import connection, OperationalError
 from django.db.models import Q
 from django.http import HttpResponse
 
@@ -143,7 +143,7 @@ def query(request):
             # 防止查询超时
             try:
                 query_log.save()
-            except:
+            except OperationalError:
                 connection.close()
                 query_log.save()
     except Exception as e:

--- a/sql/sql_workflow.py
+++ b/sql/sql_workflow.py
@@ -33,6 +33,8 @@ from sql.engines import get_engine
 logger = logging.getLogger('default')
 
 
+# TODO 清理工单上线内和engines无关的代码，各方法在engines中实现，工单只负责状态流转，方便接入不同数据库
+
 @permission_required('sql.menu_sqlworkflow', raise_exception=True)
 def sql_workflow_list(request):
     """

--- a/sql/sql_workflow.py
+++ b/sql/sql_workflow.py
@@ -99,54 +99,30 @@ def check(request):
         result['msg'] = '页面提交参数可能为空'
         return HttpResponse(json.dumps(result), content_type='application/json')
 
-    for statement in sqlparse.split(sql_content):
-        # 删除注释语句
-        statement = sqlparse.format(statement, strip_comments=True)
-        if re.match(r"^select", statement.lower()):
-            result['status'] = 1
-            result['msg'] = '仅支持DML和DDL语句，查询语句请使用SQL查询功能！'
-            return HttpResponse(json.dumps(result), content_type='application/json')
-
-    # 交给inception进行自动审核
+    # 交给engine进行检测
     try:
         check_engine = get_engine(instance=instance)
         check_result = check_engine.execute_check(db_name=db_name, sql=sql_content.strip())
     except Exception as e:
-        logger.error(traceback.format_exc())
         result['status'] = 1
-        result['msg'] = 'Inception审核报错，请检查Inception配置，错误信息：\n{}'.format(str(e))
+        result['msg'] = str(e)
         return HttpResponse(json.dumps(result), content_type='application/json')
 
-    if not check_result:
-        result['status'] = 1
-        result['msg'] = 'inception返回的结果集为空！可能是SQL语句有语法错误'
-        return JsonResponse(result)
-    # 要把result转成JSON存进数据库里，方便SQL单子详细信息展示
-    column_list = ['id', 'stage', 'errlevel', 'stagestatus', 'errormessage', 'sql', 'affected_rows', 'sequence',
-                   'backup_dbname', 'execute_time', 'sqlsha1']
-    check_warning_count = 0
-    check_error_count = 0
-    for row_item in check_result.rows:
-        if row_item.errlevel == 1:
-            check_warning_count = check_warning_count + 1
-        elif row_item.errlevel == 2:
-            check_error_count = check_error_count + 1
-    result['data']['rows'] = [r.__dict__ for r in check_result.rows]
-    result['data']['column_list'] = column_list
-    result['data']['CheckWarningCount'] = check_warning_count
-    result['data']['CheckErrorCount'] = check_error_count
-
+    # 处理检测结果
+    result['data']['rows'] = check_result.to_dict()
+    result['data']['CheckWarningCount'] = check_result.warning_count
+    result['data']['CheckErrorCount'] = check_result.error_count
     return HttpResponse(json.dumps(result), content_type='application/json')
 
 
 @permission_required('sql.sql_submit', raise_exception=True)
 def submit(request):
     """正式提交SQL, 此处生成工单"""
-    sql_content = request.POST['sql_content']
+    sql_content = request.POST['sql_content'].strip()
     workflow_title = request.POST['workflow_name']
     # 检查用户是否有权限涉及到资源组等， 比较复杂， 可以把检查权限改成一个独立的方法
     # 工单表中可以考虑不存储资源组相关信息
-    # 工单和实例关联， 实例和资源组关联， 资源组和用户关联。
+    # 工单和实例关联， 实例和资源组关联， 资源组和用户关联。（reply 一个实例可以被多个资源组关联，无法去除）
     group_name = request.POST['group_name']
     group_id = ResourceGroup.objects.get(group_name=group_name).group_id
     instance_name = request.POST['instance_name']
@@ -157,58 +133,33 @@ def submit(request):
     list_cc_addr = [email['email'] for email in Users.objects.filter(username__in=notify_users).values('email')]
 
     # 服务器端参数验证
-    if sql_content is None or workflow_title is None or instance_name is None or db_name is None or is_backup is None:
+    if None in [sql_content, db_name, instance_name, db_name, is_backup]:
         context = {'errMsg': '页面提交参数可能为空'}
         return render(request, 'error.html', context)
 
     # 验证组权限（用户是否在该组、该组是否有指定实例）
     try:
         user_instances(request.user, type='master', db_type='mysql').get(instance_name=instance_name)
-    except Exception:
+    except instance.DoesNotExist:
         context = {'errMsg': '你所在组未关联该实例！'}
         return render(request, 'error.html', context)
 
-    sql_content = sql_content.strip()
-
-    # 审核
+    # 再次交给engine进行检测，防止绕过
     try:
-        check_engine = get_engine(instance)
-        check_result = check_engine.execute_check(db_name=db_name, sql=sql_content)
-    except Exception as msg:
-        context = {'errMsg': msg}
+        check_engine = get_engine(instance=instance)
+        check_result = check_engine.execute_check(db_name=db_name, sql=sql_content.strip())
+    except Exception as e:
+        context = {'errMsg': str(e)}
         return render(request, 'error.html', context)
 
-    if not check_result:
-        context = {'errMsg': 'inception返回的结果集为空！可能是SQL语句有语法错误'}
-        return render(request, 'error.html', context)
-
-    # 遍历result，看是否有任何自动审核不通过的地方，并且按配置确定是标记审核不通过还是放行，放行的可以在工单内原生执行
+    # 按照系统配置确定是自动驳回还是放行
     sys_config = SysConfig()
-    is_manual = 0
+    auto_review_wrong = sys_config.get('auto_review_wrong', '')  # 1表示出现警告就驳回，2和空表示出现错误才驳回
     workflow_status = 'workflow_manreviewing'
-    for row in check_result.rows:
-        # 1表示警告，不影响执行
-        if row.errlevel == 1 and sys_config.get('auto_review_wrong', '') == '1':
-            workflow_status = 'workflow_autoreviewwrong'
-            break
-        # 2表示严重错误，或者inception不支持的语法，标记手工执行，可以跳过inception直接执行
-        elif row.errlevel == 2:
-            is_manual = 1
-            if sys_config.get('auto_review_wrong', '') in ('', '1', '2'):
-                workflow_status = 'workflow_autoreviewwrong'
-            break
-        elif re.match(r"\w*comments\w*", row.errormessage):
-            is_manual = 1
-            if sys_config.get('auto_review_wrong', '') in ('', '1', '2'):
-                workflow_status = 'workflow_autoreviewwrong'
-            break
-
-    # 判断SQL是否包含DDL语句，SQL语法 1、DDL，2、DML
-    syntax_type = 2
-    for stmt in sqlparse.split(sql_content):
-        if get_syntax_type(stmt) == 'DDL':
-            syntax_type = 1
-            break
+    if check_result.warning_count > 0 and auto_review_wrong == '1':
+        workflow_status = 'workflow_autoreviewwrong'
+    elif check_result.error_count > 0 and auto_review_wrong in ('', '1', '2'):
+        workflow_status = 'workflow_autoreviewwrong'
 
     # 调用工作流生成工单
     # 使用事务保持数据一致性
@@ -226,8 +177,8 @@ def submit(request):
                 is_backup=is_backup,
                 instance=instance,
                 db_name=db_name,
-                is_manual=is_manual,
-                syntax_type=syntax_type,
+                is_manual=0,
+                syntax_type=check_result.syntax_type,
                 create_time=timezone.now()
             )
             SqlWorkflowContent.objects.create(workflow=sql_workflow,
@@ -241,13 +192,13 @@ def submit(request):
                 # 调用工作流插入审核信息, 查询权限申请workflow_type=2
                 Audit.add(WorkflowDict.workflow_type['sqlreview'], workflow_id)
     except Exception as msg:
-        logger.error(traceback.format_exc())
+        logger.error(f"提交工单报错，错误信息：{traceback.format_exc()}")
         context = {'errMsg': msg}
         return render(request, 'error.html', context)
     else:
-        # 自动审核通过了，才调用工作流，进行消息通知
+        # 自动审核通过才进行消息通知
         if workflow_status == 'workflow_manreviewing':
-            # 再次获取审核信息
+            # 获取审核信息
             audit_id = Audit.detail_by_workflow_id(workflow_id=workflow_id,
                                                    workflow_type=WorkflowDict.workflow_type['sqlreview']).audit_id
             async_task(notify_for_audit, audit_id=audit_id, email_cc=list_cc_addr, timeout=60)
@@ -269,7 +220,7 @@ def passed(request):
         return render(request, 'error.html', context)
 
     user = request.user
-    if Audit.can_review(request.user, workflow_id, 2) is False:
+    if Audit.can_review(user, workflow_id, 2) is False:
         context = {'errMsg': '你无权操作当前工单！'}
         return render(request, 'error.html', context)
 
@@ -287,7 +238,7 @@ def passed(request):
                 # 将流程状态修改为审核通过
                 SqlWorkflow(id=workflow_id, status='workflow_review_pass').save(update_fields=['status'])
     except Exception as msg:
-        logger.error(traceback.format_exc())
+        logger.error(f"审核工单报错，错误信息：{traceback.format_exc()}")
         context = {'errMsg': msg}
         return render(request, 'error.html', context)
     else:
@@ -381,7 +332,7 @@ def timing_task(request):
                           operator_display=request.user.display
                           )
     except Exception as msg:
-        logger.error(traceback.format_exc())
+        logger.error(f"定时执行工单报错，错误信息：{traceback.format_exc()}")
         context = {'errMsg': msg}
         return render(request, 'error.html', context)
     return HttpResponseRedirect(reverse('sql:detail', args=(workflow_id,)))
@@ -455,7 +406,7 @@ def cancel(request):
             workflow_detail.status = 'workflow_abort'
             workflow_detail.save()
     except Exception as msg:
-        logger.error(traceback.format_exc())
+        logger.error(f"取消工单报错，错误信息：{traceback.format_exc()}")
         context = {'errMsg': msg}
         return render(request, 'error.html', context)
     else:

--- a/sql/templates/detail.html
+++ b/sql/templates/detail.html
@@ -97,26 +97,6 @@
     </table>
     <br>
     <table id="tb-detail" data-toggle="table" class="table table-condensed"></table>
-
-    {% if workflow_detail.is_manual == 1 and workflow_detail.execute_result %}
-        <table data-toggle="table" class="table table-striped table-hover">
-            <thead>
-            <tr>
-                <th>
-                    执行结果
-                </th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>
-                    {{ workflow_detail.execute_result }}
-                </td>
-            </tr>
-            </tbody>
-        </table>
-        <br>
-    {% endif %}
     <!--最后操作信息-->
     {% if last_operation_info %}
         <table data-toggle="table" class="table table-striped table-hover">

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -894,6 +894,9 @@ class TestWorkflowView(TransactionTestCase):
             'notify_users': ''
         }
         mock_user_instances.return_value.get.return_value = None
+        mock_get_engine.return_value.execute_check.return_value.warning_count = 0
+        mock_get_engine.return_value.execute_check.return_value.error_count = 0
+        mock_get_engine.return_value.execute_check.return_value.syntax_type = 0
         mock_get_engine.return_value.execute_check.return_value.rows = []
         mock_get_engine.return_value.execute_check.return_value.json.return_value = json.dumps([{
             "id": 1,


### PR DESCRIPTION
- 将工单检测和提交都完全交给engine实现
- 自动审批判断增加实例数据库类型判断，暂时还未并入engine