### PR TITLE
修复redis查询失败的问题

### DIFF
--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -20,11 +20,8 @@ logger = logging.getLogger('default')
 
 class RedisEngine(EngineBase):
     def get_connection(self, db_name=None):
-        if self.conn:
-            return self.conn
-        self.conn = redis.Redis(host=self.host, port=self.port, db=0, password=self.password,
+        return redis.Redis(host=self.host, port=self.port, db=0, password=self.password,
                                 encoding_errors='ignore', decode_responses=True)
-        return self.conn
 
     @property
     def name(self):


### PR DESCRIPTION
#127 

django-q 在返回结果的时候，需要pickle原对象， 原对象有一个 self.conn 的属性， 无法成功pickle 导致返回失败， 修改去掉了 conn 属性， 问题修复

可能带来的副作用： 

Redis不支持连接复用