### PR TITLE
调整JSON序列化的时间格式，fix #414

### DIFF
--- a/common/utils/extend_json_encoder.py
+++ b/common/utils/extend_json_encoder.py
@@ -12,7 +12,8 @@ def convert(o):
 
 @convert.register(datetime)
 def _(o):
-    return o.strftime('%Y-%m-%d %H:%M:%S')
+    # return o.strftime('%Y-%m-%d %H:%M:%S')
+    return o.isoformat(' ')
 
 
 @convert.register(date)


### PR DESCRIPTION
#414 
调整时间格式化为o.isoformat(' ')方法，可显示微秒信息