### PR TITLE
SQL工单详情增加日志列表，增加osc执行控制，包括进度查看、暂停、恢复、终止

### DIFF
--- a/sql/engines/goinception.py
+++ b/sql/engines/goinception.py
@@ -39,8 +39,10 @@ class GoInceptionEngine(EngineBase):
                 check_result.warning_count += 1
             elif r[2] == 2:  # 错误
                 check_result.error_count += 1
-            if get_syntax_type(r[5]) == 'DDL':
-                check_result.syntax_type = 1
+            # 没有找出DDL语句的才继续执行此判断
+            if check_result.syntax_type == 2:
+                if get_syntax_type(r[5]) == 'DDL':
+                    check_result.syntax_type = 1
         check_result.column_list = inception_result.column_list
         check_result.checked = True
         return check_result
@@ -90,6 +92,16 @@ class GoInceptionEngine(EngineBase):
         if close_conn:
             self.close()
         return result_set
+
+    def osc_control(self, **kwargs):
+        """控制osc执行，获取进度、终止、暂停、恢复等"""
+        sqlsha1 = kwargs.get('sqlsha1')
+        command = kwargs.get('command')
+        if command == 'get':
+            sql = f"inception get osc_percent '{sqlsha1}';"
+        else:
+            sql = f"inception {command} osc '{sqlsha1}';"
+        return self.query(sql=sql)
 
     def close(self):
         if self.conn:

--- a/sql/engines/models.py
+++ b/sql/engines/models.py
@@ -24,7 +24,7 @@ class ReviewResult:
             self.sequence = inception_result[7] or ''
             self.backup_dbname = inception_result[8] or ''
             self.execute_time = inception_result[9] or ''
-            self.sqlsha1 = inception_result[10] if len(inception_result) == 10 else ''
+            self.sqlsha1 = inception_result[10] or ''
             self.backup_time = inception_result[11] if len(inception_result) == 12 else ''
             self.actual_affected_rows = ''
         else:
@@ -39,6 +39,7 @@ class ReviewResult:
             self.backup_dbname = kwargs.get('backup_dbname', '')
             self.execute_time = kwargs.get('execute_time', '')
             self.sqlsha1 = kwargs.get('sqlsha1', '')
+            self.backup_time = kwargs.get('backup_time', '')
             self.actual_affected_rows = kwargs.get('actual_affected_rows', '')
 
 

--- a/sql/sql_workflow.py
+++ b/sql/sql_workflow.py
@@ -444,3 +444,22 @@ def get_workflow_status(request):
     workflow_detail = get_object_or_404(SqlWorkflow, pk=workflow_id)
     result = {"status": workflow_detail.status, "msg": "", "data": ""}
     return JsonResponse(result)
+
+
+def osc_control(request):
+    """用于mysql控制osc执行"""
+    workflow_id = request.POST.get('workflow_id')
+    sqlsha1 = request.POST.get('sqlsha1')
+    command = request.POST.get('command')
+    workflow = SqlWorkflow.objects.get(id=workflow_id)
+    execute_engine = get_engine(workflow.instance)
+    try:
+        execute_result = execute_engine.osc_control(command=command, sqlsha1=sqlsha1)
+        rows = execute_result.to_dict()
+        error = execute_result.error
+    except Exception as e:
+        rows = []
+        error = str(e)
+    result = {"total": len(rows), "rows": rows, "msg": error}
+    return HttpResponse(json.dumps(result, cls=ExtendJSONEncoder, bigint_as_string=True),
+                        content_type='application/json')

--- a/sql/templates/detail.html
+++ b/sql/templates/detail.html
@@ -101,29 +101,52 @@
         </tbody>
     </table>
     <br>
