### PR TITLE
增加数据字典导出功能

### DIFF
--- a/archery/__init__.py
+++ b/archery/__init__.py
@@ -1,2 +1,2 @@
-version = (1, 7, 1)
+version = (1, 7, 2)
 display_version = '.'.join(str(i) for i in version)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ mysqlclient==1.3.13
 pymysql==0.9.3
 requests==2.21.0
 simplejson==3.16.0
-moz_sql_parser==2.44.19084
 mybatis_mapper2sql==0.1.9
 django-auth-ldap==2.0.0
 python-dateutil==2.8.0

--- a/sql/data_dictionary.py
+++ b/sql/data_dictionary.py
@@ -1,11 +1,18 @@
 # -*- coding: UTF-8 -*-
-import simplejson as json
+import datetime
+import os
 
+import MySQLdb
+import simplejson as json
+from jinja2 import Template
+
+from archery import settings
 from sql.engines import get_engine
 from django.contrib.auth.decorators import permission_required
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse, FileResponse
 
 from common.utils.extend_json_encoder import ExtendJSONEncoder
+from sql.utils.resource_group import user_instances
 from .models import Instance
 
 
@@ -126,3 +133,94 @@ def table_info(request):
         res = {'status': 1, 'msg': '非法调用！'}
     return HttpResponse(json.dumps(res, cls=ExtendJSONEncoder, bigint_as_string=True),
                         content_type='application/json')
+
+
+@permission_required('sql.data_dictionary_export', raise_exception=True)
+def export(request):
+    """导出数据字典"""
+    instance_name = request.GET.get('instance_name', '')
+    db_name = request.GET.get('db_name', '')
+    try:
+        instance = user_instances(request.user, db_type=['mysql']).get(instance_name=instance_name)
+        query_engine = get_engine(instance=instance)
+    except Instance.DoesNotExist:
+        return JsonResponse({'status': 1, 'msg': '你所在组未关联该实例！', 'data': []})
+
+    html = """<html>
+    <meta charset="utf-8">
+    <title>数据库表结构说明文档</title>
+    <style>
+        body,td,th {font-family:"宋体"; font-size:12px;}  
+        table,h1,p{width:960px;margin:0px auto;}
+        table{border-collapse:collapse;border:1px solid #CCC;background:#efefef;}  
+        table caption{text-align:left; background-color:#fff; line-height:2em; font-size:14px; font-weight:bold; }  
+        table th{text-align:left; font-weight:bold;height:26px; line-height:26px; font-size:12px; border:1px solid #CCC;padding-left:5px;}  
+        table td{height:20px; font-size:12px; border:1px solid #CCC;background-color:#fff;padding-left:5px;}  
+        .c1{ width: 150px;}  
+        .c2{ width: 150px;}  
+        .c3{ width: 80px;}  
+        .c4{ width: 100px;}  
+        .c5{ width: 100px;}  
+        .c6{ width: 300px;}
+    </style>
+    <body>
+    <h1 style="text-align:center;">{{ db_name }} 数据字典 (共 {{ tables|length }} 个表)</h1>
+    <p style="text-align:center;margin:20px auto;">生成时间：{{ export_time }}</p>
+    {% for tb in tables %}
+    <table border="1" cellspacing="0" cellpadding="0" align="center">
+    <caption>表名：{{ tb['TABLE_INFO']['TABLE_NAME'] }}</caption>
+    <caption>注释：{{ tb['TABLE_INFO']['TABLE'] }}</caption>
+    <tbody><tr><th>字段名</th><th>数据类型</th><th>默认值</th><th>允许非空</th><th>自动递增</th><th>是否主键</th><th>备注</th>
+    {% for col in tb['COLUMNS'] %}
+    </tr>     
+    <td class="c1">{{ col['COLUMN_NAME'] }}</td>
+    <td class="c2">{{ col['COLUMN_TYPE'] }}</td>
+    <td class="c3">{{ col['COLUMN_DEFAULT'] }}</td>
+    <td class="c4">{{ col['IS_NULLABLE'] }}</td>
+    <td class="c5">{% if col['EXTRA']=='auto_increment' %} 是 {% endif %}</td>
+    <td class="c5">{{ col['COLUMN_KEY'] }}</td>
+    <td class="c6">{{ col['COLUMN_COMMENT'] }}</td>
+    </tr>
+    {% endfor %}
+    </tbody></table></br>
+    {% endfor %}
+    </body>
+    </html>
+    """
+
+    # 普通用户仅可以获取指定数据库的字典信息
+    if db_name:
+        dbs = [db_name]
+    # 管理员可以导出整个实例的字典信息
+    elif request.user.is_superuser:
+        dbs = query_engine.get_all_databases().rows
+    else:
+        return JsonResponse({'status': 1, 'msg': f'仅管理员可以导出整个实例的字典信息！', 'data': []})
+
+    # 获取数据，存入目录
+    path = os.path.join(settings.BASE_DIR, 'downloads/dictionary')
+    os.makedirs(path, exist_ok=True)
+    for db in dbs:
+        sql_tbs = f"SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='{db}';"
+        tbs = query_engine.query(sql=sql_tbs, cursorclass=MySQLdb.cursors.DictCursor, close_conn=False).rows
+        table_metas = []
+        for tb in tbs:
+            _meta = dict()
+            _meta['TABLE_INFO'] = tb
+            sql_cols = f"""SELECT * FROM INFORMATION_SCHEMA.COLUMNS 
+                    WHERE TABLE_SCHEMA='{tb['TABLE_SCHEMA']}' AND TABLE_NAME='{tb['TABLE_NAME']}';"""
+            _meta['COLUMNS'] = query_engine.query(sql=sql_cols,
+                                                  cursorclass=MySQLdb.cursors.DictCursor, close_conn=False).rows
+            table_metas.append(_meta)
+        data = Template(html).render(db_name=db, tables=table_metas, export_time=datetime.datetime.now())
+        with open(f'{path}/{instance_name}_{db}.html', 'w') as f:
+            f.write(data)
+    # 关闭连接
+    query_engine.close()
+    if db_name:
+        response = FileResponse(open(f'{path}/{instance_name}_{db_name}.html', 'rb'))
+        response['Content-Type'] = 'application/octet-stream'
+        response['Content-Disposition'] = f'attachment;filename="{instance_name}_{db_name}.html"'
+        return response
+    else:
+        return JsonResponse({'status': 0, 'msg': f'实例{instance_name}数据字典导出成功，请到downloads目录下载！', 'data': []})

