### PR TITLE
解决部分页面SQL内容未转义，导致展示异常的问题

### DIFF
--- a/sql/templates/detail.html
+++ b/sql/templates/detail.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h4 style="display: inline;"><a target="_blank" href="{{ workflow_detail.demand_url }}">{{ workflow_detail.workflow_name }}</a></h4>
+    <h4 style="display: inline;"><a target="_blank"
+                                    href="{{ workflow_detail.demand_url }}">{{ workflow_detail.workflow_name }}</a></h4>
     &nbsp;&nbsp;&nbsp;
     <!--只允许发起人提交其他实例-->
     {% if user.username == workflow_detail.engineer %}
@@ -125,6 +126,10 @@
     <div id="tab-content" class="tab-content">
         <!-- 工单详情-->
         <div id="detail" role="tabpanel" class="tab-pane fade in active table-responsive">
+            <!-- 自定义操作按钮-->
+            <div id="detail-toolbar" class="btn-group right">
+                <button id="expandAllRows" class="btn btn-default navbar-btn" type="button">展开全部</button>
+            </div>
             <table id="tb-detail" data-toggle="table" class="table table-condensed"
                    style="table-layout:inherit;word-break:break-word;overflow:hidden;text-overflow:ellipsis;"></table>
             <!--最后操作信息-->
@@ -352,6 +357,8 @@
     <script src="{% static 'datetimepicker/js/bootstrap-datetimepicker.js' %}"></script>
     <script src="{% static 'datetimepicker/js/bootstrap-datetimepicker.zh-CN.js' %}"></script>
     <script src="{% static 'daterangepicker/js/daterangepicker.js' %}"></script>
+    <script src="{% static 'bootstrap-table/js/bootstrap-table-export.min.js' %}"></script>
+    <script src="{% static 'bootstrap-table/js/tableExport.min.js' %}"></script>
     <!--初始化时间控件 -->
     <script>
         var date = new Date();
@@ -398,6 +405,20 @@
 
     <!--按钮控制 -->
     <script>
+        // 表格展开折叠全部行
+        $("#expandAllRows").click(function () {
+            $(this).trigger("blur");
+            if ($(this).text() === '展开全部') {
+                $('#tb-detail').bootstrapTable('hideColumn', 'sql');
+                $('#tb-detail').bootstrapTable('expandAllRows');
+                $(this).text('折叠全部')
+            } else if ($(this).text() === '折叠全部') {
+                $('#tb-detail').bootstrapTable('showColumn', 'sql');
+                $('#tb-detail').bootstrapTable('collapseAllRows');
+                $(this).text('展开全部')
+            }
+        });
+
         var editWorkflowNname = "{{ workflow_detail.workflow_name }}";
         var editDemandUrl = "{{ workflow_detail.demand_url }}";
         var editSqlContent = $("#editSqlContent").val();
