### PR TITLE
优化回滚查询，支持下载回滚语句，方便回滚

### DIFF
--- a/sql/engines/inception.py
+++ b/sql/engines/inception.py
@@ -40,7 +40,9 @@ class InceptionEngine(EngineBase):
                                port=backup_port,
                                user=backup_user,
                                passwd=backup_password,
-                               charset='utf8mb4')
+                               charset='utf8mb4',
+                               autocommit=True
+                               )
 
     def execute_check(self, instance=None, db_name=None, sql=''):
         """inception check"""
@@ -231,6 +233,9 @@ class InceptionEngine(EngineBase):
             except Exception as e:
                 logger.error(f"获取回滚语句报错，异常信息{traceback.format_exc()}")
                 raise Exception(e)
+        # 关闭连接
+        if conn:
+            conn.close()
         return list_backup_sql
 
     def get_variables(self, variables=None):

--- a/sql/templates/detail.html
+++ b/sql/templates/detail.html
@@ -14,7 +14,7 @@
     <input type="hidden" id="editSqlContent" value="{{ workflow_detail.sqlworkflowcontent.sql_content }}"/>
     <hr>
     <table data-toggle="table" class="table table-striped table-hover"
-           style="table-layout:inherit;overflow:hidden;text-overflow:ellipsis;">
+           style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
         <thead>
         <tr>
             <th>
@@ -228,6 +228,13 @@
                 <input type="submit" id="btnRollback" onclick="loading(this)" class="btn btn-default"
                        value="查看回滚SQL"/>
             </form>
+            <form action="/rollback/" method="get" style="display:inline-block;">
+                {% csrf_token %}
+                <input type="hidden" name="workflow_id" value="{{ workflow_detail.id }}">
+                <input type="hidden" name="download" value="true">
+                <input type="submit" id="btnRollback" onclick="loading(this)" class="btn btn-info"
+                       value="下载回滚SQL"/>
+            </form>
         {% endif %}
     {% endif %}
     <!--重新修改按钮-->
@@ -368,7 +375,7 @@
             autoUpdateInput: false,
             opens: "left",
             drops: "down",
-            minDate:  moment().startOf('minutes'),
+            minDate: moment().startOf('minutes'),
             startDate: moment().startOf('hour'),
             endDate: moment().startOf('hour'),
             locale: {

--- a/sql/views.py
+++ b/sql/views.py
@@ -8,9 +8,10 @@ from django.conf import settings
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.models import Group
 from django.shortcuts import render, get_object_or_404
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, FileResponse
 from django.urls import reverse
 
+from archery import settings
 from common.config import SysConfig
 from sql.engines import get_engine
 from common.utils.permission import superuser_required
@@ -187,12 +188,12 @@ def detail(request, workflow_id):
 
 def rollback(request):
     """展示回滚的SQL页面"""
-    workflow_id = request.GET['workflow_id']
+    workflow_id = request.GET.get('workflow_id')
+    download = request.GET.get('download')
     if workflow_id == '' or workflow_id is None:
         context = {'errMsg': 'workflow_id参数为空.'}
         return render(request, 'error.html', context)
-    workflow_id = int(workflow_id)
-    workflow = SqlWorkflow.objects.get(id=workflow_id)
+    workflow = SqlWorkflow.objects.get(id=int(workflow_id))
 
     try:
         query_engine = get_engine(instance=workflow.instance)
@@ -201,12 +202,28 @@ def rollback(request):
         logger.error(traceback.format_exc())
         context = {'errMsg': msg}
         return render(request, 'error.html', context)
-    workflow_detail = SqlWorkflow.objects.get(id=workflow_id)
-    workflow_title = workflow_detail.workflow_name
-    rollback_workflow_name = "【回滚工单】原工单Id:%s ,%s" % (workflow_id, workflow_title)
-    context = {'list_backup_sql': list_backup_sql, 'workflow_detail': workflow_detail,
-               'rollback_workflow_name': rollback_workflow_name}
-    return render(request, 'rollback.html', context)
+
+    # 获取数据，存入目录
+    path = os.path.join(settings.BASE_DIR, 'downloads/rollback')
+    os.makedirs(path, exist_ok=True)
+    file_name = f'{path}/rollback_{workflow_id}.sql'
+    with open(file_name, 'w') as f:
+        for sql in list_backup_sql:
+            f.write(f'/*{sql[0]}*/\n{sql[1]}\n')
+
+    # 回滚语句大于4M强制转换为下载，此时前端无法自动填充
+    if os.path.getsize(file_name) > 4194304 or download:
+        response = FileResponse(open(file_name, 'rb'))
+        response['Content-Type'] = 'application/octet-stream'
+        response['Content-Disposition'] = f'attachment;filename="rollback_{workflow_id}.sql"'
+        return response
+    # 小于4M的删除文件
+    else:
+        os.remove(file_name)
+        rollback_workflow_name = f"【回滚工单】原工单Id:{workflow_id} ,{workflow.workflow_name}"
+        context = {'list_backup_sql': list_backup_sql, 'workflow_detail': workflow,
+                   'rollback_workflow_name': rollback_workflow_name}
+        return render(request, 'rollback.html', context)
 
 
 @permission_required('sql.menu_sqlanalyze', raise_exception=True)


### PR DESCRIPTION
- 设置回滚查询的连接为autocommit，可以提升效率
- 备份成功的工单详情增加下载回滚语句的入口
- 如果回滚语句大于4M，此时前端无法传递信息，强制下载文件
- 下载的文件格式如下
```
/*原始语句*/
回滚语句

/*CREATE TABLE `test002` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'id',
  `name` varchar(255) NOT NULL COMMENT '姓名',
  `createtime` datetime NOT NULL COMMENT '创建时间',
  `updatetime` datetime NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
  PRIMARY KEY (`id`)
) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '测试表'*/
DROP TABLE `archer_test`.`test002`;
```

样式截图：
![image](https://user-images.githubusercontent.com/8842982/68988883-8134af00-0879-11ea-94fb-95e41de15f8a.png)
