### PR TITLE
增加实例标签功能

### DIFF
--- a/sql/admin.py
+++ b/sql/admin.py
@@ -5,7 +5,7 @@ from django.contrib.auth.admin import UserAdmin
 # Register your models here.
 from .models import Users, Instance, SqlWorkflow, SqlWorkflowContent, QueryLog, DataMaskingColumns, DataMaskingRules, \
     AliyunAccessKey, AliyunRdsConfig, ResourceGroup, ResourceGroupRelations, QueryPrivilegesApply, QueryPrivileges, \
-    WorkflowAudit, WorkflowLog, ParamTemplate, ParamHistory
+    WorkflowAudit, WorkflowLog, ParamTemplate, ParamHistory, InstanceTag, InstanceTagRelations
 
 
 # 用户管理
@@ -39,9 +39,18 @@ class ResourceGroupRelationsAdmin(admin.ModelAdmin):
     list_display = ('object_type', 'object_id', 'object_name', 'group_id', 'group_name', 'create_time')
 
 
-# 阿里云实例配置
-class AliRdsConfigInline(admin.TabularInline):
-    model = AliyunRdsConfig
+# 实例标签配置
+@admin.register(InstanceTag)
+class InstanceTagAdmin(admin.ModelAdmin):
+    list_display = ('id', 'tag_code', 'tag_name', 'active', 'create_time')
+    list_display_links = ('id', 'tag_code',)
+
+
+# 实例标签关系配置
+@admin.register(InstanceTagRelations)
+class InstanceTagRelationsAdmin(admin.ModelAdmin):
+    list_display = ('instance', 'instance_tag', 'active', 'create_time')
+    list_filter = ('instance', 'instance_tag', 'active')
 
 
 # 实例管理
@@ -49,8 +58,17 @@ class AliRdsConfigInline(admin.TabularInline):
 class InstanceAdmin(admin.ModelAdmin):
     list_display = ('id', 'instance_name', 'db_type', 'type', 'host', 'port', 'user', 'create_time')
     search_fields = ['instance_name', 'host', 'port', 'user']
-    list_filter = ('db_type', 'type',)
-    inlines = [AliRdsConfigInline]
+    list_filter = ('db_type', 'type')
+
+    # 阿里云实例关系配置
+    class AliRdsConfigInline(admin.TabularInline):
+        model = AliyunRdsConfig
+
+    # 实例标签关系配置
+    class InstanceTagRelationsInline(admin.TabularInline):
+        model = InstanceTagRelations
+
+    inlines = [InstanceTagRelationsInline, AliRdsConfigInline]
 
 
 # SQL工单内容

--- a/sql/admin.py
+++ b/sql/admin.py
@@ -44,6 +44,8 @@ class ResourceGroupRelationsAdmin(admin.ModelAdmin):
 class InstanceTagAdmin(admin.ModelAdmin):
     list_display = ('id', 'tag_code', 'tag_name', 'active', 'create_time')
     list_display_links = ('id', 'tag_code',)
+    fieldsets = ('不支持修改标签代码', {'fields': ('tag_name', 'active'), }),
+    add_fieldsets = (None, {'fields': ('tag_code', 'tag_name', 'active'), }),
 
 
 # 实例标签关系配置

--- a/sql/fixtures/initial_data.json
+++ b/sql/fixtures/initial_data.json
@@ -1,0 +1,22 @@
+[
+  {
+    "model": "sql.InstanceTag",
+    "pk": 1,
+    "fields": {
+      "tag_code": "write",
+      "tag_name": "支持上线",
+      "active": true,
+      "create_time": "2019-05-03"
+    }
+  },
+  {
+    "model": "sql.InstanceTag",
+    "pk": 2,
+    "fields": {
+      "tag_code": "read",
+      "tag_name": "支持查询",
+      "active": true,
+      "create_time": "2019-05-03"
+    }
+  }
+]

