### PR TITLE
在线查询新增查询语句收藏以及快捷查询功能  

### DIFF
--- a/sql/models.py
+++ b/sql/models.py
@@ -400,7 +400,7 @@ class QueryLog(models.Model):
     # TODO 改为实例外键
     instance_name = models.CharField('实例名称', max_length=50)
     db_name = models.CharField('数据库名称', max_length=64)
-    sqllog = models.TextField('执行的sql查询')
+    sqllog = models.TextField('执行的查询语句')
     effect_row = models.BigIntegerField('返回行数')
     cost_time = models.CharField('执行耗时', max_length=10, default='')
     # TODO 改为user 外键
@@ -409,6 +409,8 @@ class QueryLog(models.Model):
     priv_check = models.BooleanField('查询权限是否正常校验', choices=((False, '跳过'), (True, '正常'),), default=False)
     hit_rule = models.BooleanField('查询是否命中脱敏规则', choices=((False, '未命中/未知'), (True, '命中')), default=False)
     masking = models.BooleanField('查询结果是否正常脱敏', choices=((False, '否'), (True, '是'),), default=False)
+    favorite = models.BooleanField('是否收藏', choices=((False, '否'), (True, '是'),), default=False)
+    alias = models.CharField('语句标识', max_length=64, default='', blank=True)
     create_time = models.DateTimeField('操作时间', auto_now_add=True)
     sys_time = models.DateTimeField(auto_now=True)
 

--- a/sql/sql_workflow.py
+++ b/sql/sql_workflow.py
@@ -81,8 +81,7 @@ def sql_workflow_list(request):
 
     # 过滤搜索项，模糊检索项包括提交人名称、工单名
     if search:
