### PR TITLE
支持配置goInception替代Inception审核

### DIFF
--- a/common/check.py
+++ b/common/check.py
@@ -2,7 +2,7 @@
 import logging
 import traceback
 
-import MySQLdb
+import pymysql
 import simplejson as json
 from django.http import HttpResponse
 
@@ -26,28 +26,70 @@ def inception(request):
     inception_remote_backup_password = request.POST.get('inception_remote_backup_password', '')
 
     try:
-        conn = MySQLdb.connect(host=inception_host, port=int(inception_port), charset='utf8')
+        conn = pymysql.connect(host=inception_host, port=int(inception_port), charset='utf8mb4')
         cur = conn.cursor()
     except Exception as e:
         logger.error(traceback.format_exc())
         result['status'] = 1
-        result['msg'] = '无法连接inception\n{}'.format(str(e))
+        result['msg'] = '无法连接Inception\n{}'.format(str(e))
         return HttpResponse(json.dumps(result), content_type='application/json')
     else:
         cur.close()
         conn.close()
 
     try:
-        conn = MySQLdb.connect(host=inception_remote_backup_host,
+        conn = pymysql.connect(host=inception_remote_backup_host,
                                port=int(inception_remote_backup_port),
                                user=inception_remote_backup_user,
                                password=inception_remote_backup_password,
-                               charset='utf8')
+                               charset='utf8mb4')
         cur = conn.cursor()
     except Exception as e:
         logger.error(traceback.format_exc())
         result['status'] = 1
-        result['msg'] = '无法连接inception备份库\n{}'.format(str(e))
+        result['msg'] = '无法连接Inception备份库\n{}'.format(str(e))
+    else:
+        cur.close()
+        conn.close()
+
+    # 返回结果
+    return HttpResponse(json.dumps(result), content_type='application/json')
+
+
+# 检测inception配置
+@superuser_required
+def go_inception(request):
+    result = {'status': 0, 'msg': 'ok', 'data': []}
+    go_inception_host = request.POST.get('go_inception_host', '')
+    go_inception_port = request.POST.get('go_inception_port', '')
+    inception_remote_backup_host = request.POST.get('inception_remote_backup_host', '')
+    inception_remote_backup_port = request.POST.get('inception_remote_backup_port', '')
+    inception_remote_backup_user = request.POST.get('inception_remote_backup_user', '')
+    inception_remote_backup_password = request.POST.get('inception_remote_backup_password', '')
+
+    try:
+        conn = pymysql.connect(host=go_inception_host, port=int(go_inception_port), charset='utf8mb4')
+        cur = conn.cursor()
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        result['status'] = 1
+        result['msg'] = '无法连接Inception\n{}'.format(str(e))
+        return HttpResponse(json.dumps(result), content_type='application/json')
+    else:
+        cur.close()
+        conn.close()
+
+    try:
+        conn = pymysql.connect(host=inception_remote_backup_host,
+                               port=int(inception_remote_backup_port),
+                               user=inception_remote_backup_user,
+                               password=inception_remote_backup_password,
+                               charset='utf8mb4')
+        cur = conn.cursor()
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        result['status'] = 1
+        result['msg'] = '无法连接Inception备份库\n{}'.format(str(e))
     else:
         cur.close()
         conn.close()

--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -54,75 +54,121 @@
                 <div class="panel-body">
                     <div id="div-system-config" class="form-group" style="display: none">
                         <h4 style="color: darkgrey; display: inline;"><b>Inception配置</b></h4>&nbsp;&nbsp;&nbsp;
-                        <button id='check_incption' class='btn-sm btn-info'>测试inception连接</button>
+                        <button id='check_incption' class='btn-sm btn-info'>测试Inception连接</button>
+                        <button id='check_goincption' class='btn-sm btn-info' style="display: none">测试goInception连接
+                        </button>
                         <hr/>
                         <div class="form-horizontal">
                             <div class="form-group">
