### PR TITLE
SQL上线工单增加需求链接，方便追溯变更需求信息 #526

### DIFF
--- a/sql/models.py
+++ b/sql/models.py
@@ -176,6 +176,7 @@ class SqlWorkflow(models.Model):
     存放各个SQL上线工单的基础内容
     """
     workflow_name = models.CharField('工单内容', max_length=50)
+    demand_url = models.CharField('需求链接', max_length=200)
     group_id = models.IntegerField('组ID')
     group_name = models.CharField('组名称', max_length=100)
     instance = models.ForeignKey(Instance, on_delete=models.CASCADE)

--- a/sql/sql_workflow.py
+++ b/sql/sql_workflow.py
@@ -134,6 +134,7 @@ def submit(request):
     """正式提交SQL, 此处生成工单"""
     sql_content = request.POST.get('sql_content').strip()
     workflow_title = request.POST.get('workflow_name')
+    demand_url = request.POST.get('demand_url')
     # 检查用户是否有权限涉及到资源组等， 比较复杂， 可以把检查权限改成一个独立的方法
     group_name = request.POST.get('group_name')
     group_id = ResourceGroup.objects.get(group_name=group_name).group_id
@@ -146,7 +147,7 @@ def submit(request):
     run_date_end = request.POST.get('run_date_end')
 
     # 服务器端参数验证
-    if None in [sql_content, db_name, instance_name, db_name, is_backup]:
+    if None in [sql_content, db_name, instance_name, db_name, is_backup, demand_url]:
         context = {'errMsg': '页面提交参数可能为空'}
         return render(request, 'error.html', context)
 
@@ -185,6 +186,7 @@ def submit(request):
             # 存进数据库里
             sql_workflow = SqlWorkflow.objects.create(
                 workflow_name=workflow_title,
+                demand_url=demand_url,
                 group_id=group_id,
                 group_name=group_name,
                 engineer=request.user.username,

--- a/sql/templates/detail.html
+++ b/sql/templates/detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h4 style="display: inline;"><span>{{ workflow_detail.workflow_name }}</span></h4>
+    <h4 style="display: inline;"><a target="_blank" href="{{ workflow_detail.demand_url }}">{{ workflow_detail.workflow_name }}</a></h4>
     &nbsp;&nbsp;&nbsp;
     <!--只允许发起人提交其他实例-->
     {% if user.username == workflow_detail.engineer %}
@@ -399,6 +399,7 @@
     <!--按钮控制 -->
     <script>
         var editWorkflowNname = "{{ workflow_detail.workflow_name }}";
+        var editDemandUrl = "{{ workflow_detail.demand_url }}";
         var editSqlContent = $("#editSqlContent").val();
         var editGroup = "{{ workflow_detail.group_name }}";
         var editClustername = "{{ workflow_detail.instance.instance_name }}";
@@ -407,6 +408,7 @@
 
         $("#btnEditSql").click(function () {
             sessionStorage.setItem('editWorkflowNname', editWorkflowNname);
+            sessionStorage.setItem('editDemandUrl', editDemandUrl);
             sessionStorage.setItem('editSqlContent', editSqlContent);
             sessionStorage.setItem('editGroup', editGroup);
             sessionStorage.setItem('editClustername', editClustername);
@@ -416,6 +418,7 @@
         $("#btnViewSql").click(function () {
             sessionStorage.removeItem('editWorkflowDetailId');
             sessionStorage.setItem('editWorkflowNname', editWorkflowNname);
+            sessionStorage.setItem('editDemandUrl', editDemandUrl);
             sessionStorage.setItem('editSqlContent', editSqlContent);
             sessionStorage.setItem('editGroup', editGroup);
             sessionStorage.setItem('editClustername', editClustername);
@@ -424,6 +427,7 @@
         });
         $("#btnSubmitOtherCluster").click(function () {
             sessionStorage.setItem('editWorkflowNname', editWorkflowNname);
+            sessionStorage.setItem('editDemandUrl', editDemandUrl);
             sessionStorage.setItem('editSqlContent', editSqlContent);
             sessionStorage.setItem('editGroup', editGroup);
             sessionStorage.setItem('editIsbackup', editIsbackup);

--- a/sql/templates/sqlsubmit.html
+++ b/sql/templates/sqlsubmit.html
@@ -32,6 +32,11 @@
                                        required>
                             </div>
                             <div class="form-group">
+                                <input id="demand_url" type="text" autocomplete="off" name="demand_url" class="form-control"
+                                       data-name="需求链接" data-placeholder="请提供需求链接，记录工单需求信息！"
+                                       placeholder="请输入需求链接" required>
+                            </div>
+                            <div class="form-group">
                                 <select id="group_name" name="group_name"
                                         class="selectpicker show-tick form-control bs-select-hidden"
                                         data-name="组" data-placeholder="请选择组！"
@@ -656,12 +661,15 @@
             var pathname = window.location.pathname;
             if (pathname == "/editsql/") {
                 $("#workflow_name").val(sessionStorage.getItem('editWorkflowNname'));
+                $("#demand_url").val(sessionStorage.getItem('editDemandUrl'));
                 $("#group_name").val(sessionStorage.getItem('editGroup'));
+                $("#demand_url").val(sessionStorage.getItem('editDemandUrl'));
                 editor.setValue(sessionStorage.getItem('editSqlContent'));
                 editor.clearSelection();
                 $("#is_backup").val(sessionStorage.getItem('editIsbackup'));
             } else if (pathname === "/submitotherinstance/") {
                 $("#workflow_name").val(sessionStorage.getItem('editWorkflowNname'));
+                $("#demand_url").val(sessionStorage.getItem('editDemandUrl'));
                 $("#group_name").val(sessionStorage.getItem('editGroup'));
                 editor.setValue(sessionStorage.getItem('editSqlContent'));
                 editor.clearSelection();

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -1034,6 +1034,7 @@ class TestWorkflowView(TestCase):
                 "group_name": self.resource_group1.group_name,
                 "instance_name": self.master1.instance_name,
                 "db_name": "archery",
+                "demand_url": 'test_url',
                 "run_date_start": "",
                 "run_date_end": "",
                 "workflow_auditors": "11"}
@@ -1061,6 +1062,7 @@ class TestWorkflowView(TestCase):
                 "group_name": self.resource_group1.group_name,
                 "instance_name": self.master1.instance_name,
                 "db_name": "archery",
+                "demand_url": 'test_url',
                 "run_date_start": "",
                 "run_date_end": "",
                 "workflow_auditors": "11"}
@@ -1271,6 +1273,7 @@ class TestWorkflowView(TestCase):
             'group_name': self.resource_group1.group_name,
             'group_id': self.resource_group1.group_id,
             'instance_name': self.master1.instance_name,
+            "demand_url": 'test_url',
             'db_name': 'some_db',
             'is_backup': True,
             'notify_users': ''
@@ -1305,6 +1308,7 @@ class TestWorkflowView(TestCase):
             'group_id': self.resource_group1.group_id,
             'instance_name': self.master1.instance_name,
             'db_name': 'some_db',
+            "demand_url": 'test_url',
             'is_backup': False,
             'notify_users': ''
         }

--- a/src/init_sql/v1.7.2_v1.7.3.sql
+++ b/src/init_sql/v1.7.2_v1.7.3.sql
@@ -1,2 +1,5 @@
 -- 修改工具插件的菜单code
 UPDATE auth_permission SET codename='menu_tools' WHERE codename='menu_menu_tools';
+
+-- SQL上线工单增加需求链接
+ALTER TABLE sql_workflow ADD demand_url varchar(500) NOT NULL DEFAULT '' COMMENT '需求链接';


### PR DESCRIPTION
相关issue：#526 

- 提交工单页面增加需求链接输入框，输入框为必填，确实没有需求信息亦可填写"无"或者其他信息
- 在工单详情点击工单名称会跳转到需求链接页面