@@ -512,7 +533,10 @@
         //获取工单详情
         function get_detail() {
             $('#tb-detail').bootstrapTable('destroy').bootstrapTable({
-                escape: false,
+                escape: true,
+                method: 'get',
+                contentType: "application/x-www-form-urlencoded",
+                url: "/sqlworkflow/detail_content/",
                 striped: true,                      //是否显示行间隔色
                 cache: true,                       //是否使用缓存，默认为true，所以一般情况下需要设置一下这个属性（*）
                 pagination: true,                   //是否显示分页（*）
@@ -524,11 +548,18 @@
                 search: true,                       //是否显示表格搜索
                 strictSearch: false,                //是否全匹配搜索
                 showColumns: true,                  //是否显示所有的列（选择显示的列）
-                showRefresh: false,                  //是否显示刷新按钮
+                showRefresh: true,                  //是否显示刷新按钮
                 minimumCountColumns: 1,             //最少允许的列数
                 clickToSelect: false,                //是否启用点击选中行
                 uniqueId: "id",                     //每一行的唯一标识，一般为主键列
                 showToggle: false,                   //是否显示详细视图和列表视图的切换按钮
+                toolbar: "#detail-toolbar",         //指明自定义的toolbar
+                showExport: true,
+                exportDataType: "all",
+                exportOptions: {
+                    ignoreColumn: [0],  //忽略第一列
+                    fileName: 'detail_content'  //文件名称设置
+                },
                 cardView: false,                    //是否显示详细视图
                 detailView: true,                  //是否显示父子表
                 //格式化详情
@@ -536,7 +567,13 @@
                     var html = [];
                     $.each(row, function (key, value) {
                         if (key === 'sql') {
-                            var sql = value;
+                            //let sql = window.sqlFormatter.format(value);
+                            let sql = value;
+                            //替换标签
+                            sql = sql.replace(/&/g, "&amp;");
+                            sql = sql.replace(/</g, "&lt;");
+                            sql = sql.replace(/>/g, "&gt;");
+                            sql = sql.replace(/"/g, "&quot;");
                             //替换所有的换行符
                             sql = sql.replace(/\r\n/g, "<br>");
                             sql = sql.replace(/\n/g, "<br>");
@@ -547,12 +584,23 @@
                     });
                     return html.join('');
                 },
+                queryParamsType: 'limit',
+                //请求服务数据时所传参数
+                queryParams:
+                    function (params) {
+                        return {
+                            workflow_id: "{{ workflow_detail.id }}",
+                        }
+                    },
                 locale: 'zh-CN',                    //本地化
-                data:{{ rows|safe }},
                 columns: [{
                     title: 'ID',
                     field: 'id',
                     sortable: true
+                }, {
+                    title: '完整SQL内容',
+                    field: 'sql',
+                    visible: false // 默认不显示
                 }, {
                     title: 'SQL内容',
                     field: 'sql',

--- a/sql/templates/rollback.html
+++ b/sql/templates/rollback.html
@@ -1,13 +1,6 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <div>
-        <div style="width: 80%; float: left">
-            {% csrf_token %}
-            <input type="hidden" id="editSqlContent" value="{% for sql in list_backup_sql %}{{ sql.1 }}
-{% endfor %}">
-        </div>
-    </div>
     <!-- 自定义操作按钮-->
     <div id="toolbar" class="btn-group right">
         <a type='button' id="btnSubmitRollback" class="btn btn-warning" href="/editsql/">提交回滚请求</a>
@@ -23,9 +16,12 @@
     <script>
         $('#tb-rollback').bootstrapTable('destroy').bootstrapTable({
             escape: true,
+            method: 'get',
+            contentType: "application/x-www-form-urlencoded",
+            url: "/sqlworkflow/backup_sql/",
             striped: true,                      //是否显示行间隔色
             cache: false,                       //是否使用缓存，默认为true，所以一般情况下需要设置一下这个属性（*）
-            pagination: false,                   //是否显示分页（*）
+            pagination: true,                   //是否显示分页（*）
             sortable: true,                     //是否启用排序
             sidePagination: "client",           //分页方式：client客户端分页，server服务端分页（*）
             pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
@@ -35,11 +31,11 @@
             exportOptions: {
                 ignoreColumn: [0],  //忽略某些列的索引数组
             },
-            search: false,                       //是否显示表格搜索
+            search: true,                       //是否显示表格搜索
             strictSearch: false,                //是否全匹配搜索
             showColumns: true,                  //是否显示所有的列（选择显示的列）
-            showRefresh: false,                  //是否显示刷新按钮
-            minimumCountColumns: 2,             //最少允许的列数
+            showRefresh: true,                  //是否显示刷新按钮
+            minimumCountColumns: 1,             //最少允许的列数
             clickToSelect: false,                //是否启用点击选中行
             uniqueId: "id",                     //每一行的唯一标识，一般为主键列
             showToggle: false,                   //是否显示详细视图和列表视图的切换按钮
@@ -51,7 +47,13 @@
                 var html = [];
                 $.each(row, function (index, key) {
                         if (index === 1) {
-                            var sql = key;
+                            //let sql = window.sqlFormatter.format(key);
+                            let sql = key;
+                            //替换标签
+                            sql = sql.replace(/&/g, "&amp;");
+                            sql = sql.replace(/</g, "&lt;");
+                            sql = sql.replace(/>/g, "&gt;");
+                            sql = sql.replace(/"/g, "&quot;");
                             //替换所有的换行符
                             sql = sql.replace(/\r\n/g, "<br>");
                             sql = sql.replace(/\n/g, "<br>");
@@ -63,8 +65,15 @@
                 );
                 return html.join('');
             },
+            queryParamsType: 'limit',
+            //请求服务数据时所传参数
+            queryParams:
+                function (params) {
+                    return {
+                        workflow_id: "{{ workflow_detail.id }}",
+                    }
+                },
             locale: 'zh-CN',                    //本地化
-            data:{{ list_backup_sql|safe }},
             columns: [{
                 title: '执行语句',
                 field: 0,
@@ -94,7 +103,17 @@
                 field: 1,
                 visible: false // 默认不显示
             }],
-            onLoadSuccess: function () {
+            onLoadSuccess: function (data) {
+                // 设置回滚语句，供快速提交
+                if (data.status !== 0) {
+                    alert("数据加载失败！" + data.msg);
+                } else {
+                    let backup_sql = '';
+                    for (let sql of data.rows) {
+                        backup_sql += sql[1] + '\n'
+                    }
+                    sessionStorage.setItem('editSqlContent', backup_sql);
+                }
             },
             onLoadError: function () {
                 alert("数据加载失败！请检查接口返回信息和错误日志！");
@@ -109,14 +128,12 @@
                         $(this).dequeue();
                     });
                     var editWorkflowNname = "{{ rollback_workflow_name }}";
-                    var editSqlContent = $("#editSqlContent").val();
                     var editGroup = "{{ workflow_detail.group_name }}";
                     var editClustername = "{{ workflow_detail.instance.instance_name }}";
                     var editDbname = "{{ workflow_detail.db_name }}";
                     var editIsbackup = "{{ workflow_detail.is_backup }}";
                     sessionStorage.removeItem('editWorkflowDetailId');
                     sessionStorage.setItem('editWorkflowNname', editWorkflowNname);
-                    sessionStorage.setItem('editSqlContent', editSqlContent);
                     sessionStorage.setItem('editGroup', editGroup);
                     sessionStorage.setItem('editClustername', editClustername);
                     sessionStorage.setItem('editDbname', editDbname);

--- a/sql/templates/sqladvisor.html
+++ b/sql/templates/sqladvisor.html
@@ -440,7 +440,7 @@
                         if (result['Error']) {
                             alertStyle = "alert-danger";
                             $('#tb_explain').bootstrapTable('destroy').bootstrapTable({
-                                escape: false,
+                                escape: true,
                                 columns: [{
                                     field: 'error',
                                     title: 'Error'
@@ -464,7 +464,7 @@
                             });
                             //初始化查询结果
                             $('#tb_explain').bootstrapTable('destroy').bootstrapTable({
-                                escape: false,
+                                escape: true,
                                 data: result['rows'],
                                 columns: columns,
                                 showColumns: true,
@@ -578,7 +578,7 @@
                         if (result['Error']) {
                             alertStyle = "alert-danger";
                             $('#tb_explain').bootstrapTable('destroy').bootstrapTable({
-                                escape: false,
+                                escape: true,
                                 columns: [{
                                     field: 'error',
                                     title: 'Error'
@@ -606,7 +606,7 @@
                                 });
                                 //初始化查询结果
                                 $('#tb_sys_parameter').bootstrapTable('destroy').bootstrapTable({
-                                    escape: false,
+                                    escape: true,
                                     data: result['sys_parameter']['rows'],
                                     columns: columns
                                 });
@@ -625,7 +625,7 @@
                                 });
                                 //初始化查询结果
                                 $('#tb_optimizer_switch').bootstrapTable('destroy').bootstrapTable({
-                                    escape: false,
+                                    escape: true,
                                     data: result['optimizer_switch']['rows'],
                                     columns: columns,
                                 });
@@ -647,7 +647,7 @@
                                 });
                                 //初始化查询结果
                                 $('#tb_plan').bootstrapTable('destroy').bootstrapTable({
-                                    escape: false,
+                                    escape: true,
                                     data: result['plan']['rows'],
                                     columns: columns
                                 });
@@ -673,7 +673,7 @@
                                 });
                                 //初始化查询结果
                                 $('#tb_optimizer_rewrite_sql').bootstrapTable('destroy').bootstrapTable({
-                                    escape: false,
+                                    escape: true,
                                     data: result['optimizer_rewrite_sql']['rows'],
                                     columns: columns,
                                     detailView: true,   //是否显示父子表
@@ -732,7 +732,7 @@
                                         });
                                         //初始化查询结果
                                         $("#" + tb_table_structure_id).bootstrapTable('destroy').bootstrapTable({
-                                            escape: false,
+                                            escape: true,
                                             data: result['structure']['rows'],
                                             columns: columns,
                                             detailView: true,   //是否显示父子表
@@ -764,7 +764,7 @@
                                         });
                                         //初始化查询结果
                                         $("#" + tb_table_info_id).bootstrapTable('destroy').bootstrapTable({
-                                            escape: false,
+                                            escape: true,
                                             data: result['table_info']['rows'],
                                             columns: columns
                                         });
@@ -779,7 +779,7 @@
                                         });
                                         //初始化查询结果
                                         $("#" + tb_index_info_id).bootstrapTable('destroy').bootstrapTable({
-                                            escape: false,
+                                            escape: true,
                                             data: result['index_info']['rows'],
                                             columns: columns
                                         });
@@ -805,7 +805,7 @@
                                 });
                                 //初始化查询结果
                                 $('#tb_session_status').bootstrapTable('destroy').bootstrapTable({
-                                    escape: false,
+                                    escape: true,
                                     data: result['session_status']['SESSION_STATUS(DIFFERENT)']['rows'],
                                     columns: columns
                                 });
@@ -836,7 +836,7 @@
                                 });
                                 //初始化查询结果
                                 $('#tb_sql_profiling_summary').bootstrapTable('destroy').bootstrapTable({
-                                    escape: false,
+                                    escape: true,
                                     data: result['session_status']['PROFILING_SUMMARY']['rows'],
                                     columns: columns
                                 });

--- a/sql/templates/sqlanalyze.html
+++ b/sql/templates/sqlanalyze.html
@@ -149,6 +149,11 @@
                     $.each(row, function (key, value) {
                         if (key === 'sql') {
                             var sql = window.sqlFormatter.format(value);
+                            //替换标签
+                            sql = sql.replace(/&/g, "&amp;");
+                            sql = sql.replace(/</g, "&lt;");
+                            sql = sql.replace(/>/g, "&gt;");
+                            sql = sql.replace(/"/g, "&quot;");
                             //替换所有的换行符
                             sql = sql.replace(/\r\n/g, "<br>");
                             sql = sql.replace(/\n/g, "<br>");

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -317,12 +317,17 @@
                     var html = [];
                     $.each(row, function (key, value) {
                         if (key === 'sqllog') {
-                            var sql = value;
+                            let sql = value;
+                            //替换标签
+                            sql = sql.replace(/&/g, "&amp;");
+                            sql = sql.replace(/</g, "&lt;");
+                            sql = sql.replace(/>/g, "&gt;");
+                            sql = sql.replace(/"/g, "&quot;");
                             //替换所有的换行符
                             sql = sql.replace(/\r\n/g, "<br>");
                             sql = sql.replace(/\n/g, "<br>");
                             //替换所有的空格
-                            sql = sql.replace(/\s/g, " ");
+                            sql = sql.replace(/\s/g, "&nbsp;");
                             html.push('<span>' + sql + '</span>');
                         }
                     });
@@ -702,17 +707,22 @@
                     if (result['full_sql'].match(/^show\s+create\s+table/)) {
                         //初始化表结构显示
                         $("#" + ("query_result" + n)).bootstrapTable('destroy').bootstrapTable({
+                                escape: true,
                                 data: result['rows'],
                                 columns: [{
                                     title: 'Create Table',
                                     field: 1,
                                     formatter: function (value, row, index) {
-                                        var sql = window.sqlFormatter.format(value);
+                                        let sql = window.sqlFormatter.format(value);
+                                        //替换标签
+                                        sql = sql.replace(/&/g, "&amp;");
+                                        sql = sql.replace(/</g, "&lt;");
+                                        sql = sql.replace(/>/g, "&gt;");
+                                        sql = sql.replace(/"/g, "&quot;");
                                         //替换所有的换行符
                                         sql = sql.replace(/\r\n/g, "<br>");
                                         sql = sql.replace(/\n/g, "<br>");
                                         //替换所有的空格
-                                        sql = sql.replace(/\s/g, " ");
                                         return sql;
                                     },
                                 }
@@ -764,7 +774,7 @@
                     n = sessionStorage.getItem('tab_num');
                 }
                 $("#" + ('query_result' + n)).bootstrapTable('destroy').bootstrapTable({
-                    escape: false,
+                    escape: true,
                     columns: [{
                         field: 'error',
                         title: 'Error'

--- a/sql/templates/sqlsubmit.html
+++ b/sql/templates/sqlsubmit.html
@@ -88,10 +88,14 @@
                             <div class='form-group'>
                                 <input type="hidden" id="run_date_start" name="run_date_start">
                                 <input type="hidden" id="run_date_end" name="run_date_end">
-                                <input type="text" id="run_date_range" readonly
-                                       value="请选择可执行时间范围"
-                                       style="background-color: #fff;color: #999 "
-                                       class="form-control "/>
+                                <div class='input-group date'>
+                                    <input type="text" id="run_date_range" readonly
+                                           value="请选择可执行时间范围"
+                                           style="background-color: #fff;color: #999 "
+                                           class="form-control "/>
+                                    <span class="input-group-addon"><span
+                                            class="glyphicon glyphicon-time"></span></span>
+                                </div>
                             </div>
                             <!--增加通知人-->
                             <!--TODO 通知人落库，允许查看工单详细-->
@@ -273,10 +277,10 @@
                     var pathname = window.location.pathname;
                     if (pathname === "/editsql/") {
                         //填充库名
-                         $("#db_name").selectpicker('val', sessionStorage.getItem('editDbname'));
-                         if ($("#db_name").val()){
-                             $("#db_name").selectpicker().trigger("change");
-                         }
+                        $("#db_name").selectpicker('val', sessionStorage.getItem('editDbname'));
+                        if ($("#db_name").val()) {
+                            $("#db_name").selectpicker().trigger("change");
+                        }
                     }
                 },
                 success: function (data) {
@@ -528,13 +532,20 @@
                                     var html = [];
                                     $.each(row, function (key, value) {
                                         if (key === 'sql') {
-                                            var sql = value;
+                                            //let sql = window.sqlFormatter.format(key);
+                                            let sql = value;
+                                            //替换标签
+                                            sql = sql.replace(/&/g, "&amp;");
+                                            sql = sql.replace(/</g, "&lt;");
+                                            sql = sql.replace(/>/g, "&gt;");
+                                            sql = sql.replace(/"/g, "&quot;");
                                             //替换所有的换行符
                                             sql = sql.replace(/\r\n/g, "<br>");
                                             sql = sql.replace(/\n/g, "<br>");
                                             //替换所有的空格
                                             sql = sql.replace(/\s/g, "&nbsp;");
                                             html.push('<span>' + sql + '</span>');
+
                                         }
                                     });
                                     return html.join('');
@@ -603,7 +614,7 @@
                                 $("#optgroup-oracle").append(instance);
                             } else if (result[i]['db_type'] === 'mongo') {
                                 $("#optgroup-mongo").append(instance);
-                            }  else if (result[i]['db_type'] === 'phoenix') {
+                            } else if (result[i]['db_type'] === 'phoenix') {
                                 $("#optgroup-phoenix").append(instance);
                             }
                         }

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -1071,7 +1071,6 @@ class TestWorkflowView(TransactionTestCase):
         r = c.get('/detail/{}/'.format(self.wf1.id))
         self.assertContains(r, expected_status_display)
         self.assertContains(r, exepcted_status)
-        self.assertContains(r, 'Json decode failed.')
 
         # 执行详情为空
         self.wfc1.review_content = [
@@ -1081,7 +1080,6 @@ class TestWorkflowView(TransactionTestCase):
         self.wfc1.execute_result = ''
         self.wfc1.save()
         r = c.get('/detail/{}/'.format(self.wf1.id))
-        self.assertContains(r, 'use archery')
 
     def testWorkflowListView(self):
         """测试工单列表"""

--- a/sql/urls.py
+++ b/sql/urls.py
@@ -57,6 +57,8 @@ urlpatterns = [
 
     path('authenticate/', auth.authenticate_entry),
     path('sqlworkflow_list/', sql_workflow.sql_workflow_list),
+    path('sqlworkflow/detail_content/', sql_workflow.detail_content),
+    path('sqlworkflow/backup_sql/', sql_workflow.backup_sql),
     path('simplecheck/', sql_workflow.check),
     path('getWorkflowStatus/', sql_workflow.get_workflow_status),
     path('del_sqlcronjob/', tasks.del_schedule),

--- a/sql/views.py
+++ b/sql/views.py
@@ -103,10 +103,6 @@ def detail(request, workflow_id):
     workflow_detail = get_object_or_404(SqlWorkflow, pk=workflow_id)
     if not can_view(request.user, workflow_id):
         raise PermissionDenied
-    if workflow_detail.status in ['workflow_finish', 'workflow_exception']:
-        rows = workflow_detail.sqlworkflowcontent.execute_result
-    else:
-        rows = workflow_detail.sqlworkflowcontent.review_content
     # 自动审批不通过的不需要获取下列信息
     if workflow_detail.status != 'workflow_autoreviewwrong':
         # 获取当前审批和审批流程
@@ -155,37 +151,7 @@ def detail(request, workflow_id):
     # 获取是否开启手工执行确认
     manual = SysConfig().get('manual')
 
-    review_result = ReviewSet()
-    if rows:
-        try:
-            # 检验rows能不能正常解析
-            loaded_rows = json.loads(rows)
-            #  兼容旧数据'[[]]'格式，转换为新格式[{}]
-            if isinstance(loaded_rows[-1], list):
-                for r in loaded_rows:
-                    review_result.rows += [ReviewResult(inception_result=r)]
-                rows = review_result.json()
-        except IndexError:
-            review_result.rows += [ReviewResult(
-                id=1,
-                sql=workflow_detail.sqlworkflowcontent.sql_content,
-                errormessage="Json decode failed."
-                             "执行结果Json解析失败, 请联系管理员"
-            )]
-            rows = review_result.json()
-        except json.decoder.JSONDecodeError:
-            review_result.rows += [ReviewResult(
-                id=1,
-                sql=workflow_detail.sqlworkflowcontent.sql_content,
-                # 迫于无法单元测试这里加上英文报错信息
-                errormessage="Json decode failed."
-                             "执行结果Json解析失败, 请联系管理员"
-            )]
-            rows = review_result.json()
-    else:
-        rows = workflow_detail.sqlworkflowcontent.review_content
-
-    context = {'workflow_detail': workflow_detail, 'rows': rows, 'last_operation_info': last_operation_info,
+    context = {'workflow_detail': workflow_detail, 'last_operation_info': last_operation_info,
                'is_can_review': is_can_review, 'is_can_execute': is_can_execute, 'is_can_timingtask': is_can_timingtask,
                'is_can_cancel': is_can_cancel, 'is_can_rollback': is_can_rollback, 'audit_auth_group': audit_auth_group,
                'manual': manual, 'current_audit_auth_group': current_audit_auth_group, 'run_date': run_date}
@@ -203,34 +169,32 @@ def rollback(request):
         return render(request, 'error.html', context)
     workflow = SqlWorkflow.objects.get(id=int(workflow_id))
 
-    try:
-        query_engine = get_engine(instance=workflow.instance)
-        list_backup_sql = query_engine.get_rollback(workflow=workflow)
-    except Exception as msg:
-        logger.error(traceback.format_exc())
-        context = {'errMsg': msg}
-        return render(request, 'error.html', context)
+    # 直接下载回滚语句
+    if download:
+        try:
+            query_engine = get_engine(instance=workflow.instance)
+            list_backup_sql = query_engine.get_rollback(workflow=workflow)
+        except Exception as msg:
+            logger.error(traceback.format_exc())
+            context = {'errMsg': msg}
+            return render(request, 'error.html', context)
 
-    # 获取数据，存入目录
-    path = os.path.join(settings.BASE_DIR, 'downloads/rollback')
-    os.makedirs(path, exist_ok=True)
-    file_name = f'{path}/rollback_{workflow_id}.sql'
-    with open(file_name, 'w') as f:
-        for sql in list_backup_sql:
-            f.write(f'/*{sql[0]}*/\n{sql[1]}\n')
-
-    # 回滚语句大于4M强制转换为下载，此时前端无法自动填充
-    if os.path.getsize(file_name) > 4194304 or download:
+        # 获取数据，存入目录
+        path = os.path.join(settings.BASE_DIR, 'downloads/rollback')
+        os.makedirs(path, exist_ok=True)
+        file_name = f'{path}/rollback_{workflow_id}.sql'
+        with open(file_name, 'w') as f:
+            for sql in list_backup_sql:
+                f.write(f'/*{sql[0]}*/\n{sql[1]}\n')
+        # 返回
         response = FileResponse(open(file_name, 'rb'))
         response['Content-Type'] = 'application/octet-stream'
         response['Content-Disposition'] = f'attachment;filename="rollback_{workflow_id}.sql"'
         return response
-    # 小于4M的删除文件
+    # 异步获取，并在页面展示，如果数据量大加载会缓慢
     else:
-        os.remove(file_name)
         rollback_workflow_name = f"【回滚工单】原工单Id:{workflow_id} ,{workflow.workflow_name}"
-        context = {'list_backup_sql': list_backup_sql, 'workflow_detail': workflow,
-                   'rollback_workflow_name': rollback_workflow_name}
+        context = {'workflow_detail': workflow, 'rollback_workflow_name': rollback_workflow_name}
         return render(request, 'rollback.html', context)
 
 


### PR DESCRIPTION
主要是为了解决转义的问题，SQL内容如果出现html标签或者其他信息会导致页面展示异常，同时存在安全风险

- SQL上线工单和回滚的表格内容采取异步获取，不采取异步方式暂未找到比较好的转义办法
- SQL上线工单详情增加导出以及快速展开、折叠内容按钮，同时增加隐藏的完整SQL列
- 查看回滚语句不再限制4M以上的强制下载，否则按照现在异步获取的逻辑，4M以下的回滚信息会查询两次
- SQL内容详情展示时，不再自动格式化(性能比较差)，以用户提交的为准