-                                <label for="inception_host"
-                                       class="col-sm-4 control-label">INCEPTION_HOST</label>
-                                <div class="col-sm-5">
-                                    <input type="text" class="form-control"
-                                           id="inception_host"
-                                           key="inception_host"
-                                           value="{{ config.inception_host }}"
-                                           placeholder="Inception地址">
+                                <label for="go_inception"
+                                       class="col-sm-4 control-label">GO_INCEPTION</label>
+                                <div class="col-sm-8">
+                                    <div class="switch switch-small">
+                                        <label>
+                                            <input id="go_inception"
+                                                   key="go_inception"
+                                                   value="{{ config.go_inception }}"
+                                                   type="checkbox">
+                                            是否启用goInception
+                                        </label>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="form-group">
-                                <label for="inception_port"
-                                       class="col-sm-4 control-label">INCEPTION_PORT</label>
-                                <div class="col-sm-5">
-                                    <input type="number" class="form-control"
-                                           id="inception_port"
-                                           key="inception_port"
-                                           value="{{ config.inception_port }}"
-                                           placeholder="Inception端口">
+                            <div id="div-inception-config">
+                                <div class="form-group">
+                                    <label for="inception_host"
+                                           class="col-sm-4 control-label">INCEPTION_HOST</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control"
+                                               id="inception_host"
+                                               key="inception_host"
+                                               value="{{ config.inception_host }}"
+                                               placeholder="Inception地址">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="inception_port"
+                                           class="col-sm-4 control-label">INCEPTION_PORT</label>
+                                    <div class="col-sm-5">
+                                        <input type="number" class="form-control"
+                                               id="inception_port"
+                                               key="inception_port"
+                                               value="{{ config.inception_port }}"
+                                               placeholder="Inception端口">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="inception_remote_backup_host"
+                                           class="col-sm-4 control-label">REMOTE_BACKUP_HOST</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control"
+                                               id="inception_remote_backup_host"
+                                               key="inception_remote_backup_host"
+                                               value="{{ config.inception_remote_backup_host }}"
+                                               placeholder="Inception备份库地址">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="inception_remote_backup_port"
+                                           class="col-sm-4 control-label">REMOTE_BACKUP_PORT</label>
+                                    <div class="col-sm-5">
+                                        <input type="number" class="form-control"
+                                               id="inception_remote_backup_port"
+                                               key="inception_remote_backup_port"
+                                               value="{{ config.inception_remote_backup_port }}"
+                                               placeholder="Inception备份库端口">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="inception_remote_backup_user"
+                                           class="col-sm-4 control-label">REMOTE_BACKUP_USER</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" autocomplete="new-password" class="form-control"
+                                               id="inception_remote_backup_user"
+                                               key="inception_remote_backup_user"
+                                               value="{{ config.inception_remote_backup_user }}"
+                                               placeholder="Inception备份库用户">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="inception_remote_backup_password"
+                                           class="col-sm-4 control-label">REMOTE_BACKUP_PASSWORD</label>
+                                    <div class="col-sm-5">
+                                        <input type="password" autocomplete="new-password" class="form-control"
+                                               id="inception_remote_backup_password"
+                                               key="inception_remote_backup_password"
+                                               value="{{ config.inception_remote_backup_password }}"
+                                               placeholder="Inception备份库用户密码">
+                                    </div>
                                 </div>
                             </div>
-                            <div class="form-group">
-                                <label for="inception_remote_backup_host"
-                                       class="col-sm-4 control-label">REMOTE_BACKUP_HOST</label>
-                                <div class="col-sm-5">
-                                    <input type="text" class="form-control"
-                                           id="inception_remote_backup_host"
-                                           key="inception_remote_backup_host"
-                                           value="{{ config.inception_remote_backup_host }}"
-                                           placeholder="Inception备份库地址">
+
+                            <div id="div-go-inception-config" style="display: none">
+                                <hr/>
+                                <div class="form-group">
+                                    <label for="go_inception_host"
+                                           class="col-sm-4 control-label">GO_INCEPTION_HOST</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control"
+                                               id="go_inception_host"
+                                               key="go_inception_host"
+                                               value="{{ config.go_inception_host }}"
+                                               placeholder="goInception地址">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="go_inception_port"
+                                           class="col-sm-4 control-label">GO_INCEPTION_PORT</label>
+                                    <div class="col-sm-5">
+                                        <input type="number" class="form-control"
+                                               id="go_inception_port"
+                                               key="go_inception_port"
+                                               value="{{ config.go_inception_port }}"
+                                               placeholder="goInception端口">
+                                    </div>
                                 </div>
                             </div>
