### PR TITLE
实例配置增加默认字符集

### DIFF
--- a/sql/completer/mysql.py
+++ b/sql/completer/mysql.py
@@ -33,7 +33,7 @@ class MysqlComEngine(Completer):
         """
         return SQLExecute(self.db_name, self.instance.user, self.instance.raw_password, self.instance.host,
                           int(self.instance.port),
-                          socket='', charset='utf8mb4',
+                          socket='', charset=self.instance.charset or 'utf8mb4',
                           local_infile='', ssl='', ssh_user='', ssh_host='', ssh_port='',
                           ssh_password='', ssh_key_filename=''
                           )

--- a/sql/engines/goinception.py
+++ b/sql/engines/goinception.py
@@ -17,7 +17,7 @@ class GoInceptionEngine(EngineBase):
         if self.conn:
             return self.conn
         if hasattr(self, 'instance'):
-            self.conn = pymysql.connect(host=self.host, port=self.port, charset='utf8mb4')
+            self.conn = pymysql.connect(host=self.host, port=self.port, charset=self.instance.charset or 'utf8mb4')
             return self.conn
         archer_config = SysConfig()
         go_inception_host = archer_config.get('go_inception_host')

--- a/sql/engines/inception.py
+++ b/sql/engines/inception.py
@@ -19,7 +19,7 @@ class InceptionEngine(EngineBase):
         if self.conn:
             return self.conn
         if hasattr(self, 'instance'):
-            self.conn = MySQLdb.connect(host=self.host, port=self.port, charset='utf8mb4')
+            self.conn = MySQLdb.connect(host=self.host, port=self.port, charset=self.instance.charset or 'utf8mb4')
             return self.conn
         archer_config = SysConfig()
         inception_host = archer_config.get('inception_host')

--- a/sql/engines/mssql.py
+++ b/sql/engines/mssql.py
@@ -17,8 +17,8 @@ logger = logging.getLogger('default')
 class MssqlEngine(EngineBase):
     def get_connection(self, db_name=None):
         connstr = """DRIVER=ODBC Driver 17 for SQL Server;SERVER={0},{1};UID={2};PWD={3};
-        client charset = UTF-8;connect timeout=10;CHARSET=UTF8;""".format(self.host,
-                                                                          self.port, self.user, self.password)
+client charset = UTF-8;connect timeout=10;CHARSET={4};""".format(self.host, self.port, self.user, self.password,
+                                                                 self.instance.charset or 'UTF8')
         if self.conn:
             return self.conn
         self.conn = pyodbc.connect(connstr)
@@ -160,9 +160,9 @@ class MssqlEngine(EngineBase):
         """上线单执行前的检查, 返回Review set"""
         check_result = ReviewSet(full_sql=sql)
         # 切分语句，追加到检测结果中，默认全部检测通过
-        split_reg  = re.compile('^GO$', re.I | re.M)
+        split_reg = re.compile('^GO$', re.I | re.M)
         sql = re.split(split_reg, sql, 0)
-        sql = filter(None,sql)
+        sql = filter(None, sql)
         split_sql = [f"""use [{db_name}]"""]
         for i in sql:
             split_sql = split_sql + [i]
@@ -192,7 +192,7 @@ class MssqlEngine(EngineBase):
         cursor = conn.cursor()
         split_reg = re.compile('^GO$', re.I | re.M)
         sql = re.split(split_reg, sql, 0)
-        sql = filter(None,sql)
+        sql = filter(None, sql)
         split_sql = [f"""use [{db_name}]"""]
         for i in sql:
             split_sql = split_sql + [i]

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -23,10 +23,10 @@ class MysqlEngine(EngineBase):
             return self.conn
         if db_name:
             self.conn = MySQLdb.connect(host=self.host, port=self.port, user=self.user, passwd=self.password,
-                                        db=db_name, charset='utf8mb4')
+                                        db=db_name, charset=self.instance.charset or 'utf8mb4')
         else:
             self.conn = MySQLdb.connect(host=self.host, port=self.port, user=self.user, passwd=self.password,
-                                        charset='utf8mb4')
+                                        charset=self.instance.charset or 'utf8mb4')
         return self.conn
 
     @property

--- a/sql/models.py
+++ b/sql/models.py
@@ -46,6 +46,7 @@ class Instance(models.Model):
     port = models.IntegerField('端口', default=0)
     user = models.CharField('用户名', max_length=100, default='', blank=True)
     password = models.CharField('密码', max_length=300, default='', blank=True)
+    charset = models.CharField('字符集', max_length=20, default='', blank=True)
     service_name = models.CharField('Oracle service name', max_length=50, null=True, blank=True)
     sid = models.CharField('Oracle sid', max_length=50, null=True, blank=True)
     create_time = models.DateTimeField('创建时间', auto_now_add=True)

--- a/src/init_sql/v1.6.1_v1.6.2.sql
+++ b/src/init_sql/v1.6.1_v1.6.2.sql
@@ -41,3 +41,7 @@ drop table resource_group_relations;
 ALTER TABLE sql_workflow
   ADD run_date_start datetime(6) DEFAULT NULL COMMENT '可执行起始时间',
   ADD run_date_end datetime(6) DEFAULT NULL COMMENT '可执行结束时间';
+
+-- 实例配置增加默认字符集信息
+ALTER TABLE sql_instance
+  ADD `charset` varchar(20) DEFAULT NULL COMMENT '字符集' after `password`;

--- a/themis/rule_analysis/db/db_operat.py
+++ b/themis/rule_analysis/db/db_operat.py
@@ -22,13 +22,14 @@ class DbOperat(object):
         self.port = int(instance_info.port)
         self.user = instance_info.user
         self.password = instance_info.raw_password
+        self.charset = instance_info.charset or charset
         if flag:
             self.conn = MySQLdb.connect(host=self.host,
                                         port=int(self.port),
                                         user=self.user,
                                         passwd=self.password,
                                         db=db_name,
-                                        charset=charset)
+                                        charset=self.charset)
             self.cursor = self.conn.cursor()
 
     def get_db_cursor(self):


### PR DESCRIPTION
关联issue：#158 #214 #249
- 实例配置中新增字符集字段，可为空 
- 为空时mysql默认使用utf8mb4，mssql默认使用UTF8