-    <table id="tb-detail" data-toggle="table" class="table table-condensed"
-           style="table-layout:inherit;word-break:break-word;overflow:hidden;text-overflow:ellipsis;"></table>
-    <!--最后操作信息-->
-    {% if last_operation_info %}
-        <table data-toggle="table" class="table table-striped table-hover"
-               style="table-layout:inherit;overflow:hidden;text-overflow:ellipsis;">
-            <thead>
-            <tr>
-                <th>
-                    操作信息
-                </th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>
-                    {{ last_operation_info }}
-                </td>
-            </tr>
-            </tbody>
-        </table>
-        <br>
-    {% endif %}
+
+    <!-- Nav tabs -->
+    <ul id="nav-tabs" class="nav nav-tabs" role="tablist">
+        <li id="detail_tab" class="active">
+            <a href="#detail" role="tab" data-toggle="tab">工单详情</a>
+        </li>
+        <li id="logs_tab">
+            <a href="#logs" role="tab" data-toggle="tab">工单日志</a>
+        </li>
+    </ul>
+    <!-- Tab panes -->
+    <div id="tab-content" class="tab-content">
+        <!-- 工单详情-->
+        <div id="detail" role="tabpanel" class="tab-pane fade in active table-responsive">
+            <table id="tb-detail" data-toggle="table" class="table table-condensed"
+                   style="table-layout:inherit;word-break:break-word;overflow:hidden;text-overflow:ellipsis;"></table>
+            <!--最后操作信息-->
+            {% if last_operation_info %}
+                <table data-toggle="table" class="table table-striped table-hover"
+                       style="table-layout:inherit;overflow:hidden;text-overflow:ellipsis;">
+                    <thead>
+                    <tr>
+                        <th>
+                            操作信息
+                        </th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>
+                            {{ last_operation_info }}
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                <br>
+            {% endif %}
+        </div>
+
+        <!-- 工单日志-->
+        <div id="logs" role="tabpanel" class="tab-pane fade table-responsive">
+            <table id="tb-logs" data-toggle="table" class="table table-hover"
+                   style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+            </table>
+        </div>
+    </div>
 
     <!--审核备注输入框-->
     {% if is_can_review or is_can_cancel %}
@@ -229,6 +252,34 @@
             </div>
         </div>
     </form>
+
+    <!-- 执行进度弹出框-->
+    <!-- 自定义操作按钮-->
+    <div id="osc-toolbar" class="btn-group left" style="display:none;">
+        <button id="pause_osc" class="btn btn-warning" type="button">暂停</button>
+        <button id="resume_osc" class="btn btn-success" type="button">恢复</button>
+        <button id="kill_osc" class="btn btn-danger" type="button">终止</button>
+    </div>
+    <div class="modal fade" id="osc_percent">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content message_align">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">×</span></button>
+                    <h4 class="modal-title text-danger">执行进度</h4>
+                </div>
+                <div class="modal-body">
+                    <div class="table-responsive">
+                        <table id="osc_percent_list" data-toggle="table" class="table table-striped table-hover"
+                               style="table-layout:inherit;overflow:hidden;text-overflow:ellipsis;">
+                        </table>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                </div>
+            </div>
+        </div>
+    </div>
 
 
 {% endblock content %}
@@ -357,106 +408,336 @@
     </script>
     <!--表格初始化 -->
     <script>
