### PR TITLE
修改 OracleEngine 使其不需要 dba 权限。

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -75,7 +75,7 @@ class OracleEngine(EngineBase):
         获取模式列表
         :return:
         """
-        result = self.query(sql="select username from sys.dba_users")
+        result = self.query(sql="SELECT username FROM all_users")
         sysschema = (
             'AUD_SYS', 'ANONYMOUS', 'APEX_030200', 'APEX_PUBLIC_USER', 'APPQOSSYS', 'BI USERS', 'CTXSYS', 'DBSNMP',
             'DIP USERS', 'EXFSYS', 'FLOWS_FILES', 'HR USERS', 'IX USERS', 'MDDATA', 'MDSYS', 'MGMT_VIEW', 'OE USERS',
@@ -88,15 +88,7 @@ class OracleEngine(EngineBase):
 
     def get_all_tables(self, db_name):
         """获取table 列表, 返回一个ResultSet"""
-        sql = f"""select
-        TABLE_NAME
-        from dba_tab_privs
-        where grantee in ('{db_name}')
-        union
-        select
-        OBJECT_NAME
-        from dba_objects
-        WHERE OWNER IN ('{db_name}') and object_type in ('TABLE')
+        sql = f"""SELECT table_name FROM all_tables WHERE nvl(tablespace_name, 'no tablespace') NOT IN ('SYSTEM', 'SYSAUX') AND OWNER = '{db_name}' AND IOT_NAME IS NULL AND DURATION IS NULL
         """
         result = self.query(sql=sql)
         tb_list = [row[0] for row in result.rows if row[0] not in ['test']]


### PR DESCRIPTION
如代码所示，参考 sqlalchemy 的SQL实现，替换查询数据库列表和表列表的SQL语句。参考sqlalchemy\dialects\oracle\base.py：
```python
    @reflection.cache
    def get_schema_names(self, connection, **kw):
        s = "SELECT username FROM all_users ORDER BY username"
        cursor = connection.execute(s,)
        return [self.normalize_name(row[0]) for row in cursor]

    @reflection.cache
    def get_table_names(self, connection, schema=None, **kw):
        schema = self.denormalize_name(schema or self.default_schema_name)

        # note that table_names() isn't loading DBLINKed or synonym'ed tables
        if schema is None:
            schema = self.default_schema_name

        sql_str = "SELECT table_name FROM all_tables WHERE "
        if self.exclude_tablespaces:
            sql_str += (
                "nvl(tablespace_name, 'no tablespace') "
                "NOT IN (%s) AND " % (
                    ', '.join(["'%s'" % ts for ts in self.exclude_tablespaces])
                )
            )
        sql_str += (
            "OWNER = :owner "
            "AND IOT_NAME IS NULL "
            "AND DURATION IS NULL")

        cursor = connection.execute(sql.text(sql_str), owner=schema)
        return [self.normalize_name(row[0]) for row in cursor]
```


