### PR TITLE
修复脱敏异常时将权限校验标记为跳过的问题

### DIFF
--- a/sql/query.py
+++ b/sql/query.py
@@ -7,7 +7,6 @@ import traceback
 
 import simplejson as json
 from django.contrib.auth.decorators import permission_required
-from django.core import serializers
 from django.db import connection, OperationalError
 from django.db.models import Q
 from django.http import HttpResponse
@@ -123,7 +122,6 @@ def query(request):
                     else:
                         logger.warning(f'数据脱敏异常，按照配置放行，查询语句：{sql_content}，错误信息：{masking_result.error}')
                         query_result.error = None
-                        priv_check = False
                         result['data'] = query_result.__dict__
                 # 正常脱敏
                 else:
@@ -137,7 +135,6 @@ def query(request):
                 else:
                     logger.warning(f'数据脱敏异常，按照配置放行，查询语句：{sql_content}，错误信息：{msg}')
                     query_result.error = None
-                    priv_check = False
                     result['data'] = query_result.__dict__
         # 无需脱敏的语句
         else:


### PR DESCRIPTION
现在的代码中，当权限校验正常但是脱敏异常时，会将权限校验状态设置为跳过，导致统计出现错误。
删除相关赋值，权限校验情况以校验方法返回的结果为准