--- a/sql/fixtures/initial_data.json
+++ b/sql/fixtures/initial_data.json
@@ -3,7 +3,7 @@
     "model": "sql.InstanceTag",
     "pk": 1,
     "fields": {
-      "tag_code": "write",
+      "tag_code": "can_write",
       "tag_name": "支持上线",
       "active": true,
       "create_time": "2019-05-03"
@@ -13,7 +13,7 @@
     "model": "sql.InstanceTag",
     "pk": 2,
     "fields": {
-      "tag_code": "read",
+      "tag_code": "can_read",
       "tag_name": "支持查询",
       "active": true,
       "create_time": "2019-05-03"

--- a/sql/instance.py
+++ b/sql/instance.py
@@ -38,7 +38,7 @@ def lists(request):
     # 过滤标签，返回同时包含全部标签的实例，循环会生成多表JOIN，如果数据量大会存在效率问题
     if tags:
         for tag in tags:
-            instances = instances.filter(instancetagrelations__instance_tag=tag)
+            instances = instances.filter(instancetagrelations__instance_tag=tag, instancetagrelations__active=True)
 
     count = instances.count()
     instances = instances[offset:limit].values("id", "instance_name", "db_type", "type", "host", "port", "user")

--- a/sql/models.py
+++ b/sql/models.py
@@ -117,6 +117,37 @@ class Instance(models.Model):
         super(Instance, self).save(*args, **kwargs)
 
 
+class InstanceTag(models.Model):
+    """实例标签配置"""
+    tag_code = models.CharField('标签代码', max_length=20, unique=True)
+    tag_name = models.CharField('标签名称', max_length=20, unique=True)
+    active = models.BooleanField('激活状态', default=True)
+    create_time = models.DateTimeField('创建时间', auto_now_add=True)
+
+    def __str__(self):
+        return self.tag_name
+
+    class Meta:
+        managed = True
+        db_table = 'sql_instance_tag'
+        verbose_name = u'实例标签'
+        verbose_name_plural = u'实例标签'
+
+
+class InstanceTagRelations(models.Model):
+    """实例标签关系"""
+    instance = models.ForeignKey(Instance, on_delete=models.CASCADE)
+    instance_tag = models.ForeignKey(InstanceTag, on_delete=models.CASCADE)
+    active = models.BooleanField('激活状态', default=True)
+    create_time = models.DateTimeField('创建时间', auto_now_add=True)
+
+    class Meta:
+        managed = True
+        db_table = 'sql_instance_tag_relations'
+        verbose_name = u'实例标签关系'
+        verbose_name_plural = u'实例标签关系'
+
+
 SQL_WORKFLOW_CHOICES = (
     ('workflow_finish', _('workflow_finish')),
     ('workflow_abort', _('workflow_abort')),

--- a/sql/models.py
+++ b/sql/models.py
@@ -144,6 +144,7 @@ class InstanceTagRelations(models.Model):
     class Meta:
         managed = True
         db_table = 'sql_instance_tag_relations'
+        unique_together = ('instance', 'instance_tag')
         verbose_name = u'实例标签关系'
         verbose_name_plural = u'实例标签关系'
 

--- a/sql/resource_group.py
+++ b/sql/resource_group.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse
 
 from common.utils.extend_json_encoder import ExtendJSONEncoder
 from common.utils.permission import superuser_required
-from sql.models import ResourceGroup, ResourceGroupRelations, Users, Instance
+from sql.models import ResourceGroup, ResourceGroupRelations, Users, Instance, InstanceTag
 from sql.utils.workflow_audit import Audit
 
 logger = logging.getLogger('default')
@@ -97,18 +97,21 @@ def instances(request):
     """获取资源组关联实例列表"""
     group_name = request.POST.get('group_name')
     group_id = ResourceGroup.objects.get(group_name=group_name).group_id
-    type = request.POST.get('type')
-    db_type = request.POST.getlist('db_type[]')
+    tag_code = request.POST.get('tag_code')
+
     # 先获取资源组关联所有实例列表
     instance_ids = [group['object_id'] for group in
                     ResourceGroupRelations.objects.filter(group_id=group_id, object_type=1).values('object_id')]
 
-    # 获取实例信息
-    instances = Instance.objects.filter(pk__in=instance_ids, type=type).values('id', 'type', 'db_type',
-                                                                               'instance_name')
-    # 过滤db_type
-    if db_type:
-        instances = instances.filter(db_type=db_type)
+    instances = Instance.objects.filter(pk__in=instance_ids)
+
+    # 过滤tag
+    if tag_code:
+        tag_id = InstanceTag.objects.get(tag_code=tag_code).id
+        instances = Instance.objects.filter(instancetagrelations__instance_tag=tag_id,
+                                            instancetagrelations__active=True
+                                            ).values('id', 'type', 'db_type', 'instance_name')
+
     rows = [row for row in instances]
     result = {'status': 0, 'msg': 'ok', "data": rows}
     return HttpResponse(json.dumps(result), content_type='application/json')

--- a/sql/templates/instance.html
+++ b/sql/templates/instance.html
@@ -2,21 +2,29 @@
 
 {% block content %}
     <!-- 自定义操作按钮-->
-    <div id="toolbar" class="form-inline">
-        <div class="form-group bootstrap-select ">
-            <select id="type" class="dropdown-menu-right selectpicker ">
-                <option value="" selected="selected">全部实例类型</option>
+    <div id="toolbar" class="form-inline pull-left">
+        <div class="form-group">
+            <select id="type" class="form-control selectpicker">
+                <option value="" selected="selected">实例类型</option>
                 <option value="master">MASTER</option>
                 <option value="slave">SLAVE</option>
             </select>
         </div>
-        <div class="form-group bootstrap-select ">
-            <select id="db_type" class="dropdown-menu-right selectpicker ">
-                <option value="" selected="selected">全部数据库类型</option>
+        <div class="form-group">
+            <select id="db_type" class="form-control selectpicker">
+                <option value="" selected="selected">数据库类型</option>
                 <option value="mysql">MySQL</option>
                 <option value="mssql">MsSQL</option>
                 <option value="redis">Redis</option>
                 <option value="pgsql">PgSQL</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <select id="tags" class="form-control selectpicker" data-live-search="true"
+                    multiple data-selected-text-format="count > 2" data-none-selected-text="标签筛选">
+                {% for tag in tags %}
+                    <option value="{{ tag.id }}">{{ tag.tag_name }}</option>
+                {% endfor %}
             </select>
         </div>
         <div class="form-group ">
@@ -66,6 +74,12 @@
     <script src="{% static 'bootstrap-table/js/bootstrap-table-export.min.js' %}"></script>
     <script src="{% static 'bootstrap-table/js/tableExport.min.js' %}"></script>
     <script>
+        //选择控件初始化
+        $("#tag").selectpicker({
+            countSelectedText: "已选中{0}项",
+            selectedTextFormat: "count > 2"
+        });
+
         //获取列表
         function instancelist() {
             //采取异步请求
@@ -109,7 +123,8 @@
                             offset: params.offset,
                             search: params.search,
                             type: $("#type").val(),
-                            db_type: $("#db_type").val()
+                            db_type: $("#db_type").val(),
+                            tags: $("#tags").val(),
                         }
                     },
                 columns: [
@@ -246,6 +261,10 @@
         });
 
         $("#db_type").change(function () {
+            instancelist();
+        });
+
+         $("#tags").change(function () {
             instancelist();
         });
 

--- a/sql/templates/instance.html
+++ b/sql/templates/instance.html
@@ -74,12 +74,6 @@
     <script src="{% static 'bootstrap-table/js/bootstrap-table-export.min.js' %}"></script>
     <script src="{% static 'bootstrap-table/js/tableExport.min.js' %}"></script>
     <script>
-        //选择控件初始化
-        $("#tag").selectpicker({
-            countSelectedText: "已选中{0}项",
-            selectedTextFormat: "count > 2"
-        });
-
         //获取列表
         function instancelist() {
             //采取异步请求
@@ -264,7 +258,7 @@
             instancelist();
         });
 
