### PR TITLE
解决MySQL在线查询超时后，查询会话没有主动关闭的问题

### DIFF
--- a/sql/engines/__init__.py
+++ b/sql/engines/__init__.py
@@ -7,6 +7,7 @@ class EngineBase:
 
     def __init__(self, instance=None):
         self.conn = None
+        self.thread_id = None
         if instance:
             self.instance = instance
             self.instance_name = instance.instance_name
@@ -27,6 +28,14 @@ class EngineBase:
     def info(self):
         """返回引擎简介"""
         return 'Base engine'
+
+    @property
+    def server_version(self):
+        """返回引擎服务器版本，返回对象为tuple (x,y,z)"""
+        return tuple()
+
+    def kill_connection(self, thread_id):
+        """终止数据库连接"""
 
     def get_all_databases(self):
         """获取数据库列表, 返回一个ResultSet，rows=list"""
@@ -69,6 +78,14 @@ class EngineBase:
 
     def get_rollback(self, workflow):
         """获取工单回滚语句"""
+
+    def get_variables(self, variables=None):
+        """获取实例参数，返回一个 ResultSet"""
+        return ResultSet()
+
+    def set_variable(self, variable_name, variable_value):
+        """修改实例参数值，返回一个 ResultSet"""
+        return ResultSet()
 
 
 def get_engine(instance=None):

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -20,6 +20,7 @@ logger = logging.getLogger('default')
 class MysqlEngine(EngineBase):
     def get_connection(self, db_name=None):
         if self.conn:
