### PR TITLE
添加查看表结构的同时查看索引 功能

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -125,6 +125,17 @@ class OracleEngine(EngineBase):
         result = self.query(sql=sql)
         return result
 
+    def describe_index(self, db_name, tb_name):
+        """return ResultSet"""
+        sql = f"""select uic.index_name as 名, '"' || uic.column_name || '" ' || uic.DESCEND as 字段,ui.uniqueness as 索引类型 
+        from 
+        (select index_name, wm_concat(column_name) as column_name,max(DESCEND) as DESCEND
+        from user_ind_columns where table_name = '{tb_name}' group by index_name) uic
+        left join user_indexes ui on ui.index_name = uic.index_name
+        """
+        result = self.query(sql=sql)
+        return result
+
     def query_check(self, db_name=None, sql=''):
         # 查询语句的检查、注释去除、切分
         result = {'msg': '', 'bad_query': False, 'filtered_sql': sql, 'has_star': False}

--- a/sql/instance.py
+++ b/sql/instance.py
@@ -321,7 +321,7 @@ def instance_resource(request):
     return HttpResponse(json.dumps(result), content_type='application/json')
 
 
-def describe(request):
+def describe(request,resource):
     """获取表结构"""
     instance_name = request.POST.get('instance_name')
     try:
@@ -337,9 +337,9 @@ def describe(request):
     try:
         query_engine = get_engine(instance=instance)
         if schema_name:
-            query_result = query_engine.describe_table(db_name, tb_name, schema_name)
+            query_result = eval('query_engine.describe_'+ resource + '(db_name, tb_name, schema_name)')
         else:
-            query_result = query_engine.describe_table(db_name, tb_name)
+            query_result = eval('query_engine.describe_'+ resource + '(db_name, tb_name)')
         result['data'] = query_result.__dict__
     except Exception as msg:
         result['status'] = 1

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -502,7 +502,7 @@
         );
 
         // 展示数据
-        function display_data(data) {
+        function display_data(data, index) {
             var result = data.data;
             //获取当前的标签页,如果当前不在执行结果页，则默认新增一个页面
             var active_li_id = sessionStorage.getItem('active_li_id');
@@ -516,6 +516,7 @@
                     } else {
                         var tb_name = result['full_sql'].match(/^show\s+create\s+table\s+(.*);/)[1];
                     }
+                    tb_name+=index||""
                     if (tb_name !== active_li_title) {
                         tab_add(tb_name);
                     }
@@ -832,6 +833,7 @@
 
         //获取表结构
         $("#table_name").change(function () {
+            var optgroup = $('#instance_name :selected').parent().attr('label');
             $.ajax({
                 type: "post",
                 url: "/instance/describetable/",
@@ -846,7 +848,27 @@
                     data.is_describe = true;
                     display_data(data);
                 },
+                complete : function () {
+                    if (optgroup === "Oracle") {
+                        $.ajax({
+                            type: "post",
+                            url: "/instance/describeindex/",
+                            dataType: "json",
+                            data: {
+                                instance_name: $("#instance_name").val(),
+                                db_name: $("#db_name").val(),
+                                tb_name: $("#table_name").val()
+                            },
+                            success: function (data) {
+                                data.is_describe = true;
+                                display_data(data," 索引");
+                            }
+                        });
+                    };
+
+                }
             });
+
             //自动补全提示
             setColumnsCompleteData()
         });

--- a/sql/urls.py
+++ b/sql/urls.py
@@ -80,7 +80,7 @@ urlpatterns = [
     path('instance/users/', instance.users),
     path('instance/schemasync/', instance.schemasync),
     path('instance/instance_resource/', instance.instance_resource),
-    path('instance/describetable/', instance.describe),
+    path('instance/describe<str:resource>/', instance.describe),
 
     path('param/list/', instance.param_list),
     path('param/history/', instance.param_history),


### PR DESCRIPTION
修改了一些基础的东西，为所有有索引的数据库添加索引显示做好准备
增加oracle 查看表结构的同时 查看索引    
这里需要注意 账号的是否有权限查看索引  ，对应语句为

select uic.index_name as 名, '"' || uic.column_name || '" ' || uic.DESCEND as 字段,ui.uniqueness as 索引类型 
        from 
        (select index_name, wm_concat(column_name) as column_name,max(DESCEND) as DESCEND
        from user_ind_columns where table_name = '{tb_name}' group by index_name) uic
        left join user_indexes ui on ui.index_name = uic.index_name