-         $("#tags").change(function () {
+        $("#tags").change(function () {
             instancelist();
         });
 

--- a/sql/templates/queryapplylist.html
+++ b/sql/templates/queryapplylist.html
@@ -143,7 +143,7 @@
                 dataType: "json",
                 data: {
                     group_name: $("#group_name").val(),
-                    type: 'slave'
+                    tag_code: 'can_read'
                 },
                 complete: function () {
                 },

--- a/sql/templates/sqlsubmit.html
+++ b/sql/templates/sqlsubmit.html
@@ -542,7 +542,7 @@
                 dataType: "json",
                 data: {
                     group_name: $("#group_name").val(),
-                    type: 'master'
+                    tag_code: 'can_write'
                 },
                 complete: function () {
                     var pathname = window.location.pathname;

--- a/sql/templates/sqlworkflow.html
+++ b/sql/templates/sqlworkflow.html
@@ -2,9 +2,9 @@
 
 {% block content %}
     <!-- 自定义操作按钮-->
-    <div id="toolbar" class="form-inline">
-        <div class="form-group bootstrap-select ">
-            <select id="navStatus" class="dropdown-menu-right selectpicker ">
+    <div id="toolbar" class="form-inline pull-left">
+        <div class="form-group">
+            <select id="navStatus" class="form-control selectpicker">
                 <option value="all" selected="selected">全部工单</option>{% for status, status_display in status_list %}
                 <option value="{{ status }}">{{ status_display }}</option>{% endfor %}
             </select>

--- a/sql/utils/resource_group.py
+++ b/sql/utils/resource_group.py
@@ -18,12 +18,13 @@ def user_groups(user):
     return group_list
 
 
-def user_instances(user, type='all', db_type='all'):
+def user_instances(user, type='all', db_type='all', tags=None):
     """
     获取用户实例列表（通过资源组间接关联）
     :param user:
     :param type: 实例类型 all：全部，master主库，salve从库
     :param db_type: 数据库类型, mysql，mssql
+    :param tags: 标签id列表, [1,2]
     :return:
     """
     # 先获取用户关联资源组列表
@@ -34,7 +35,8 @@ def user_instances(user, type='all', db_type='all'):
     else:
         # 获取资源组关联的实例列表
         instance_ids = [group['object_id'] for group in
-                        ResourceGroupRelations.objects.filter(group_id__in=group_ids, object_type=1).values('object_id')]
+                        ResourceGroupRelations.objects.filter(group_id__in=group_ids, object_type=1).values(
+                            'object_id')]
     # 过滤type
     if type == 'all':
         instances = Instance.objects.filter(pk__in=instance_ids)
@@ -44,6 +46,11 @@ def user_instances(user, type='all', db_type='all'):
     # 过滤db_type
     if db_type != 'all':
         instances = instances.filter(db_type=db_type)
+
+    # 过滤tag
+    if tags:
+        for tag in tags:
+            instances = instances.filter(instancetagrelations__instance_tag=tag, instancetagrelations__active=True)
 
     return instances
 

--- a/sql/views.py
+++ b/sql/views.py
@@ -16,7 +16,7 @@ from sql.engines.models import ReviewResult, ReviewSet
 from sql.utils.tasks import task_info
 
 from .models import Users, SqlWorkflow, QueryPrivileges, ResourceGroup, \
-    QueryPrivilegesApply, Config, SQL_WORKFLOW_CHOICES
+    QueryPrivilegesApply, Config, SQL_WORKFLOW_CHOICES, InstanceTag
 from sql.utils.workflow_audit import Audit
 from sql.utils.sql_review import can_execute, can_timingtask, can_cancel
 from common.utils.const import Const, WorkflowDict
@@ -304,7 +304,9 @@ def groupmgmt(request, group_id):
 # 实例管理页面
 @permission_required('sql.menu_instance', raise_exception=True)
 def instance(request):
-    return render(request, 'instance.html')
+    # 获取实例标签
+    tags = InstanceTag.objects.filter(active=True)
+    return render(request, 'instance.html', {'tags': tags})
 
 
 # 实例用户管理页面

--- a/sql/views.py
+++ b/sql/views.py
@@ -173,8 +173,10 @@ def dashboard(request):
 # SQL在线查询页面
 @permission_required('sql.menu_query', raise_exception=True)
 def sqlquery(request):
+    # 获取实例支持查询的标签id
+    tag_id = InstanceTag.objects.get(tag_code='can_read').id
     # 获取用户关联实例列表
-    instances = [slave for slave in user_instances(request.user, type='slave', db_type='all')]
+    instances = [slave for slave in user_instances(request.user, type='all', db_type='all', tags=[tag_id])]
 
     context = {'instances': instances}
     return render(request, 'sqlquery.html', context)

--- a/src/init_sql/v1.5.3_v1.5.4.sql
+++ b/src/init_sql/v1.5.3_v1.5.4.sql
@@ -1,1 +1,36 @@
+-- 变更字段名
 ALTER TABLE param_history CHANGE update_time create_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '参数修改时间';
+
+-- 变更字符集为utf8mb4，本身是utf8mb4的无需执行该语句
+ALTER TABLE sql_workflow_content
+  modify `sql_content` longtext CHARACTER SET utf8mb4 NOT NULL COMMENT '提交的SQL文本',
+  modify `review_content` longtext CHARACTER SET utf8mb4 NOT NULL COMMENT '自动审核内容的JSON格式',
+  modify `execute_result` longtext CHARACTER SET utf8mb4 NOT NULL COMMENT '执行结果的JSON格式';
+
+ALTER TABLE query_log
+  modify `sqllog` longtext CHARACTER SET utf8mb4 NOT NULL COMMENT '执行的sql查询';
+
+-- 增加实例标签配置
+CREATE TABLE `sql_instance_tag` (
+  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT '标签id',
+  `tag_code` varchar(20) NOT NULL COMMENT '标签代码',
+  `tag_name` varchar(20) NOT NULL COMMENT '标签名称',
+  `active` tinyint(1) NOT NULL COMMENT '激活状态',
+  `create_time` datetime(6) NOT NULL COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_tag_code` (`tag_code`),
+  UNIQUE KEY `uniq_tag_name` (`tag_name`)
+) COMMENT '实例标签配置' ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `sql_instance_tag_relations` (
+  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT '关联id',
+  `instance_id` int(11) NOT NULL COMMENT '关联实例ID',
+  `instance_tag_id` int(11) NOT NULL COMMENT '关联标签ID',
+  `active` tinyint(1) NOT NULL COMMENT '激活状态',
+  `create_time` datetime(6) NOT NULL COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_instance_id` (`instance_id`),
+  KEY `idx_instance_tag_id` (`instance_tag_id`),
+  CONSTRAINT `fk_itr_instance` FOREIGN KEY (`instance_id`) REFERENCES `sql_instance` (`id`),
+  CONSTRAINT `fk_itr_instance_tag` FOREIGN KEY (`instance_tag_id`) REFERENCES `sql_instance_tag` (`id`)
+) COMMENT '实例标签关系' ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/init_sql/v1.5.3_v1.5.4.sql
+++ b/src/init_sql/v1.5.3_v1.5.4.sql
@@ -29,8 +29,20 @@ CREATE TABLE `sql_instance_tag_relations` (
   `active` tinyint(1) NOT NULL COMMENT '激活状态',
   `create_time` datetime(6) NOT NULL COMMENT '创建时间',
   PRIMARY KEY (`id`),
-  KEY `idx_instance_id` (`instance_id`),
   KEY `idx_instance_tag_id` (`instance_tag_id`),
+  UNIQUE KEY `uniq_instance_id_instance_tag_id` (`instance_id`,`instance_tag_id`),
   CONSTRAINT `fk_itr_instance` FOREIGN KEY (`instance_id`) REFERENCES `sql_instance` (`id`),
   CONSTRAINT `fk_itr_instance_tag` FOREIGN KEY (`instance_tag_id`) REFERENCES `sql_instance_tag` (`id`)
 ) COMMENT '实例标签关系' ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 初始化标签数据
+INSERT INTO sql_instance_tag (id, tag_code, tag_name, active, create_time) VALUES (1, 'can_write', '支持上线', 1, '2019-05-03 00:00:00.000000');
+INSERT INTO sql_instance_tag (id, tag_code, tag_name, active, create_time) VALUES (2, 'can_read', '支持查询', 1, '2019-05-03 00:00:00.000000');
+
+-- 给原有主从数据增加标签
+insert into sql_instance_tag_relations (instance_id, instance_tag_id, active, create_time)
+select id,1,1,now() from sql_instance where type='master';
+insert into sql_instance_tag_relations (instance_id, instance_tag_id, active, create_time)
+select id,2,1,now() from sql_instance where type='slave';
+
+


### PR DESCRIPTION
相关issue：#152
 
- 增加两个默认标签，可通过命令 `python manage.py loaddata initial_data.json` 初始化
- 标签可在添加实例时进行关联
- 实例列表标签筛选逻辑是&&

@LeoQuote @yyukai 
关于tag_code，标签代码有没有命名规范建议?

- 查询和上线的实例过滤条件会由主库、从库变成标签过滤，所以tag_code和权限代码类似会存在于代码中