### PR TITLE
权限校验中, mssql 改为只简单校验db权限, 不做具体的语句解析

### DIFF
--- a/sql/query_privileges.py
+++ b/sql/query_privileges.py
@@ -70,7 +70,7 @@ def query_priv_check(user, instance, db_name, sql_content, limit_num):
     except Exception as msg:
         # 表权限校验失败再次校验库权限
         # 先获取查询语句涉及的库
-        if instance.db_type == 'redis':
+        if instance.db_type in ['redis', 'mssql']:
             dbs = [db_name]
         else:
             dbs = [i['schema'].strip('`') for i in extract_tables(sql_content) if i['schema'] is not None]

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -376,7 +376,7 @@ class TestQueryPrivilegesCheck(TestCase):
         测试用户权限校验，非mysql实例、普通用户 无库权限
         :return:
         """
-        mssql_instance = Instance(instance_name='mssql', type='slave', db_type='mssql',
+        mssql_instance = Instance(instance_name='mssql', type='slave', db_type='oracle',
                                   host='some_host', port=3306, user='some_user', password='some_password')
         r = sql.query_privileges.query_priv_check(user=self.user,
                                                   instance=mssql_instance, db_name=self.db_name,


### PR DESCRIPTION
mssql 的 sql 语句比较灵活, 可以 ``select col1 from db_name`` , 也可以 ``select col1 from [dbo.db_name]`` ,  使用sqlparse 或 moz-parse 解析会出现差错, 后面那种语句查询时, 会报没有dbo的权限, 造成使用上的困扰, 可以暂时跳过解析.