-                            <div class="form-group">
-                                <label for="inception_remote_backup_port"
-                                       class="col-sm-4 control-label">REMOTE_BACKUP_PORT</label>
-                                <div class="col-sm-5">
-                                    <input type="number" class="form-control"
-                                           id="inception_remote_backup_port"
-                                           key="inception_remote_backup_port"
-                                           value="{{ config.inception_remote_backup_port }}"
-                                           placeholder="Inception备份库端口">
-                                </div>
-                            </div>
-                            <div class="form-group">
-                                <label for="inception_remote_backup_user"
-                                       class="col-sm-4 control-label">REMOTE_BACKUP_USER</label>
-                                <div class="col-sm-5">
-                                    <input type="text" autocomplete="new-password" class="form-control"
-                                           id="inception_remote_backup_user"
-                                           key="inception_remote_backup_user"
-                                           value="{{ config.inception_remote_backup_user }}"
-                                           placeholder="Inception备份库用户">
-                                </div>
-                            </div>
-                            <div class="form-group">
-                                <label for="inception_remote_backup_password"
-                                       class="col-sm-4 control-label">REMOTE_BACKUP_PASSWORD</label>
-                                <div class="col-sm-5">
-                                    <input type="password" autocomplete="new-password" class="form-control"
-                                           id="inception_remote_backup_password"
-                                           key="inception_remote_backup_password"
-                                           value="{{ config.inception_remote_backup_password }}"
-                                           placeholder="Inception备份库用户密码">
-                                </div>
-                            </div>
+
                         </div>
                         <br>
                         <h4 style="color: darkgrey"><b>功能模块配置</b></h4>
@@ -564,6 +610,9 @@
                     $("#div-mail-config").show();
                 } else if ($(this).attr("id") === 'auto_review') {
                     $("#div-auto-review-config").show();
+                } else if ($(this).attr("id") === 'go_inception') {
+                    $("#div-go-inception-config").show();
+                    $("#check_goincption").show()
                 }
             } else {
                 $(this).val(false);
@@ -572,6 +621,9 @@
                     $("#div-mail-config").hide();
                 } else if ($(this).attr("id") === 'auto_review') {
                     $("#div-auto-review-config").hide();
+                } else if ($(this).attr("id") === 'go_inception') {
+                    $("#div-go-inception-config").hide();
+                    $("#check_goincption").hide()
                 }
             }
         });
