### PR TITLE
解决下拉筛选项被表格遮挡的问题 fix #413

### DIFF
--- a/common/templates/base.html
+++ b/common/templates/base.html
@@ -282,6 +282,25 @@
         }
         return cookieValue;
     }
+
+    // 解决下拉筛选项被表格遮挡
+    // https://github.com/twbs/bootstrap/issues/11037#issuecomment-274870381
+    $('.table-responsive').on('shown.bs.dropdown', function (e) {
+        var t = $(this),
+            m = $(e.target).find('.dropdown-menu'),
+            tb = t.offset().top + t.height(),
+            mb = m.offset().top + m.outerHeight(true),
+            d = 20; // Space for shadow + scrollbar.
+        if (t[0].scrollWidth > t.innerWidth()) {
+            if (mb + d > tb) {
+                t.css('padding-bottom', ((mb + d) - tb));
+            }
+        } else {
+            t.css('overflow', 'visible');
+        }
+    }).on('hidden.bs.dropdown', function () {
+        $(this).css({'padding-bottom': '', 'overflow': ''});
+    });
 </script>
 {% block js %}
 {% endblock %}

--- a/sql/templates/instanceuser.html
+++ b/sql/templates/instanceuser.html
@@ -9,7 +9,7 @@
                     data-live-search="true">
             </select>
         </div>
-        <div class="form-group ">
+        <div class="form-group " style="display: none">
             <button id="btn_add_master" type="button" class="btn btn-default"
                     onclick="window.open('')">
                 <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>


### PR DESCRIPTION
参考：https://github.com/twbs/bootstrap/issues/11037#issuecomment-274870381

- 全局解决下拉菜单被表格遮挡的问题
- 隐藏用户添加入口（功能未实现）

fix #413