--- a/sql/data_dictionary.py
+++ b/sql/data_dictionary.py
@@ -169,7 +169,7 @@ def export(request):
     {% for tb in tables %}
     <table border="1" cellspacing="0" cellpadding="0" align="center">
     <caption>表名：{{ tb['TABLE_INFO']['TABLE_NAME'] }}</caption>
-    <caption>注释：{{ tb['TABLE_INFO']['TABLE'] }}</caption>
+    <caption>注释：{{ tb['TABLE_INFO']['TABLE_COMMENT'] }}</caption>
     <tbody><tr><th>字段名</th><th>数据类型</th><th>默认值</th><th>允许非空</th><th>自动递增</th><th>是否主键</th><th>备注</th>
     {% for col in tb['COLUMNS'] %}
     </tr>     

--- a/sql/data_dictionary.py
+++ b/sql/data_dictionary.py
@@ -4,6 +4,7 @@ import os
 
 import MySQLdb
 import simplejson as json
+from django.utils.http import urlquote
 from jinja2 import Template
 
 from archery import settings
@@ -175,7 +176,7 @@ def export(request):
     </tr>     
     <td class="c1">{{ col['COLUMN_NAME'] }}</td>
     <td class="c2">{{ col['COLUMN_TYPE'] }}</td>
-    <td class="c3">{{ col['COLUMN_DEFAULT'] }}</td>
+    <td class="c3">{{ col['COLUMN_DEFAULT'] or '' }}</td>
     <td class="c4">{{ col['IS_NULLABLE'] }}</td>
     <td class="c5">{% if col['EXTRA']=='auto_increment' %} 是 {% endif %}</td>
     <td class="c5">{{ col['COLUMN_KEY'] }}</td>
@@ -220,7 +221,8 @@ def export(request):
     if db_name:
         response = FileResponse(open(f'{path}/{instance_name}_{db_name}.html', 'rb'))
         response['Content-Type'] = 'application/octet-stream'
-        response['Content-Disposition'] = f'attachment;filename="{instance_name}_{db_name}.html"'
+        response['Content-Disposition'] = f'attachment;filename="{urlquote(instance_name)}_{urlquote(db_name)}.html"'
         return response
+
     else:
         return JsonResponse({'status': 0, 'msg': f'实例{instance_name}数据字典导出成功，请到downloads目录下载！', 'data': []})

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -111,12 +111,13 @@ class MysqlEngine(EngineBase):
         result = self.query(db_name=db_name, sql=sql)
         return result
 
-    def query(self, db_name=None, sql='', limit_num=0, close_conn=True):
+    def query(self, db_name=None, sql='', limit_num=0, close_conn=True, **kwargs):
         """返回 ResultSet """
         result_set = ResultSet(full_sql=sql)
+        cursorclass = kwargs.get('cursorclass') or MySQLdb.cursors.Cursor
         try:
             conn = self.get_connection(db_name=db_name)
-            cursor = conn.cursor()
+            cursor = conn.cursor(cursorclass)
             effect_row = cursor.execute(sql)
             if int(limit_num) > 0:
                 rows = cursor.fetchmany(size=int(limit_num))

--- a/sql/models.py
+++ b/sql/models.py
@@ -619,6 +619,7 @@ class Permission(models.Model):
             ('instance_account_manage', '管理实例账号'),
             ('param_view', '查看实例参数列表'),
             ('param_edit', '修改实例参数'),
+            ('data_dictionary_export', '导出数据字典')
         )
 
 

--- a/sql/templates/data_dictionary.html
+++ b/sql/templates/data_dictionary.html
@@ -3,20 +3,32 @@
 {% block content %}
     <!-- 自定义操作按钮-->
     <div class="form-group ">