@@ -724,6 +776,39 @@
                 complete: function () {
                     $("#check_incption").removeClass('disabled');
                     $("#check_incption").prop('disabled', false);
+                },
+                success: function (data) {
+                    if (data.status === 0) {
+                        alert('inception和备份库测试连接成功，请点击保存生效！')
+                    } else {
+                        alert(data.msg);
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            });
+        });
+
+        // 检测goInception
+        $("#check_goincption").click(function () {
+            $(this).addClass('disabled');
+            $(this).prop('disabled', true);
+            $.ajax({
+                type: "post",
+                url: "/check/go_inception/",
+                dataType: "json",
+                data: {
+                    go_inception_host: $("#go_inception_host").val(),
+                    go_inception_port: $("#go_inception_port").val(),
+                    inception_remote_backup_host: $("#inception_remote_backup_host").val(),
+                    inception_remote_backup_port: $("#inception_remote_backup_port").val(),
+                    inception_remote_backup_user: $("#inception_remote_backup_user").val(),
+                    inception_remote_backup_password: $("#inception_remote_backup_password").val(),
+                },
+                complete: function () {
+                    $("#check_goincption").removeClass('disabled');
+                    $("#check_goincption").prop('disabled', false);
                 },
                 success: function (data) {
                     if (data.status === 0) {

--- a/common/tests.py
+++ b/common/tests.py
@@ -312,6 +312,38 @@ class CheckTest(TestCase):
         r_json = r.json()
         self.assertEqual(r_json['status'], 0)
 
+    @patch('pymysql.connect')
+    def test_inception_check(self, _conn):
+        c = Client()
+        c.force_login(self.superuser1)
+        data = {
+            "inception_host": "inception",
+            "inception_port": "6669",
+            "inception_remote_backup_host": "mysql",
+            "inception_remote_backup_port": 3306,
+            "inception_remote_backup_user": "mysql",
+            "inception_remote_backup_password": "123456"
+        }
+        r = c.post('/check/inception/', data=data)
+        r_json = r.json()
+        self.assertEqual(r_json['status'], 0)
+
+    @patch('pymysql.connect')
+    def test_go_inception_check(self, _conn):
+        c = Client()
+        c.force_login(self.superuser1)
+        data = {
+            "go_inception_host": "inception",
+            "go_inception_port": "6669",
+            "inception_remote_backup_host": "mysql",
+            "inception_remote_backup_port": 3306,
+            "inception_remote_backup_user": "mysql",
+            "inception_remote_backup_password": "123456"
+        }
+        r = c.post('/check/go_inception/', data=data)
+        r_json = r.json()
+        self.assertEqual(r_json['status'], 0)
+
 
 class ChartTest(TestCase):
     """报表测试"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django==2.0.13
 mysqlclient==1.3.13
+pymysql==0.9.3
 requests==2.21.0
 simplejson==3.16.0
 pycryptodome==3.7.3

--- a/sql/engines/goinception.py
+++ b/sql/engines/goinception.py
@@ -1,0 +1,111 @@
+# -*- coding: UTF-8 -*-
+import logging
+import re
+import pymysql
+from django.db import connection, OperationalError
+
+from common.config import SysConfig
+from sql.utils.sql_utils import get_syntax_type
+from . import EngineBase
+from .models import ResultSet, ReviewSet, ReviewResult
+
+logger = logging.getLogger('default')
+
+
+class GoInceptionEngine(EngineBase):
+    def get_connection(self, db_name=None):
+        if self.conn:
+            return self.conn
+        archer_config = SysConfig()
+        go_inception_host = archer_config.get('go_inception_host')
+        go_inception_port = int(archer_config.get('go_inception_port', 4000))
+        self.conn = pymysql.connect(host=go_inception_host, port=go_inception_port, charset='utf8mb4')
+        return self.conn
+
+    def execute_check(self, instance=None, db_name=None, sql=''):
+        """inception check"""
+        check_result = ReviewSet(full_sql=sql)
+        # inception 校验
+        check_result.rows = []
+        inception_sql = f"""/*--user={instance.user};--password={instance.raw_password};--host={instance.host};--port={instance.port};--check=1;*/
+                            inception_magic_start;
+                            use {db_name};
+                            {sql}
+                            inception_magic_commit;"""
+        inception_result = self.query(sql=inception_sql)
+        check_result.syntax_type = 2  # TODO 工单类型 0、其他 1、DDL，2、DML 仅适用于MySQL，待调整
+        for r in inception_result.rows:
+            check_result.rows += [ReviewResult(inception_result=r)]
+            if r[2] == 1:  # 警告
+                check_result.warning_count += 1
+            elif r[2] == 2:  # 错误
+                check_result.error_count += 1
+            if get_syntax_type(r[5]) == 'DDL':
+                check_result.syntax_type = 1
+        check_result.column_list = inception_result.column_list
+        check_result.checked = True
+        return check_result
+
+    def execute(self, workflow=None):
+        """执行上线单"""
+        instance = workflow.instance
+        execute_result = ReviewSet(full_sql=workflow.sqlworkflowcontent.sql_content)
+        if workflow.is_backup:
+            str_backup = "--backup=1"
+        else:
+            str_backup = "--backup=0"
+
+        # 提交inception执行
+        sql_execute = f"""/*--user={instance.user};--password={instance.raw_password};--host={instance.host};--port={instance.port};--execute=1;--ignore-warnings=1;{str_backup};*/
+                            inception_magic_start;
+                            use {workflow.db_name};
+                            {workflow.sqlworkflowcontent.sql_content}
+                            inception_magic_commit;"""
+        inception_result = self.query(sql=sql_execute)
+        # 把结果转换为ReviewSet
+        for r in inception_result.rows:
+            execute_result.rows += [ReviewResult(inception_result=r)]
+
+        # 执行结果更新到工单的execute_result
+        workflow.sqlworkflowcontent.execute_result = execute_result.json()
+        try:
+            workflow.sqlworkflowcontent.save()
+            workflow.save()
+        # 防止执行超时
+        except OperationalError:
+            connection.close()
+            workflow.sqlworkflowcontent.save()
+            workflow.save()
+
+        # 如果发现任何一个行执行结果里有errLevel为1或2，并且状态列没有包含Execute Successfully，则最终执行结果为有异常.
+        execute_result.status = "workflow_finish"
+        for r in execute_result.rows:
+            if r.errlevel in (1, 2) and not re.search(r"Execute Successfully", r.stagestatus):
+                execute_result.status = "workflow_exception"
+                execute_result.error = "Line {0} has error/warning: {1}".format(r.id, r.errormessage)
+                break
+        return execute_result
+
+    def query(self, db_name=None, sql='', limit_num=0, close_conn=True):
+        """返回 ResultSet """
+        result_set = ResultSet(full_sql=sql)
+        conn = self.get_connection()
+        with conn.cursor() as cursor:
+            effect_row = cursor.execute(sql)
+            if int(limit_num) > 0:
+                rows = cursor.fetchmany(size=int(limit_num))
+            else:
+                rows = cursor.fetchall()
+            fields = cursor.description
+
+            result_set.column_list = [i[0] for i in fields] if fields else []
+            result_set.rows = rows
+            result_set.affected_rows = effect_row
+        if close_conn:
+            self.close()
+        return result_set
+
+    def close(self):
+        if self.conn:
+            self.conn.close()
+            self.conn = None

--- a/sql/engines/models.py
+++ b/sql/engines/models.py
@@ -7,34 +7,39 @@ class ReviewResult:
     """审核的单条结果"""
 
     def __init__(self, inception_result=None, **kwargs):
+        """
+        inception的结果列 = ['ID', 'stage', 'errlevel', 'stagestatus', 'errormessage', 'SQL', 'Affected_rows',
+                           'sequence','backup_dbname', 'execute_time', 'sqlsha1']
+        go_inception的结果列 = ['order_id', 'stage', 'error_level', 'stage_status', 'error_message', 'sql',
+                              'affected_rows', 'sequence', 'backup_dbname', 'execute_time', 'sqlsha1', 'backup_time']
+        """
         if inception_result:
-            column_list = ['ID', 'stage', 'errlevel', 'stagestatus', 'errormessage', 'SQL', 'Affected_rows', 'sequence',
-                           'backup_dbname', 'execute_time', 'sqlsha1']
-            self.id = inception_result[0]
-            self.stage = inception_result[1]
-            self.errlevel = inception_result[2]
-            self.stagestatus = inception_result[3]
-            self.errormessage = inception_result[4]
-            self.sql = inception_result[5]
-            self.affected_rows = inception_result[6]
-            self.sequence = inception_result[7]
-            self.backup_dbname = inception_result[8]
-            self.execute_time = inception_result[9]
-            self.sqlsha1 = inception_result[10]
-            self.actual_affected_rows = None
+            self.id = inception_result[0] or 0
+            self.stage = inception_result[1] or ''
+            self.errlevel = inception_result[2] or 0
+            self.stagestatus = inception_result[3] or ''
+            self.errormessage = inception_result[4] or ''
+            self.sql = inception_result[5] or ''
+            self.affected_rows = inception_result[6] or 0
+            self.sequence = inception_result[7] or ''
+            self.backup_dbname = inception_result[8] or ''
+            self.execute_time = inception_result[9] or ''
+            self.sqlsha1 = inception_result[10] if len(inception_result) == 10 else ''
+            self.backup_time = inception_result[11] if len(inception_result) == 12 else ''
+            self.actual_affected_rows = ''
         else:
-            self.id = kwargs.get('id')
-            self.stage = kwargs.get('stage')
-            self.errlevel = kwargs.get('errlevel')
-            self.stagestatus = kwargs.get('stagestatus')
-            self.errormessage = kwargs.get('errormessage')
-            self.sql = kwargs.get('sql')
-            self.affected_rows = kwargs.get('affected_rows')
-            self.sequence = kwargs.get('sequence')
-            self.backup_dbname = kwargs.get('backup_dbname')
-            self.execute_time = kwargs.get('execute_time')
-            self.sqlsha1 = kwargs.get('sqlsha1')
-            self.actual_affected_rows = kwargs.get('actual_affected_rows')
+            self.id = kwargs.get('id', 0)
+            self.stage = kwargs.get('stage', '')
+            self.errlevel = kwargs.get('errlevel', 0)
+            self.stagestatus = kwargs.get('stagestatus', '')
+            self.errormessage = kwargs.get('errormessage', '')
+            self.sql = kwargs.get('sql', '')
+            self.affected_rows = kwargs.get('affected_rows', 0)
+            self.sequence = kwargs.get('sequence', '')
+            self.backup_dbname = kwargs.get('backup_dbname', '')
+            self.execute_time = kwargs.get('execute_time', '')
+            self.sqlsha1 = kwargs.get('sqlsha1', '')
+            self.actual_affected_rows = kwargs.get('actual_affected_rows', '')
 
 
 class ReviewSet:
@@ -52,10 +57,7 @@ class ReviewSet:
         self.is_critical = False
         self.syntax_type = 0  # 语法类型
         # rows 为普通列表
-        if rows is None:
-            self.rows = []
-        else:
-            self.rows = rows
+        self.rows = rows or []
         self.column_list = column_list
         self.status = status
         self.affected_rows = affected_rows
@@ -89,10 +91,7 @@ class ResultSet:
         self.error = None
         self.is_critical = False
         # rows 为普通列表
-        if rows is None:
-            self.rows = []
-        else:
-            self.rows = rows
+        self.rows = rows or []
         self.column_list = column_list if column_list else []
         self.status = status
         self.affected_rows = affected_rows
@@ -111,17 +110,3 @@ class ResultSet:
 
     def to_sep_dict(self):
         return {'column_list': self.column_list, 'rows': self.rows}
-
-
-class Node:
-    def __init__(self, *args, **kwargs):
-        self.original_name = original_name
-        self.alias = alias
-        self.type = type
-        if children:
-            self.children = children
-        else:
-            self.children = []
-
-    def __str__(self):
-        return "<Node: {}>".format(original_name)

--- a/sql/engines/mssql.py
+++ b/sql/engines/mssql.py
@@ -132,11 +132,7 @@ class MssqlEngine(EngineBase):
                 rows = cursor.fetchall()
             fields = cursor.description
 
-            column_list = []
-            if fields:
-                for i in fields:
-                    column_list.append(i[0])
-            result_set.column_list = column_list
+            result_set.column_list = [i[0] for i in fields] if fields else []
             result_set.rows = [tuple(x) for x in rows]
             result_set.affected_rows = len(result_set.rows)
         except Exception as e:

--- a/sql/engines/pgsql.py
+++ b/sql/engines/pgsql.py
@@ -152,11 +152,8 @@ class PgSQLEngine(EngineBase):
             else:
                 rows = cursor.fetchall()
             fields = cursor.description
-            column_list = []
-            if fields:
-                for i in fields:
-                    column_list.append(i[0])
-            result_set.column_list = column_list
+
+            result_set.column_list = [i[0] for i in fields] if fields else []
             result_set.rows = rows
             result_set.affected_rows = effect_row
         except Exception as e:

--- a/sql/urls.py
+++ b/sql/urls.py
@@ -63,6 +63,7 @@ urlpatterns = [
     path('config/change/', config.change_config),
 
     path('check/inception/', check.inception),
+    path('check/go_inception/', check.go_inception),
     path('check/email/', check.email),
     path('check/instance/', check.instance),
 

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -19,14 +19,15 @@ def get_syntax_type(sql):
     :param sql:
     :return:
     """
-    statement = sqlparse.parse(sql)[0]
-    syntax_type = statement.token_first(skip_cm=True).ttype.__str__()
-    if syntax_type == 'Token.Keyword.DDL':
-        syntax_type = 'DDL'
-    elif syntax_type == 'Token.Keyword.DML':
-        syntax_type = 'DML'
-    else:
-        syntax_type = None
+    parser = sqlparse.parse(sql)
+    syntax_type = None
+    if parser:
+        statement = sqlparse.parse(sql)[0]
+        syntax_type = statement.token_first(skip_cm=True).ttype.__str__()
+        if syntax_type == 'Token.Keyword.DDL':
+            syntax_type = 'DDL'
+        elif syntax_type == 'Token.Keyword.DML':
+            syntax_type = 'DML'
     return syntax_type
 
 


### PR DESCRIPTION
- 系统配置页面可选择开启goInception，开启后将会替换Inception的审核和执行
- 调整部分engine内的column_list获取方法
- 修改engine中ReviewSet的默认值信息，减少None判断

goInception是基于TiDB的语法解析器，和inpcetion审核工具重构的版本，兼容原Inception的审核规则，并且持续完善中：https://github.com/hanchuanchuan/goInception

