### PR TITLE
bugfix: 为 failed_login_count 增加范围限制, 强制限制在 0-127

### DIFF
--- a/sql/models.py
+++ b/sql/models.py
@@ -13,6 +13,11 @@ class Users(AbstractUser):
     failed_login_count = models.IntegerField('失败计数', default=0)
     last_login_failed_at = models.DateTimeField('上次失败登录时间', blank=True, null=True)
 
+    def save(self, *args, **kwargs):
+        self.failed_login_count = min(127, self.failed_login_count)
+        self.failed_login_count = max(0, self.failed_login_count)
+        super(Users, self).save(*args, **kwargs)
+
     def __str__(self):
         if self.display:
             return self.display

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -141,6 +141,23 @@ class TestUser(TestCase):
         # init 只调用一次
         mock_init.assert_called_once()
 
+    def test_out_ranged_failed_login_count(self):
+        # 正常保存
+        self.u1.failed_login_count = 64
+        self.u1.save()
+        self.u1.refresh_from_db()
+        self.assertEqual(64, self.u1.failed_login_count)
+        # 超过127视为127
+        self.u1.failed_login_count = 256
+        self.u1.save()
+        self.u1.refresh_from_db()
+        self.assertEqual(127, self.u1.failed_login_count)
+        # 小于0视为0
+        self.u1.failed_login_count = -1
+        self.u1.save()
+        self.u1.refresh_from_db()
+        self.assertEqual(0, self.u1.failed_login_count)
+
 
 class TestQueryPrivilegesCheck(TestCase):
     """测试权限校验"""


### PR DESCRIPTION
fix #417 