### PR TITLE
修复Django后台查询个人权限，筛选用户时报500错误

### DIFF
--- a/sql/admin.py
+++ b/sql/admin.py
@@ -135,7 +135,7 @@ class QueryPrivilegesAdmin(admin.ModelAdmin):
 @admin.register(QueryPrivilegesApply)
 class QueryPrivilegesApplyAdmin(admin.ModelAdmin):
     list_display = ('apply_id', 'user_display', 'group_name', 'instance', 'valid_date', 'limit_num', 'create_time')
-    search_fields = ['user_display', 'instance__instance_name', 'db_list', 'tb_list']
+    search_fields = ['user_display', 'instance__instance_name', 'db_list', 'table_list']
     list_filter = ('user_display', 'group_name', 'instance')
 
 


### PR DESCRIPTION
修改 class QueryPrivilegesApplyAdmin.search_fields 中 tb_list 为 table_list