-        <div id="toolbar" class="form-inline">
-            <div class="form-group">
-                <select id="instance_name" class="form-control selectpicker "
-                        title="请选择实例"
-                        data-live-search="true">
-                </select>
+        <form action="/data_dictionary/export/">
+            <div id="toolbar" class="form-inline">
+                <div class="form-group">
+                    <select id="instance_name" class="form-control selectpicker "
+                            name="instance_name"
+                            title="请选择实例"
+                            data-live-search="true">
+                    </select>
+                </div>
+                <div class="form-group">
+                    <select id="db_name" class="form-control selectpicker "
+                            name="db_name"
+                            title="请选择数据库"
+                            data-live-search="true">
+                    </select>
+                </div>
+                {% if perms.sql.data_dictionary_export %}
+                    <div class="form-group">
+                        <button id="btn_export_dict" type="submit" disabled="disabled" class="btn btn-default">
+                            <span class="glyphicon glyphicon-export" aria-hidden="true"></span>
+                            导出
+                        </button>
+                    </div>
+                {% endif %}
             </div>
-            <div class="form-group">
-                <select id="db_name" class="form-control selectpicker "
-                        title="请选择数据库"
-                        data-live-search="true">
-                </select>
-            </div>
-        </div>
+        </form>
     </div>
 
     <div id="jumpbox" class="modindex-jumpbox">
@@ -191,6 +203,11 @@
                 complete: function () {
                     $('#db_name').selectpicker('render');
                     $('#db_name').selectpicker('refresh');
+                    // 管理员激活导出按钮
+                    if ("{{ request.user.is_superuser }}" === 'True') {
+                        $('#btn_export_dict').removeClass('disabled');
+                        $('#btn_export_dict').prop('disabled', false);
+                    }
                 }
             });
         });
@@ -200,6 +217,7 @@
             get_table_list()
         });
 
+        // 获取表
         function get_table_list() {
             var instance_name = $("#instance_name").val();
             var db_name = $('#db_name').val();
@@ -216,6 +234,9 @@
                     },
                     success: function (data) {
                         if (data.status === 0) {
+                            // 激活导出按钮
+                            $('#btn_export_dict').removeClass('disabled');
+                            $('#btn_export_dict').prop('disabled', false);
                             $('#jumpbox').empty();
                             $('#indexTable').empty();
                             var result = data.data;
@@ -253,6 +274,7 @@
             }
         }
 
+        // 展示表信息
         function showTableInfo(ins_name, db_name, tb_name) {
             // console.log(ins_name, db_name, tb_name);
             $.ajax({

--- a/sql/urls.py
+++ b/sql/urls.py
@@ -101,6 +101,7 @@ urlpatterns = [
     path('data_dictionary/', views.data_dictionary),
     path('data_dictionary/table_list/', data_dictionary.table_list),
     path('data_dictionary/table_info/', data_dictionary.table_info),
+    path('data_dictionary/export/', data_dictionary.export),
 
     path('param/list/', instance.param_list),
     path('param/history/', instance.param_history),

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -82,16 +82,6 @@ class TestSQLUtils(TestCase):
         sql = "select * from user.users a join logs.log b on a.id=b.id;"
         self.assertEqual(extract_tables(sql), [{'name': 'users', 'schema': 'user'}, {'name': 'log', 'schema': 'logs'}])
 
-    def test_extract_tables_by_moz(self):
-        """
-        测试表解析
-        :return:
-        """
-        sql = "select * from user.users a join logs.log b on a.id=b.id where a.id in (select id from logs.log);"
-        self.assertEqual(extract_tables(sql, _type='select'),
-                         [{'name': 'users', 'schema': 'user'}, {'name': 'log', 'schema': 'logs'},
-                          {'name': 'log', 'schema': 'logs'}])
-
     def test_generate_sql_from_sql(self):
         """
         测试从SQl文本中解析SQL

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/centos:7
 
-ENV VERSION v1.7.1
+ENV VERSION v1.7.2
 
 WORKDIR /opt/archery
 

--- a/src/init_sql/v1.7.1_v1.7.2.sql
+++ b/src/init_sql/v1.7.1_v1.7.2.sql
@@ -1,0 +1,3 @@
+-- 增加导出数据字典权限
+set @content_type_id=(select id from django_content_type where app_label='sql' and model='permission');
+INSERT IGNORE INTO auth_permission (name, content_type_id, codename) VALUES ('导出数据字典', @content_type_id, 'data_dictionary_export');


### PR DESCRIPTION
样式参考：https://github.com/shangheguang/data_dictionary

- 导出格式为html
- 增加导出权限控制
- 拥有导出权限的普通用户单次仅可以获取指定数据库的字典信息，并直接下载
- 管理员可以导出整个实例的字典信息，但是需要到下载目录获取

导出结果大致如下，暂时没有索引跳转目录：
![image](https://user-images.githubusercontent.com/8842982/68542683-3a166c00-03ea-11ea-826f-3e96b92fe9ba.png)

