### PR TITLE
修复oracle 行数限制功能bug

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -151,7 +151,7 @@ class OracleEngine(EngineBase):
         # 对查询sql增加limit限制
         if re.match(r"^select", sql_lower):
             if sql_lower.find(' rownum ') == -1:
-                if sql_lower.find(' where ') == -1:
+                if sql_lower.find('where') == -1:
                     return f"{sql.rstrip(';')} WHERE ROWNUM <= {limit_num}"
                 else:
                     return f"{sql.rstrip(';')} AND ROWNUM <= {limit_num}"


### PR DESCRIPTION
where 定格的时候会出现判断失误导致 添加 方式不对