-        $('#tb-detail').bootstrapTable('destroy').bootstrapTable({
-            escape: false,
-            striped: true,                      //是否显示行间隔色
-            cache: false,                       //是否使用缓存，默认为true，所以一般情况下需要设置一下这个属性（*）
-            pagination: true,                   //是否显示分页（*）
-            sortable: true,                     //是否启用排序
-            sidePagination: "client",           //分页方式：client客户端分页，server服务端分页（*）
-            pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
-            pageSize: 500,                       //每页的记录行数（*）
-            pageList: [500, 1000, 5000],        //可供选择的每页的行数（*）
-            search: false,                       //是否显示表格搜索
-            strictSearch: false,                //是否全匹配搜索
-            showColumns: false,                  //是否显示所有的列（选择显示的列）
-            showRefresh: false,                  //是否显示刷新按钮
-            minimumCountColumns: 2,             //最少允许的列数
-            clickToSelect: false,                //是否启用点击选中行
-            uniqueId: "id",                     //每一行的唯一标识，一般为主键列
-            showToggle: false,                   //是否显示详细视图和列表视图的切换按钮
-            cardView: false,                    //是否显示详细视图
-            detailView: true,                  //是否显示父子表
-            //格式化详情
-            detailFormatter: function (index, row) {
-                var html = [];
-                $.each(row, function (key, value) {
-                    if (key === 'sql') {
-                        var sql = value;
-                        //替换所有的换行符
-                        sql = sql.replace(/\r\n/g, "<br>");
-                        sql = sql.replace(/\n/g, "<br>");
-                        //替换所有的空格
-                        sql = sql.replace(/\s/g, "&nbsp;");
-                        html.push('<span>' + sql + '</span>');
-                    }
-                });
-                return html.join('');
-            },
-            locale: 'zh-CN',                    //本地化
-            data:{{ rows|safe }},
-            columns: [{
-                title: 'ID',
-                field: 'id',
-                sortable: true
-            }, {
-                title: 'SQL内容',
-                field: 'sql',
-                formatter: function (value, row, index) {
-                    if (value.length > 80) {
-                        return value.substr(0, 80) + '...';
-                    } else {
-                        return value
-                    }
+        //获取工单详情
+        function get_detail() {
+            $('#tb-detail').bootstrapTable('destroy').bootstrapTable({
+                escape: false,
+                striped: true,                      //是否显示行间隔色
+                cache: true,                       //是否使用缓存，默认为true，所以一般情况下需要设置一下这个属性（*）
+                pagination: true,                   //是否显示分页（*）
+                sortable: true,                     //是否启用排序
+                sidePagination: "client",           //分页方式：client客户端分页，server服务端分页（*）
+                pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
+                pageSize: 500,                       //每页的记录行数（*）
+                pageList: [500, 1000, 5000],        //可供选择的每页的行数（*）
+                search: true,                       //是否显示表格搜索
+                strictSearch: false,                //是否全匹配搜索
+                showColumns: true,                  //是否显示所有的列（选择显示的列）
+                showRefresh: false,                  //是否显示刷新按钮
+                minimumCountColumns: 1,             //最少允许的列数
+                clickToSelect: false,                //是否启用点击选中行
+                uniqueId: "id",                     //每一行的唯一标识，一般为主键列
+                showToggle: false,                   //是否显示详细视图和列表视图的切换按钮
+                cardView: false,                    //是否显示详细视图
+                detailView: true,                  //是否显示父子表
+                //格式化详情
+                detailFormatter: function (index, row) {
+                    var html = [];
+                    $.each(row, function (key, value) {
+                        if (key === 'sql') {
+                            var sql = value;
+                            //替换所有的换行符
+                            sql = sql.replace(/\r\n/g, "<br>");
+                            sql = sql.replace(/\n/g, "<br>");
+                            //替换所有的空格
+                            sql = sql.replace(/\s/g, "&nbsp;");
+                            html.push('<span>' + sql + '</span>');
+                        }
+                    });
+                    return html.join('');
                 },
-                sortable: false
-            }, {
-                title: '审核/执行状态',
-                field: 'errlevel',
-                formatter: function (value, row, index) {
-                    if (value === 0) {
-                        return 'pass'
-                    } else if (value === 1) {
-                        return 'warning'
-                    } else if (value === 2) {
-                        return 'error'
+                locale: 'zh-CN',                    //本地化
+                data:{{ rows|safe }},
+                columns: [{
+                    title: 'ID',
+                    field: 'id',
+                    sortable: true
+                }, {
+                    title: 'SQL内容',
+                    field: 'sql',
+                    formatter: function (value, row, index) {
+                        if (value.length > 80) {
+                            return value.substr(0, 80) + '...';
+                        } else {
+                            return value
+                        }
+                    },
+                    sortable: false
+                }, {
+                    title: '审核/执行状态',
+                    field: 'errlevel',
+                    formatter: function (value, row, index) {
+                        if (value === 0) {
+                            return 'pass'
+                        } else if (value === 1) {
+                            return 'warning'
+                        } else if (value === 2) {
+                            return 'error'
+                        }
+                    },
+                    sortable: true
+                }, {
+                    title: '审核/执行信息',
+                    field: 'errormessage',
+                    formatter: function (value, row, index) {
+                        return value.replace(/\n/g, '<br>');
+                    },
+                    sortable: true
+                }, {
+                    title: '扫描/影响行数',
+                    field: 'affected_rows',
+                    sortable: true
+                }, {
+                    title: '执行耗时',
+                    field: 'execute_time',
+                    sortable: true
+                }, {
+                    title: '当前阶段',
+                    field: 'stagestatus',
+                    sortable: true
+                }, {
+                    title: '操作',
+                    field: 'sqlsha1',
+                    formatter: function (value, row, index) {
+                        let btn_percent = "<button class=\"btn btn-info btn-xs\" sqlsha1=\"" + row.sqlsha1 + "\" onclick=\"get_osc_percent(this)" + "\">查看进度</button>\n";
+                        let status = $("#workflow_detail_status").text();
+                        if (row.sqlsha1 && status === 'workflow_executing') {
+                            return btn_percent;
+                        }
+                    },
+
+                }],
+                rowStyle: function (row, index) {
+                    var style = "";
+                    if (row.errlevel === 1) {
+                        style = 'warning';
+                    } else if (row.errlevel === 2) {
+                        style = 'danger';
                     }
+                    return {classes: style}
                 },
-                sortable: true
-            }, {
-                title: '审核/执行信息',
-                field: 'errormessage',
-                formatter: function (value, row, index) {
-                    return value.replace(/\n/g, '<br>');
+                onLoadSuccess: function () {
                 },
-                sortable: true
-            }, {
-                title: '扫描/影响行数',
-                field: 'affected_rows',
-                sortable: true
-            }, {
-                title: '执行耗时',
-                field: 'execute_time',
-                sortable: true
-            }, {
-                title: '当前阶段',
-                field: 'stagestatus',
-                sortable: true
-            }],
-            rowStyle: function (row, index) {
-                var style = "";
-                if (row.errlevel === 1) {
-                    style = 'warning';
-                } else if (row.errlevel === 2) {
-                    style = 'danger';
+                onLoadError: function () {
+                    alert("数据加载失败！请检查接口返回信息和错误日志！");
                 }
-                return {classes: style}
-            },
-            onLoadSuccess: function () {
-            },
-            onLoadError: function () {
-                alert("数据加载失败！请检查接口返回信息和错误日志！");
+            });
+        }
+
+        // 获取操作日志
+        function get_logs() {
+            $.ajax({
+                type: "post",
+                url: "/workflow/log/",
+                dataType: "json",
+                data: {
+                    workflow_id: "{{ workflow_detail.id }}",
+                    workflow_type: 2,
+                },
+                complete: function () {
+                },
+                success: function (data) {
+                    //初始化table
+                    $('#tb-logs').bootstrapTable('destroy').bootstrapTable({
+                        escape: true,
+                        striped: true,                      //是否显示行间隔色
+                        cache: true,                       //是否使用缓存，默认为true，所以一般情况下需要设置一下这个属性（*）
+                        pagination: true,                   //是否显示分页（*）
+                        sortable: false,                     //是否启用排序
+                        sortOrder: "asc",                   //排序方式
+                        sidePagination: "client",           //分页方式：client客户端分页，server服务端分页（*）
+                        pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
+                        pageSize: 14,                     //每页的记录行数（*）
+                        pageList: [20, 30, 50, 100],       //可供选择的每页的行数（*）
+                        search: true,                      //是否显示表格搜索
+                        strictSearch: false,                //是否全匹配搜索
+                        showColumns: false,                  //是否显示所有的列（选择显示的列）
+                        showRefresh: false,                  //是否显示刷新按钮
+                        minimumCountColumns: 2,             //最少允许的列数
+                        clickToSelect: false,                //是否启用点击选中行
+                        uniqueId: "id",                     //每一行的唯一标识，一般为主键列
+                        showToggle: false,                   //是否显示详细视图和列表视图的切换按钮
+                        cardView: false,                    //是否显示详细视图
+                        detailView: false,                  //是否显示父子表
+                        locale: 'zh-CN',                    //本地化
+                        data: data.rows,
+                        columns: [{
+                            title: '操作',
+                            field: 'operation_type_desc'
+                        }, {
+                            title: '操作人',
+                            field: 'operator_display'
+                        }, {
+                            title: '操作时间',
+                            field: 'operation_time'
+                        }, {
+                            title: '操作信息',
+                            field: 'operation_info'
+                        }],
+                        onLoadSuccess: function () {
+                        },
+                        onLoadError: function () {
+                            alert("数据加载失败！请检查接口返回信息和错误日志！");
+                        }
+                    });
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            })
+        }
+
+        //获取osc执行进度信息
+        function get_osc_percent(obj) {
+            $('#osc_percent_list').bootstrapTable('destroy').bootstrapTable({
+                escape: true,
+                method: 'post',
+                contentType: "application/x-www-form-urlencoded",
+                url: "/inception/osc_control/",
+                striped: true,                      //是否显示行间隔色
+                cache: false,                       //是否使用缓存，默认为true，所以一般情况下需要设置一下这个属性（*）
+                pagination: false,                   //是否显示分页（*）
+                sortable: false,                     //是否启用排序
+                sortOrder: "asc",                   //排序方式
+                sidePagination: "server",           //分页方式：client客户端分页，server服务端分页（*）
+                pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
+                pageSize: 14,                     //每页的记录行数（*）
+                pageList: [20, 30, 50, 100],       //可供选择的每页的行数（*）
+                search: false,                      //是否显示表格搜索
+                strictSearch: false,                //是否全匹配搜索
+                showColumns: false,                  //是否显示所有的列（选择显示的列）
+                showRefresh: true,                  //是否显示刷新按钮
+                minimumCountColumns: 2,             //最少允许的列数
+                checkboxHeader: false,             //隐藏全选框
+                singleSelect: true,                  //单选框
+                clickToSelect: true,                //是否启用点击选中行
+                uniqueId: "id",                     //每一行的唯一标识，一般为主键列
+                showToggle: false,                   //是否显示详细视图和列表视图的切换按钮
+                cardView: false,                    //是否显示详细视图
+                detailView: true,                  //是否显示父子表
+                //格式化详情
+                detailFormatter: function (index, row) {
+                    var html = [];
+                    $.each(row, function (key, value) {
+                        if (key === 'INFOMATION') {
+                            //替换所有的换行符
+                            value = value.replace(/\r\n/g, "<br>");
+                            value = value.replace(/\n/g, "<br>");
+                            //替换所有的空格
+                            value = value.replace(/\s/g, "&nbsp;");
+                            html.push('<span>' + value + '</span>');
+                        }
+                    });
+                    return html.join('');
+                },
+                locale: 'zh-CN',                    //本地化
+                toolbar: "#osc-toolbar",               //指明自定义的toolbar
+                queryParamsType: 'limit',
+                //请求服务数据时所传参数
+                queryParams:
+                    function (params) {
+                        return {
+                            sqlsha1: $(obj).attr("sqlsha1"),
+                            workflow_id: "{{ workflow_detail.id }}",
+                            command: "get"
+                        }
+                    },
+                columns: [{
+                    title: '',
+                    field: 'checkbox',
+                    checkbox: true,
+                    formatter: function stateFormatter(value, row, index) {
+                        return {
+                            checked: true//设置选中
+                        };
+                    },
+                }, {
+                    title: 'DBNAME',
+                    field: 'DBNAME'
+                }, {
+                    title: 'TABLENAME',
+                    field: 'TABLENAME'
+                }, {
+                    title: 'PERCENT',
+                    field: 'PERCENT'
+                }, {
+                    title: 'SQLSHA1',
+                    field: 'SQLSHA1',
+                    visible: false // 默认不显示
+                }, {
+                    title: 'REMAINTIME',
+                    field: 'REMAINTIME'
+                }, {
+                    title: 'INFOMATION',
+                    field: 'INFOMATION',
+                    formatter: function (value, row, index) {
+                        if (value.length > 300) {
+                            value = value.substr(0, 300) + '...';
+                        }
+                        return value.replace(/\n/g, '<br>');
+                    },
+                }],
+                onLoadSuccess: function () {
+                    $("#osc-toolbar").show();
+                    $('#osc_percent').modal('show');
+                },
+                onLoadError: function () {
+                    alert("数据加载失败！请检查接口返回信息和错误日志！");
+                }
+            });
+
+        }
+    </script>
+    <!--OSC控制-->
+    <script>
+        $(":input[id$='_osc']").bind('click', function () {
+            let AllSelections = $("#osc_percent_list").bootstrapTable('getSelections');
+            if (AllSelections.length === 1) {
+                //获取选择的sqlsha1
+                let sqlsha1 = AllSelections[0]['SQLSHA1'];
+                let command = '';
+                let isContinue = true;
+
+                // 判断command值
+                switch (this.id) {
+                    case 'pause_osc':
+                        command = 'pause';
+                        break;
+                    case 'resume_osc':
+                        command = 'resume';
+                        break;
+                    case 'kill_osc':
+                        command = 'kill';
+                        isContinue = confirm("请确认是否立即终止？终止后需要手动清理触发器以及相关中间表！");
+                        break;
+                    default:
+                        alert('命令错误！')
+                }
+
+                //发送请求
+                $.ajax({
+                    type: "post",
+                    url: "/inception/osc_control/",
+                    dataType: "json",
+                    data: {
+                        sqlsha1: sqlsha1,
+                        workflow_id: "{{ workflow_detail.id }}",
+                        command: command
+                    },
+                    complete: function () {
+                    },
+                    success: function (data) {
+                        if (data.msg) {
+                            alert(data.msg);
+                        } else {
+                            alert('操作成功！请稍后刷新获取最新状态');
+                        }
+                    }
+                })
+            } else {
+                alert("请先选择要终止进程")
             }
+
         });
     </script>
     <!--状态控制 -->
@@ -466,6 +747,8 @@
         var key;
         var retryCnt = 1;
         $(document).ready(function () {
+            sessionStorage.setItem('sql_workflow_active_li_id', 'detail_tab');
+            get_detail();
             if (status === "workflow_executing") {
                 getWorkflowStatus(workflow_id);
             }
@@ -477,7 +760,7 @@
                 clearTimeout(key);
                 key = setTimeout(function () {
                     getWorkflowStatus(workflow_id);
-                }, 1000);
+                }, 2500);
                 retryCnt++;
             } else {
                 retryCnt = 1;
@@ -513,4 +796,21 @@
 
 
     </script>
+    <!--TAB控制 -->
+    <script>
+        //tab切换,保留当前激活的标签id
+        $(function () {
+            $("#nav-tabs").on('shown.bs.tab', "li", function (e) {
+                var active_li_id = $(e.target).parents().attr('id');
+                sessionStorage.setItem('sql_workflow_active_li_id', active_li_id);
+                //当前激活的标签id
+                if (active_li_id === 'detail_tab') {
+                    get_detail();
+                } else if (active_li_id === 'logs_tab') {
+                    get_logs();
+                }
+            });
+        });
+    </script>
+
 {% endblock %}

--- a/sql/templates/detail.html
+++ b/sql/templates/detail.html
@@ -713,27 +713,29 @@
                     default:
                         alert('命令错误！')
                 }
-
-                //发送请求
-                $.ajax({
-                    type: "post",
-                    url: "/inception/osc_control/",
-                    dataType: "json",
-                    data: {
-                        sqlsha1: sqlsha1,
-                        workflow_id: "{{ workflow_detail.id }}",
-                        command: command
-                    },
-                    complete: function () {
-                    },
-                    success: function (data) {
-                        if (data.msg) {
-                            alert(data.msg);
-                        } else {
-                            alert('操作成功！请稍后刷新获取最新状态');
+                if (isContinue) {
+                    //发送请求
+                    $.ajax({
+                        type: "post",
+                        url: "/inception/osc_control/",
+                        dataType: "json",
+                        data: {
+                            sqlsha1: sqlsha1,
+                            workflow_id: "{{ workflow_detail.id }}",
+                            command: command
+                        },
+                        complete: function () {
+                        },
+                        success: function (data) {
+                            if (data.msg) {
+                                alert(data.msg);
+                            } else {
+                                alert('操作成功！请稍后刷新获取最新状态');
+                            }
                         }
-                    }
-                })
+                    })
+                }
+
             } else {
                 alert("请先选择要终止进程")
             }

--- a/sql/templates/sqlsubmit.html
+++ b/sql/templates/sqlsubmit.html
@@ -484,13 +484,13 @@
                                 pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
                                 pageSize: 500,                     //每页的记录行数（*）
                                 pageList: [500, 1000, 5000],       //可供选择的每页的行数（*）
-                                search: false,                      //是否显示表格搜索
+                                search: true,                      //是否显示表格搜索
                                 strictSearch: false,                //是否全匹配搜索
                                 showColumns: true,                  //是否显示所有的列（选择显示的列）
                                 showRefresh: false,                  //是否显示刷新按钮
                                 showExport: true,
                                 exportDataType: "all",
-                                minimumCountColumns: 2,             //最少允许的列数
+                                minimumCountColumns: 1,             //最少允许的列数
                                 uniqueId: "id",                     //每一行的唯一标识，一般为主键列
                                 showToggle: true,                   //是否显示详细视图和列表视图的切换按钮
                                 cardView: false,                    //是否显示详细视图

--- a/sql/urls.py
+++ b/sql/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
     path('simplecheck/', sql_workflow.check),
     path('getWorkflowStatus/', sql_workflow.get_workflow_status),
     path('del_sqlcronjob/', tasks.del_schedule),
+    path('inception/osc_control/', sql_workflow.osc_control),
 
     path('sql_analyze/generate/', sql_analyze.generate),
     path('sql_analyze/analyze/', sql_analyze.analyze),


### PR DESCRIPTION
关联issue：#4 

主要涉及以下改动
- 工单详情改成两个tab页，工单详情和工单日志
![image](https://user-images.githubusercontent.com/8842982/58378579-db3e7100-7fc8-11e9-9bb9-59ed841abf7c.png)

- 工单详情新增一列操作项，当使用inception操作pt-osc或者gh-ost执行时，会显示查看进度按钮
支持暂停、恢复、终止（pt-osc仅支持终止），同时支持inception和goinception
![image](https://user-images.githubusercontent.com/8842982/58378613-5e5fc700-7fc9-11e9-84a2-03b1ada6a95c.png)