-        workflow = SqlWorkflow.objects.filter(Q(engineer_display__icontains=search) |
-                                              Q(workflow_name__icontains=search))
+        workflow = workflow(Q(engineer_display__icontains=search) | Q(workflow_name__icontains=search))
 
     count = workflow.count()
     workflow_list = workflow.order_by('-create_time')[offset:limit].values(

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -1,11 +1,62 @@
 {% extends "base.html" %}
 
 {% block content %}
+    <!-- 自定义操作按钮-->
+    <div id="query-log-toolbar" class="form-inline pull-left">
+        <div class="form-group">
+            <select id="filter-star" class="form-control selectpicker"
+                    title="全部">
+                <option value="" selected="selected">全部</option>
+                <option value="true">已收藏</option>
+                <option value="false">未收藏</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <select id="filter-alias" class="form-control selectpicker"
+                    data-live-search="true"
+                    title="全部">
+                <option value="" selected="selected">全部</option>
+                {% for sql in favorites %}
+                    <option value={{ sql.id }}>{{ sql.alias }}</option>
+                {% endfor %}
+            </select>
+        </div>
+    </div>
+    <!-- 收藏信息弹出框-->
+    <div class="modal fade" id="favorite">
+        <div class="modal-dialog modal-sm">
+            <div class="modal-content message_align">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">×</span></button>
+                    <h4 class="modal-title text-danger">收藏语句</h4>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" id="query_log_id">
+                    <input id="alias" name="alias" type='text' autocomplete="off" class="form-control"
+                           placeholder="请输入语句别名"/>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-info" data-dismiss="modal">取消</button>
+                    <button type="button" id="btn-star" class="btn btn-danger" onclick="star()">收藏</button>
+                </div>
+            </div>
+        </div>
+    </div>
     <div class="row clearfix">
         <div class="col-md-12">
             <div class="panel panel-default">
-                <div class="panel-heading">
+                <div class="panel-heading form-inline">
                     SQL查询
+                    <select id="favorites" name="favorites"
+                            class="form-control selectpicker"
+                            data-live-search="true"
+                            title="常用查询"
+                            required>
+                        {% for sql in favorites %}
+                            <option value={{ sql.id }}>{{ sql.alias }}</option>
+                        {% endfor %}
+                    </select>
                 </div>
                 <div class="panel-body">
                     <form id="form-sqlquery" action="/sqlquery/" method="post" class="form-horizontal" role="form">
@@ -214,12 +265,11 @@
     <!-- 查询历史  -->
     <script>
         //获取查询列表
-        function get_querylog() {
-            //采取异步请求
+        function get_querylog(query_log_id) {
             //初始化table
             $('#sql-log').bootstrapTable('destroy').bootstrapTable({
                 escape: true,
-                method: 'post',
+                method: 'get',
                 contentType: "application/x-www-form-urlencoded",
                 url: "/query/querylog/",
                 striped: true,                      //是否显示行间隔色
@@ -248,12 +298,14 @@
                 cardView: false,                    //是否显示详细视图
                 detailView: true,                   //是否显示父子表
                 locale: 'zh-CN',                    //本地化
-                toolbar: "#toolbar",                //指明自定义的toolbar
+                toolbar: "#query-log-toolbar",      //指明自定义的toolbar
                 queryParamsType: 'limit',
                 //获取查询列表请求服务数据时所传参数
                 queryParams:
                     function (params) {
                         return {
+                            star: $("#filter-star").val(),
+                            query_log_id: $("#filter-alias").val(),
                             limit: params.limit,
                             offset: params.offset,
                             search: params.search
@@ -276,6 +328,19 @@
                     return html.join('');
                 },
                 columns: [{
+                    title: '操作',
+                    field: '',
+                    formatter: function (value, row, index) {
+                        if (row.favorite) {
+                            var btn_favorite = "<button type=\"button\" class=\"btn btn-xs\" data-toggle=\"tooltip\" title=\"取消收藏\" onclick=\"unstar(" + row.id + ")" + "\"><span class=\"fa fa-star\"></span></button>\n";
+                        } else {
+                            var btn_favorite = "<button type=\"button\" class=\"btn btn-xs\" data-toggle=\"modal\" data-target=\"#favorite\" onclick=\"star(" + row.id + ")" + "\"><span class=\"fa fa-star-o\"></span></button>\n";
+                        }
+                        let btn_re_query = "<button type=\"button\" class=\"btn btn-xs\"  data-toggle=\"tooltip\" title=\"一键查询\" onclick=\"re_query(" + row.id + ")" + "\"><span class=\"fa fa-search\"></span></button>";
+                        return btn_favorite + btn_re_query
+                    }
+
+                }, {
                     title: '用户',
                     field: 'user_display'
                 }, {
@@ -288,7 +353,7 @@
                     title: '查询时间',
                     field: 'create_time'
                 }, {
-                    title: 'sql语句',
+                    title: '语句',
                     field: 'sqllog',
                     formatter: function (value, row, index) {
                         if (value.length > 50) {
@@ -299,7 +364,7 @@
                         }
                     }
                 }, {
-                    title: '完整sql语句',
+                    title: '完整语句',
                     field: 'sqllog',
                     visible: false // 默认不显示
                 }, {
@@ -310,6 +375,9 @@
                     field: 'cost_time'
                 }],
                 onLoadSuccess: function () {
+                    if (query_log_id) {
+                        re_query(query_log_id)
+                    }
                 },
                 onLoadError: function () {
                     alert("数据加载失败！请检查接口返回信息和错误日志！");
@@ -323,6 +391,106 @@
                     return res;
                 }
             });
+        }
+
+        // 筛选
+        $("#filter-star").change(function () {
+            get_querylog();
+        });
+        $("#filter-alias").change(function () {
+            get_querylog()
+        });
+
+        // 快捷查询
+        $("#favorites").change(function () {
+            let query_log_id = $("#favorites").val();
+            $("#filter-alias").val(query_log_id);
+            $('#filter-alias').selectpicker('render');
+            $('#filter-alias').selectpicker('refresh');
+            get_querylog(query_log_id);
+        });
+
+        // 收藏
+        function star(query_log_id) {
+            if (query_log_id) {
+                $("#query_log_id").val(query_log_id);
+            } else if ($("#alias").val()) {
+                $.ajax({
+                    type: "post",
+                    url: "/query/favorite/",
+                    dataType: "json",
+                    data: {
+                        query_log_id: $("#query_log_id").val(),
+                        star: true,
+                        alias: $("#alias").val(),
+                    },
+                    complete: function () {
+                        $("#sql-log").bootstrapTable('refresh');
+                        $("#favorite").modal('hide');
+                        $("#alias").val('')
+                    },
+                    success: function (data) {
+                        if (data.status !== 0) {
+                            alert(data.msg);
+                        }
+                    },
+                    error: function (XMLHttpRequest, textStatus, errorThrown) {
+                        alert(errorThrown);
+                    }
+                });
+            } else {
+                alert('请输入语句别名！')
+            }
+        }
+
+        // 取消收藏
+        function unstar(query_log_id) {
+            $.ajax({
+                type: "post",
+                url: "/query/favorite/",
+                dataType: "json",
+                data: {
+                    query_log_id: query_log_id,
+                    star: false,
+                    alias: '',
+                },
+                complete: function () {
+                    $("#sql-log").bootstrapTable('refresh');
+                },
+                success: function (data) {
+                    if (data.status !== 0) {
+                        alert(data.msg);
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            });
+        }
+
+        // 一键重新查询
+        function re_query(query_log_id) {
+            let row_data = $('#sql-log').bootstrapTable('getRowByUniqueId', query_log_id);
+            $("#instance_name").selectpicker('val', row_data['instance_name']);
+            if ($("#instance_name").val()) {
+                get_instance(false)
+            }
+            $("#db_name").selectpicker('val', row_data['db_name']);
+            let instance_name = $("#instance_name").val();
+            let db_name = $("#db_name").val();
+            if (db_name) {
+                $("#db_name").selectpicker().trigger("change");
+            }
+            let sql = row_data['sqllog'];
+            let limit_num = 100;
+            editor.setValue(sql);
+            editor.clearSelection();
+            $("#limit_num").val(limit_num);
+            if (instance_name && db_name && sql) {
+                sqlquery()
+            } else {
+                alert("信息不完整，无法一键查询！")
+            }
         }
     </script>
     <!-- 执行结果  -->
@@ -633,7 +801,7 @@
     <!-- common -->
     <script>
         // 实例变更获取数据库
-        $("#instance_name").change(function () {
+        function get_instance(async) {
             $("#db_name").empty();
             $('#db_name').selectpicker('render');
             $('#db_name').selectpicker('refresh');
@@ -671,11 +839,16 @@
                 type: "post",
                 url: "/instance/instance_resource/",
                 dataType: "json",
+                async: async,
                 data: {
                     instance_name: $("#instance_name").val(),
                     resource_type: "database"
                 },
                 complete: function () {
+                    $("#db_name").selectpicker('val', db_name);
+                    if ($("#db_name").val()) {
+                        $("#db_name").selectpicker().trigger("change");
+                    }
                 },
                 success: function (data) {
                     if (data.status === 0) {
@@ -705,6 +878,10 @@
                     alert(errorThrown);
                 }
             });
+        }
+
+        $("#instance_name").change(function () {
+            get_instance(true)
         });
 
 
@@ -891,7 +1068,7 @@
                                     $("#optgroup-oracle").append(instance);
                                 } else if (result[i]['db_type'] === 'mongo') {
                                     $("#optgroup-mongo").append(instance);
-                                } 
+                                }
                             }
                             $('#instance_name').selectpicker('render');
                             $('#instance_name').selectpicker('refresh');

--- a/sql/urls.py
+++ b/sql/urls.py
@@ -95,6 +95,7 @@ urlpatterns = [
 
     path('query/', query.query),
     path('query/querylog/', query.querylog),
+    path('query/favorite/', query.favorite),
     path('query/explain/', sql.sql_optimize.explain),
     path('query/applylist/', sql.query_privileges.query_priv_apply_list),
     path('query/userprivileges/', sql.query_privileges.user_query_priv),

--- a/sql/views.py
+++ b/sql/views.py
@@ -18,7 +18,7 @@ from sql.engines.models import ReviewResult, ReviewSet
 from sql.utils.tasks import task_info
 
 from .models import Users, SqlWorkflow, QueryPrivileges, ResourceGroup, \
-    QueryPrivilegesApply, Config, SQL_WORKFLOW_CHOICES, InstanceTag, Instance
+    QueryPrivilegesApply, Config, SQL_WORKFLOW_CHOICES, InstanceTag, Instance, QueryLog
 from sql.utils.workflow_audit import Audit
 from sql.utils.sql_review import can_execute, can_timingtask, can_cancel
 from common.utils.const import Const, WorkflowDict
@@ -219,7 +219,10 @@ def sqlquery(request):
     """SQL在线查询页面"""
     # 主动创建标签
     InstanceTag.objects.get_or_create(tag_code='can_read', defaults={'tag_name': '支持查询', 'active': True})
-    return render(request, 'sqlquery.html')
+    # 收藏语句
+    user = request.user
+    favorites = QueryLog.objects.filter(username=user.username, favorite=True).values('id', 'alias')
+    return render(request, 'sqlquery.html', {'favorites': favorites})
 
 
 @permission_required('sql.menu_queryapplylist', raise_exception=True)

--- a/src/init_sql/v1.6.5_v1.6.6.sql
+++ b/src/init_sql/v1.6.5_v1.6.6.sql
@@ -1,0 +1,4 @@
+-- 增加查询语句收藏/置顶功能
+alter table query_log
+  add favorite tinyint not null default 0 comment '是否收藏',
+  add alias varchar(100) not null default '' comment '语句标识/别名';


### PR DESCRIPTION
相关issue #333

在查询日志中增加收藏和别名属性

- 查询日志列表增加是否收藏、别名下拉筛选项
- 增加收藏、取消收藏查询日志功能，但是不允许编辑语句内容
- 所有查询语句均可以一键重新查询
- 收藏语句可以快捷筛选，一键查询

![image](https://user-images.githubusercontent.com/8842982/61994523-e2a7f680-b0ad-11e9-81bc-676c21146082.png)

![image](https://user-images.githubusercontent.com/8842982/61994541-2a2e8280-b0ae-11e9-8ba2-73b0b146578a.png)