+            self.thread_id = self.conn.thread_id()
             return self.conn
         if db_name:
             self.conn = MySQLdb.connect(host=self.host, port=self.port, user=self.user, passwd=self.password,
@@ -27,6 +28,7 @@ class MysqlEngine(EngineBase):
         else:
             self.conn = MySQLdb.connect(host=self.host, port=self.port, user=self.user, passwd=self.password,
                                         charset=self.instance.charset or 'utf8mb4')
+        self.thread_id = self.conn.thread_id()
         return self.conn
 
     @property
@@ -41,6 +43,10 @@ class MysqlEngine(EngineBase):
     def server_version(self):
         version = self.query(sql="select @@version").rows[0][0]
         return tuple([numeric_part(n) for n in version.split('.')[:3]])
+
+    def kill_connection(self, thread_id):
+        """终止数据库连接"""
+        self.query(sql=f'kill {thread_id}')
 
     def get_all_databases(self):
         """获取数据库列表, 返回一个ResultSet"""

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -481,6 +481,12 @@ class TestMysql(TestCase):
         new_engine = MysqlEngine(instance=self.ins1)
         new_engine.osc_control(sqlsha1=sqlsha1, command=command)
 
+    @patch.object(MysqlEngine, 'query')
+    def test_kill_connection(self, _query):
+        new_engine = MysqlEngine(instance=self.ins1)
+        new_engine.kill_connection(100)
+        _query.assert_called_once_with(sql="kill 100")
+
 
 class TestRedis(TestCase):
     @classmethod

--- a/sql/query.py
+++ b/sql/query.py
@@ -1,4 +1,5 @@
 # -*- coding: UTF-8 -*-
+import datetime
 import logging
 import re
 import time
@@ -10,13 +11,13 @@ from django.core import serializers
 from django.db import connection, OperationalError
 from django.db.models import Q
 from django.http import HttpResponse
-from django_q.tasks import async_task, fetch
-
 from common.config import SysConfig
 from common.utils.extend_json_encoder import ExtendJSONEncoder
+from common.utils.timer import FuncTimer
 from sql.query_privileges import query_priv_check
+from sql.utils.tasks import add_kill_conn_schedule, del_schedule
 from .models import QueryLog, Instance
-from sql.engines import get_engine, ResultSet
+from sql.engines import get_engine
 
 logger = logging.getLogger('default')
 
@@ -80,24 +81,21 @@ def query(request):
         # 对查询sql增加limit限制或者改写语句
         sql_content = query_engine.filter_sql(sql=sql_content, limit_num=limit_num)
 
-        # 执行查询语句，timeout=max_execution_time
+        # 先获取查询连接，用于后面查询复用连接以及终止会话
+        query_engine.get_connection(db_name=db_name)
+        thread_id = query_engine.thread_id
         max_execution_time = int(config.get('max_execution_time', 60))
-        query_task_id = async_task(query_engine.query, db_name=str(db_name), sql=sql_content, limit_num=limit_num,
-                                   timeout=max_execution_time, cached=60)
-        # 等待执行结果，max_execution_time后还没有返回结果代表将会被终止
-        query_task = fetch(query_task_id, wait=max_execution_time * 1000, cached=True)
-        # 在max_execution_time内执行结束
-        if query_task:
-            if query_task.success:
-                query_result = query_task.result
-                query_result.query_time = query_task.time_taken()
-            else:
-                query_result = ResultSet(full_sql=sql_content)
-                query_result.error = query_task.result
-        # 等待超时，async_task主动关闭连接
-        else:
-            query_result = ResultSet(full_sql=sql_content)
-            query_result.error = f'查询时间超过 {max_execution_time} 秒，已被主动终止，请优化语句或者联系管理员。'
+        # 执行查询语句，并增加一个定时终止语句的schedule，timeout=max_execution_time
+        if thread_id:
+            schedule_name = f'query-{time.time()}'
+            run_date = (datetime.datetime.now() + datetime.timedelta(seconds=max_execution_time))
+            add_kill_conn_schedule(schedule_name, run_date, instance.id, thread_id)
+        with FuncTimer() as t:
+            query_result = query_engine.query(db_name, sql_content, limit_num)
+        query_result.query_time = t.cost
+        # 返回查询结果后删除schedule
+        if thread_id:
+            del_schedule(schedule_name)
 
         # 查询异常
         if query_result.error:
@@ -105,12 +103,10 @@ def query(request):
             result['msg'] = query_result.error
         # 数据脱敏，仅对查询无错误的结果集进行脱敏，并且按照query_check配置是否返回
         elif config.get('data_masking'):
-            query_masking_task_id = async_task(query_engine.query_masking, db_name=db_name, sql=sql_content,
-                                               resultset=query_result, cached=60)
-            query_masking_task = fetch(query_masking_task_id, wait=60 * 1000, cached=True)
-            if query_masking_task.success:
-                masking_result = query_masking_task.result
-                masking_result.mask_time = query_masking_task.time_taken()
+            try:
+                with FuncTimer() as t:
+                    masking_result = query_engine.query_masking(db_name, sql_content, query_result)
+                masking_result.mask_time = t.cost
                 # 脱敏出错
                 if masking_result.error:
                     # 开启query_check，直接返回异常，禁止执行
@@ -126,12 +122,12 @@ def query(request):
                 # 正常脱敏
                 else:
                     result['data'] = masking_result.__dict__
-            else:
-                logger.error(f'数据脱敏异常，查询语句：{sql_content}\n，错误信息：{query_masking_task.result}')
+            except Exception as msg:
+                logger.error(f'数据脱敏异常，查询语句：{sql_content}\n，错误信息：{msg}')
                 # 抛出未定义异常，并且开启query_check，直接返回异常，禁止执行
                 if config.get('query_check'):
                     result['status'] = 1
-                    result['msg'] = f'数据脱敏异常，请联系管理员，错误信息：{query_masking_task.result}'
+                    result['msg'] = f'数据脱敏异常，请联系管理员，错误信息：{msg}'
                 # 关闭query_check，忽略错误信息，返回未脱敏数据，权限校验标记为跳过
                 else:
                     query_result.error = None
@@ -216,3 +212,10 @@ def querylog(request):
     # 返回查询结果
     return HttpResponse(json.dumps(result, cls=ExtendJSONEncoder, bigint_as_string=True),
                         content_type='application/json')
+
+
+def kill_query_conn(instance_id, thread_id):
+    """终止查询会话，用于schedule调用"""
+    instance = Instance.objects.get(pk=instance_id)
+    query_engine = get_engine(instance)
+    query_engine.kill_connection(thread_id)

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -674,7 +674,7 @@ class TestQueryPrivilegesApply(TestCase):
         self.assertEqual(json.loads(r.content), {"total": 0, "rows": []})
 
 
-class TestQuery(TransactionTestCase):
+class TestQuery(TestCase):
     def setUp(self):
         self.slave1 = Instance(instance_name='test_slave_instance', type='slave', db_type='mysql',
                                host='testhost', port=3306, user='mysql_user', password='mysql_password')
@@ -788,7 +788,7 @@ class TestQuery(TransactionTestCase):
         _get_engine.return_value.kill_connection.return_value = ResultSet()
 
 
-class TestWorkflowView(TransactionTestCase):
+class TestWorkflowView(TestCase):
 
     def setUp(self):
         self.now = datetime.now()
@@ -1112,7 +1112,7 @@ class TestWorkflowView(TransactionTestCase):
         self.assertEqual(r_json['rows'][1]['workflow_name'], self.wf1.workflow_name)
 
         # 资源组
-        r = c.post('/sqlworkflow_list/', {'limit': 10, 'offset': 0, 'instance_id': self.wf1.group_id})
+        r = c.post('/sqlworkflow_list/', {'limit': 10, 'offset': 0, 'resource_group_id': self.wf1.group_id})
         r_json = r.json()
         self.assertEqual(r_json['total'], 2)
         # 列表按创建时间倒序排列, 第二个是wf1
@@ -1734,7 +1734,7 @@ class TestBinLog(TestCase):
         self.assertEqual(json.loads(r.content), {'status': 2, 'msg': '清理失败,Error:清理失败', 'data': ''})
 
 
-class TestParam(TransactionTestCase):
+class TestParam(TestCase):
     """
     测试实例参数修改
     """

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -15,6 +15,7 @@ from sql.binlog import binlog2sql_file
 from sql.engines.models import ResultSet, ReviewSet, ReviewResult
 from sql.notify import notify_for_audit, notify_for_execute, notify_for_binlog2sql
 from sql.utils.execute_sql import execute_callback
+from sql.query import kill_query_conn
 from sql.models import Instance, QueryPrivilegesApply, QueryPrivileges, SqlWorkflow, SqlWorkflowContent, \
     ResourceGroup, ResourceGroup2User, ParamTemplate, WorkflowAudit
 
@@ -697,11 +698,9 @@ class TestQuery(TransactionTestCase):
         archer_config = SysConfig()
         archer_config.set('disable_star', False)
 
-    @patch('sql.query.fetch')
-    @patch('sql.query.async_task')
-    @patch('sql.engines.mysql.MysqlEngine.query')
+    @patch('sql.query.get_engine')
     @patch('sql.query.query_priv_check')
-    def testCorrectSQL(self, _priv_check, _query, _async_task, _fetch):
+    def testCorrectSQL(self, _priv_check, _get_engine):
         c = Client()
         some_sql = 'select some from some_table limit 100;'
         some_db = 'some_db'
@@ -715,25 +714,23 @@ class TestQuery(TransactionTestCase):
         c.force_login(self.u2)
         q_result = ResultSet(full_sql=some_sql, rows=['value'])
         q_result.column_list = ['some']
-
-        _async_task.return_value = q_result
-        _fetch.return_value.result = q_result
+        _get_engine.return_value.query_check.return_value = {
+            'msg': '', 'bad_query': False, 'filtered_sql': some_sql, 'has_star': False}
+        _get_engine.return_value.filter_sql.return_value = some_sql
+        _get_engine.return_value.query.return_value = q_result
         _priv_check.return_value = {'status': 0, 'data': {'limit_num': 100, 'priv_check': True}}
         r = c.post('/query/', data={'instance_name': self.slave1.instance_name,
                                     'sql_content': some_sql,
                                     'db_name': some_db,
                                     'limit_num': some_limit})
-        _async_task.assert_called_once_with(_query, db_name=some_db, sql=some_sql, limit_num=some_limit, timeout=60,
-                                            cached=60)
+        _get_engine.return_value.query.assert_called_once_with(some_db, some_sql, some_limit)
         r_json = r.json()
         self.assertEqual(r_json['data']['rows'], ['value'])
         self.assertEqual(r_json['data']['column_list'], ['some'])
 
-    @patch('sql.query.fetch')
-    @patch('sql.query.async_task')
-    @patch('sql.engines.mysql.MysqlEngine.query')
+    @patch('sql.query.get_engine')
     @patch('sql.query.query_priv_check')
-    def testSQLWithoutLimit(self, _priv_check, _query, _async_task, _fetch):
+    def testSQLWithoutLimit(self, _priv_check, _get_engine):
         c = Client()
         some_limit = 100
         sql_without_limit = 'select some from some_table'
@@ -742,16 +739,16 @@ class TestQuery(TransactionTestCase):
         c.force_login(self.u2)
         q_result = ResultSet(full_sql=sql_without_limit, rows=['value'])
         q_result.column_list = ['some']
-        _async_task.return_value = q_result
-        _fetch.return_value.result = q_result
-        _fetch.return_value.time_taken.return_value = 1
+        _get_engine.return_value.query_check.return_value = {
+            'msg': '', 'bad_query': False, 'filtered_sql': sql_without_limit, 'has_star': False}
+        _get_engine.return_value.filter_sql.return_value = sql_with_limit
+        _get_engine.return_value.query.return_value = q_result
         _priv_check.return_value = {'status': 0, 'data': {'limit_num': 100, 'priv_check': True}}
         r = c.post('/query/', data={'instance_name': self.slave1.instance_name,
                                     'sql_content': sql_without_limit,
                                     'db_name': some_db,
                                     'limit_num': some_limit})
-        _async_task.assert_called_once_with(_query, db_name=some_db, sql=sql_with_limit, limit_num=some_limit,
-                                            timeout=60, cached=60)
+        _get_engine.return_value.query.assert_called_once_with(some_db, sql_with_limit, some_limit)
         r_json = r.json()
         self.assertEqual(r_json['data']['rows'], ['value'])
         self.assertEqual(r_json['data']['column_list'], ['some'])
@@ -759,13 +756,13 @@ class TestQuery(TransactionTestCase):
         # 带 * 且不带 limit 的sql
         sql_with_star = 'select * from some_table'
         filtered_sql_with_star = 'select * from some_table limit {0};'.format(some_limit)
-        _async_task.reset_mock()
+        _get_engine.return_value.filter_sql.return_value = filtered_sql_with_star
+        _get_engine.return_value.query.reset_mock()
         c.post('/query/', data={'instance_name': self.slave1.instance_name,
                                 'sql_content': sql_with_star,
                                 'db_name': some_db,
                                 'limit_num': some_limit})
-        _async_task.assert_called_once_with(_query, db_name=some_db, sql=filtered_sql_with_star, limit_num=some_limit,
-                                            timeout=60, cached=60)
+        _get_engine.return_value.query.assert_called_once_with(some_db, filtered_sql_with_star, some_limit)
 
     @patch('sql.query.query_priv_check')
     def testStarOptionOn(self, _priv_check):
@@ -784,6 +781,11 @@ class TestQuery(TransactionTestCase):
         archer_config.set('disable_star', False)
         r_json = r.json()
         self.assertEqual(1, r_json['status'])
+
+    @patch('sql.query.get_engine')
+    def test_kill_query_conn(self, _get_engine):
+        kill_query_conn(self.slave1.id, 10)
+        _get_engine.return_value.kill_connection.return_value = ResultSet()
 
 
 class TestWorkflowView(TransactionTestCase):

--- a/sql/utils/tasks.py
+++ b/sql/utils/tasks.py
@@ -16,6 +16,13 @@ def add_sql_schedule(name, run_date, workflow_id):
     logger.debug(f"添加SQL定时执行任务：{name} 执行时间：{run_date}")
 
 
+def add_kill_conn_schedule(name, run_date, instance_id, thread_id):
+    """添加/修改终止数据库连接的定时任务"""
+    del_schedule(name)
+    schedule('sql.query.kill_query_conn', instance_id, thread_id,
+             name=name, schedule_type='O', next_run=run_date, repeats=1, timeout=-1)
+
+
 def del_schedule(name):
     """删除task"""
     try:
@@ -23,7 +30,7 @@ def del_schedule(name):
         Schedule.delete(sql_schedule)
         logger.debug(f'删除task：{name}')
     except Schedule.DoesNotExist:
-        logger.debug(f'删除task：{name}失败，任务不存在')
+        pass
 
 
 def task_info(name):


### PR DESCRIPTION
关联PR：#125

采取原PR中的第二种实现

- engine类增加thread_id属性，表示当前会话的线程id
- engine类增加kill_connection的方法用于终止数据库连接
- query.py增加kill_query_conn的方法调用kill_connection用于终止查询连接
- 在查询前按照max_execution_time配置增加一个定时终止语句的schedule，查询结束后删除

弊端：
- 查询又回归最初的同步查询，不依赖django_q，因为django_q序列化所使用的pickle方法不支持Connection对象，无法在获取conn后提交异步task，会抛出如下错误
    ```
    TypeError: can't pickle Connection objects
    ```
- 各类数据库kill_connection后的错误不一致，无法try Exception后给出友好的查询终止提示，MySQL查询会话在被终止后会抛出
    ```
    (2013, 'Lost connection to MySQL server during query')
    ```
- django_q轮询间隔为30s，所以终止会话的操作会有30s的误差


但是问题是解决了，各类数据库拓展对应的方法也可以实现

