### PR TITLE
修改手工工单逻辑, 调整详情页兼容无执行结果

### DIFF
--- a/sql/models.py
+++ b/sql/models.py
@@ -157,7 +157,6 @@ SQL_WORKFLOW_CHOICES = (
     ('workflow_timingtask', _('workflow_timingtask')),
     ('workflow_executing', _('workflow_executing')),
     ('workflow_autoreviewwrong', _('workflow_autoreviewwrong')),
-    ('workflow_finish_manual', _('workflow_finish_manual')),
     ('workflow_exception', _('workflow_exception')))
 
 

--- a/sql/sql_workflow.py
+++ b/sql/sql_workflow.py
@@ -271,7 +271,7 @@ def execute(request):
         operation_info = "自动操作执行"
         finish_time = None
     else:
-        status = "workflow_finish_manual"
+        status = "workflow_finish"
         operation_type = 6
         operation_type_desc = '手工工单'
         operation_info = "手动执行"

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -825,13 +825,13 @@ class TestWorkflowView(TransactionTestCase):
         r = c.get('/detail/{}/'.format(self.wf1.id))
         self.assertContains(r, expected_status_display)
         self.assertContains(r, exepcted_status)
-        self.assertContains(r, '执行结果解析失败')
+        self.assertContains(r, 'Json decode failed.')
 
         # 执行详情为空
         self.wfc1.execute_result = ''
         self.wfc1.save()
         r = c.get('/detail/{}/'.format(self.wf1.id))
-        self.assertContains(r, '未收集到执行结果')
+        self.assertContains(r, 'No valid execution result.')
 
     def testWorkflowListView(self):
         c = Client()

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -819,6 +819,20 @@ class TestWorkflowView(TransactionTestCase):
         exepcted_status = r"""id="workflow_detail_status">workflow_finish"""
         self.assertContains(r, exepcted_status)
 
+        # 测试执行详情解析失败
+        self.wfc1.execute_result = 'cannotbedecode:1,:'
+        self.wfc1.save()
+        r = c.get('/detail/{}/'.format(self.wf1.id))
+        self.assertContains(r, expected_status_display)
+        self.assertContains(r, exepcted_status)
+        self.assertContains(r, '执行结果解析失败')
+
+        # 执行详情为空
+        self.wfc1.execute_result = ''
+        self.wfc1.save()
+        r = c.get('/detail/{}/'.format(self.wf1.id))
+        self.assertContains(r, '未收集到执行结果')
+
     def testWorkflowListView(self):
         c = Client()
         c.force_login(self.superuser1)

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -879,7 +879,7 @@ class TestWorkflowView(TransactionTestCase):
         mock_detail_by_id = 123
         r = c.post('/execute/', data={'workflow_id': self.wf2.id, 'mode': 'manual'})
         self.wf2.refresh_from_db()
-        self.assertEqual('workflow_finish_manual', self.wf2.status)
+        self.assertEqual('workflow_finish', self.wf2.status)
 
     @patch('sql.sql_workflow.Audit.add_log')
     @patch('sql.sql_workflow.Audit.detail_by_workflow_id')


### PR DESCRIPTION
* 手工执行工单不再单独拥有一个状态
* 详情页解析会考虑到json解析失败和json解析后为空列表等情况