### PR TITLE
增加MySQL数据归档模块，使用pt-archiver归档数据

### DIFF
--- a/archery/__init__.py
+++ b/archery/__init__.py
@@ -1,2 +1,2 @@
-version = (1, 7, 4)
+version = (1, 7, 5)
 display_version = '.'.join(str(i) for i in version)

--- a/common/templates/base.html
+++ b/common/templates/base.html
@@ -188,6 +188,11 @@
                         <li>
                             <a href="#"><i class="fa fa-plug fa-fw"></i> 工具插件<span class="fa arrow"></span></a>
                             <ul class="nav nav-second-level">
+                                {% if perms.sql.menu_archive %}
+                                    <li>
+                                        <a href="/archive/">PTArchiver</a>
+                                    </li>
+                                {% endif %}
                                 {% if perms.sql.menu_binlog2sql %}
                                     <li>
                                         <a href="/binlog2sql/">Binlog2SQL</a>

--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -30,6 +30,8 @@
                                     {{ WorkflowDict.workflow_type.sqlreview_display }}</option>
                                 <option value="{{ WorkflowDict.workflow_type.query }}">
                                     {{ WorkflowDict.workflow_type.query_display }}</option>
+                                <option value="{{ WorkflowDict.workflow_type.archive }}">
+                                    {{ WorkflowDict.workflow_type.archive_display }}</option>
                             </select>
                         </div>
                         <h5 class="control-label text-bold">组：</h5>

--- a/common/utils/const.py
+++ b/common/utils/const.py
@@ -5,6 +5,7 @@ class Const(object):
     workflowJobprefix = {
         'query': 'query',
         'sqlreview': 'sqlreview',
+        'archive': 'archive'
     }
 
 
@@ -15,6 +16,8 @@ class WorkflowDict:
         'query_display': '查询权限申请',
         'sqlreview': 2,
         'sqlreview_display': 'SQL上线申请',
+        'archive': 3,
+        'archive_display': '数据归档申请',
     }
 
     # 工作流状态，0.待审核 1.审核通过 2.审核不通过 3.审核取消

--- a/sql/admin.py
+++ b/sql/admin.py
@@ -5,7 +5,7 @@ from django.contrib.auth.admin import UserAdmin
 # Register your models here.
 from .models import Users, Instance, SqlWorkflow, SqlWorkflowContent, QueryLog, DataMaskingColumns, DataMaskingRules, \
     AliyunRdsConfig, ResourceGroup, ResourceGroup2User, ResourceGroup2Instance, QueryPrivilegesApply, \
-    QueryPrivileges, InstanceAccount, InstanceDatabase, \
+    QueryPrivileges, InstanceAccount, InstanceDatabase, ArchiveConfig, \
     WorkflowAudit, WorkflowLog, ParamTemplate, ParamHistory, InstanceTag, InstanceTagRelations
 
 
@@ -214,6 +214,18 @@ class ParamHistoryAdmin(admin.ModelAdmin):
     list_display = ('variable_name', 'instance', 'old_var', 'new_var', 'user_display', 'create_time')
     search_fields = ('variable_name',)
     list_filter = ('instance', 'user_display')
+
+
+# 归档配置
+@admin.register(ArchiveConfig)
+class ArchiveConfigAdmin(admin.ModelAdmin):
+    list_display = (
+        'id', 'title', 'src_instance', 'src_db_name', 'src_table_name',
+        'dest_instance', 'dest_db_name', 'dest_table_name',
+        'mode', 'no_delete', 'status', 'state', 'user_display', 'create_time', 'resource_group')
+    search_fields = ('title', 'src_table_name')
+    list_display_links = ('id', 'title')
+    list_filter = ('src_instance', 'src_db_name', 'mode', 'no_delete', 'state')
 
 
 # 阿里云实例配置信息

--- a/sql/archiver.py
+++ b/sql/archiver.py
@@ -1,0 +1,390 @@
+# -*- coding: UTF-8 -*-
+""" 
+@author: hhyo
+@license: Apache Licence
+@file: archive.py
+@time: 2020/01/10
+"""
+import logging
+import os
+import re
+import traceback
+import time
+
+import simplejson as json
+from django.conf import settings
+from django.contrib.auth.decorators import permission_required
+from django.db import transaction, connection, close_old_connections
+from django.db.models import Q, Value as V, TextField
+from django.db.models.functions import Concat
+from django.http import HttpResponse, JsonResponse, HttpResponseRedirect
+from django.shortcuts import render
+from django.urls import reverse
+from django_q.tasks import async_task
+
+from common.utils.const import WorkflowDict
+from common.utils.extend_json_encoder import ExtendJSONEncoder
+from common.utils.timer import FuncTimer
+from sql.notify import notify_for_audit
+from sql.plugins.pt_archiver import PtArchiver
+from sql.utils.resource_group import user_instances, user_groups
+from sql.models import ArchiveConfig, ArchiveLog, Instance, ResourceGroup
+from sql.utils.workflow_audit import Audit
+
+logger = logging.getLogger('default')
+__author__ = 'hhyo'
+
+
+@permission_required('sql.menu_archive', raise_exception=True)
+def archive_list(request):
+    """
+    获取归档申请列表
+    :param request:
+    :return:
+    """
+    user = request.user
+    filter_instance_id = request.GET.get('filter_instance_id')
+    state = request.GET.get('state')
+    limit = int(request.GET.get('limit', 0))
+    offset = int(request.GET.get('offset', 0))
+    limit = offset + limit
+    search = request.GET.get('search', '')
+
+    # 组合筛选项
+    filter_dict = dict()
+    if filter_instance_id:
+        filter_dict['src_instance'] = filter_instance_id
+    if state == 'true':
+        filter_dict['state'] = True
+    elif state == 'false':
+        filter_dict['state'] = False
+
+    # 管理员可以看到全部数据
+    if user.is_superuser:
+        pass
+    # 拥有审核权限、可以查看组内所有工单
+    elif user.has_perm('sql.archive_review'):
+        # 先获取用户所在资源组列表
+        group_list = user_groups(user)
+        group_ids = [group.group_id for group in group_list]
+        filter_dict['resource_group__in'] = group_ids
+    # 其他人只能看到自己提交的工单
+    else:
+        filter_dict['user_name'] = user.username
+
+    # 过滤组合筛选项
+    archive_config = ArchiveConfig.objects.filter(**filter_dict)
+
+    # 过滤搜索项，支持模糊搜索标题、用户
+    if search:
+        archive_config = archive_config.filter(Q(title__icontains=search) | Q(user_display__icontains=search))
+
+    count = archive_config.count()
+    lists = archive_config.order_by('-id')[offset:limit].values(
+        'id', 'title', 'src_instance__instance_name', 'src_db_name', 'src_table_name',
+        'dest_instance__instance_name', 'dest_db_name', 'dest_table_name', 'sleep',
+        'mode', 'no_delete', 'status', 'state', 'user_display', 'create_time', 'resource_group__group_name'
+    )
+
+    # QuerySet 序列化
+    rows = [row for row in lists]
+
+    result = {"total": count, "rows": rows}
+    # 返回查询结果
+    return HttpResponse(json.dumps(result, cls=ExtendJSONEncoder, bigint_as_string=True),
+                        content_type='application/json')
+
+
+@permission_required('sql.archive_apply', raise_exception=True)
+def archive_apply(request):
+    """申请归档实例数据"""
+    user = request.user
+    title = request.POST.get('title')
+    group_name = request.POST.get('group_name')
+    src_instance_name = request.POST.get('src_instance_name')
+    src_db_name = request.POST.get('src_db_name')
+    src_table_name = request.POST.get('src_table_name')
+    mode = request.POST.get('mode')
+    dest_instance_name = request.POST.get('dest_instance_name')
+    dest_db_name = request.POST.get('dest_db_name')
+    dest_table_name = request.POST.get('dest_table_name')
+    condition = request.POST.get('condition')
+    no_delete = True if request.POST.get('no_delete') == 'true' else False
+    sleep = request.POST.get('sleep', 0)
+    result = {'status': 0, 'msg': 'ok', 'data': {}}
+
+    # 参数校验
+    if not all(
+            [title, group_name, src_instance_name, src_db_name, src_table_name, mode, condition]) or no_delete is None:
+        return JsonResponse({'status': 1, 'msg': '请填写完整！', 'data': {}})
+    if mode == 'dest' and not all([dest_instance_name, dest_db_name, dest_table_name]):
+        return JsonResponse({'status': 1, 'msg': '归档到实例时目标实例信息必选！', 'data': {}})
+
+    # 获取源实例信息
+    try:
+        s_ins = user_instances(request.user, db_type=['mysql']).get(instance_name=src_instance_name)
+    except Instance.DoesNotExist:
+        return JsonResponse({'status': 1, 'msg': '你所在组未关联该实例！', 'data': {}})
+
+    # 获取目标实例信息
+    if mode == 'dest':
+        try:
+            d_ins = user_instances(request.user, db_type=['mysql']).get(instance_name=dest_instance_name)
+        except Instance.DoesNotExist:
+            return JsonResponse({'status': 1, 'msg': '你所在组未关联该实例！', 'data': {}})
+    else:
+        d_ins = None
+
+    # 获取资源组和审批信息
+    res_group = ResourceGroup.objects.get(group_name=group_name)
+    audit_auth_groups = Audit.settings(res_group.group_id, WorkflowDict.workflow_type['archive'])
+    if not audit_auth_groups:
+        return JsonResponse({'status': 1, 'msg': '审批流程不能为空，请先配置审批流程', 'data': {}})
+
+    # 使用事务保持数据一致性
+    try:
+        with transaction.atomic():
+            # 保存申请信息到数据库
+            archive_info = ArchiveConfig.objects.create(
+                title=title,
+                resource_group=res_group,
+                audit_auth_groups=audit_auth_groups,
+                src_instance=s_ins,
+                src_db_name=src_db_name,
+                src_table_name=src_table_name,
+                dest_instance=d_ins,
+                dest_db_name=dest_db_name,
+                dest_table_name=dest_table_name,
+                condition=condition,
+                mode=mode,
+                no_delete=no_delete,
+                sleep=sleep,
+                status=WorkflowDict.workflow_status['audit_wait'],
+                state=False,
+                user_name=user.username,
+                user_display=user.display,
+            )
+            archive_id = archive_info.id
+            # 调用工作流插入审核信息
+            audit_result = Audit.add(WorkflowDict.workflow_type['archive'], archive_id)
+    except Exception as msg:
+        logger.error(traceback.format_exc())
+        result['status'] = 1
+        result['msg'] = str(msg)
+    else:
+        result = audit_result
+        # 消息通知
+        audit_id = Audit.detail_by_workflow_id(workflow_id=archive_id,
+                                               workflow_type=WorkflowDict.workflow_type['archive']).audit_id
+        async_task(notify_for_audit, audit_id=audit_id, timeout=60, task_name=f'archive-apply-{archive_id}')
+    return HttpResponse(json.dumps(result), content_type='application/json')
+
+
+@permission_required('sql.archive_review', raise_exception=True)
+def archive_audit(request):
+    """
+    审核数据归档申请
+    :param request:
+    :return:
+    """
+    # 获取用户信息
+    user = request.user
+    archive_id = int(request.POST['archive_id'])
+    audit_status = int(request.POST['audit_status'])
+    audit_remark = request.POST.get('audit_remark')
+
+    if audit_remark is None:
+        audit_remark = ''
+
+    if Audit.can_review(request.user, archive_id, 3) is False:
+        context = {'errMsg': '你无权操作当前工单！'}
+        return render(request, 'error.html', context)
+
+    # 使用事务保持数据一致性
+    try:
+        with transaction.atomic():
+            audit_id = Audit.detail_by_workflow_id(workflow_id=archive_id,
+                                                   workflow_type=WorkflowDict.workflow_type['archive']).audit_id
+
+            # 调用工作流插入审核信息，更新业务表审核状态
+            audit_status = Audit.audit(audit_id, audit_status, user.username, audit_remark)['data']['workflow_status']
+            ArchiveConfig(id=archive_id,
+                          status=audit_status,
+                          state=True if audit_status == WorkflowDict.workflow_status['audit_success'] else False
+                          ).save(update_fields=['status', 'state'])
+    except Exception as msg:
+        logger.error(traceback.format_exc())
+        context = {'errMsg': msg}
+        return render(request, 'error.html', context)
+    else:
+
+        # 消息通知
+        async_task(notify_for_audit, audit_id=audit_id, audit_remark=audit_remark, timeout=60,
+                   task_name=f'archive-audit-{archive_id}')
+
+    return HttpResponseRedirect(reverse('sql:archive_detail', args=(archive_id,)))
+
+
+def add_archive_task():
+    """添加数据归档异步任务"""
+    # 全部有效归档任务
+    for archive_info in ArchiveConfig.objects.filter(
+            state=True, status=WorkflowDict.workflow_status['audit_success']):
+        archive_id = archive_info.id
+        async_task('sql.archiver.archive',
+                   archive_id,
+                   group=f'archive-{time.strftime("%Y-%m-%d %H:%M:%S ")}', timeout=-1,
+                   task_name=f'archive-{archive_id}')
+
+
+def archive(archive_id):
+    """
+    执行数据库归档
+    :return:
+    """
+    archive_info = ArchiveConfig.objects.get(id=archive_id)
+    s_ins = archive_info.src_instance
+    src_db_name = archive_info.src_db_name
+    src_table_name = archive_info.src_table_name
+    condition = archive_info.condition
+    no_delete = archive_info.no_delete
+    sleep = archive_info.sleep
+    mode = archive_info.mode
+
+    pt_archiver = PtArchiver()
+    # 准备参数
+    source = fr"h={s_ins.host},u={s_ins.user},p={s_ins.password},P={s_ins.port},D={src_db_name},t={src_table_name}"
+    args = {
+        "no-version-check": True,
+        "source": source,
+        "where": condition,
+        "progress": 5000,
+        "statistics": True,
+        "charset": 'UTF8',
+        "limit": 10000,
+        "txn-size": 1000,
+        "sleep": sleep
+    }
+
+    # 归档到目标实例
+    if mode == 'dest':
+        d_ins = archive_info.dest_instance
+        dest_db_name = archive_info.dest_db_name
+        dest_table_name = archive_info.dest_table_name
+        dest = fr"h={d_ins.host},u={d_ins.user},p={d_ins.password},P={d_ins.port},D={dest_db_name},t={dest_table_name}"
+        args['dest'] = dest
+        args['bulk-insert'] = True
+        if no_delete:
+            args['no-delete'] = no_delete
+        else:
+            args['bulk-delete'] = True
+    elif mode == 'file':
+        output_directory = os.path.join(settings.BASE_DIR, 'downloads/archiver')
+        os.makedirs(output_directory, exist_ok=True)
+        args['file'] = f'{output_directory}/{s_ins.instance_name}-{src_db_name}-{src_table_name}.txt'
+        if no_delete:
+            args['no-delete'] = no_delete
+        else:
+            args['bulk-delete'] = True
+    elif mode == 'purge':
+        args['purge'] = ''
+
+    # 参数检查
+    args_check_result = pt_archiver.check_args(args)
+    if args_check_result['status'] == 1:
+        return JsonResponse(args_check_result)
+    # 参数转换
+    cmd_args = pt_archiver.generate_args2cmd(args, shell=True)
+    # 执行命令，获取结果
+    select_cnt = 0
+    insert_cnt = 0
+    delete_cnt = 0
+    with FuncTimer() as t:
+        p = pt_archiver.execute_cmd(cmd_args, shell=True)
+        stdout = ''
+        for line in iter(p.stdout.readline, ''):
+            if re.match(r'^SELECT\s(\d+)$', line, re.I):
+                select_cnt = re.findall(r'^SELECT\s(\d+)$', line)
+            elif re.match(r'^INSERT\s(\d+)$', line, re.I):
+                insert_cnt = re.findall(r'^INSERT\s(\d+)$', line)
+            elif re.match(r'^DELETE\s(\d+)$', line, re.I):
+                delete_cnt = re.findall(r'^DELETE\s(\d+)$', line)
+            stdout += f'{line}\n'
+        statistics = stdout
+        # 获取异常信息
+        stderr = p.stderr.read()
+        if stderr:
+            statistics = stdout + stderr
+
+    # 判断归档结果
+    select_cnt = int(select_cnt[0]) if select_cnt else 0
+    insert_cnt = int(insert_cnt[0]) if insert_cnt else 0
+    delete_cnt = int(delete_cnt[0]) if delete_cnt else 0
+    error_info = ''
+    success = True
+    if stderr:
+        error_info = f'命令执行报错:{stderr}'
+        success = False
+    if mode == 'dest':
+        # 删除源数据，判断删除数量和写入数量
+        if not no_delete and (insert_cnt != delete_cnt):
+            error_info = f"删除和写入数量不一致:{insert_cnt}!={delete_cnt}"
+            success = False
+    elif mode == 'file':
+        # 删除源数据，判断查询数量和删除数量
+        if not no_delete and (select_cnt != delete_cnt):
+            error_info = f"查询和删除数量不一致:{select_cnt}!={delete_cnt}"
+            success = False
+    elif mode == 'purge':
+        # 直接删除。判断查询数量和删除数量
+        if select_cnt != delete_cnt:
+            error_info = f"查询和删除数量不一致:{select_cnt}!={delete_cnt}"
+            success = False
+
+    # 执行信息保存到数据库
+    if connection.connection and not connection.is_usable():
+        close_old_connections()
+    # 更新最后归档时间
+    ArchiveConfig(id=archive_id, last_archive_time=t.end).save(update_fields=['last_archive_time'])
+    # 替换密码信息后保存
+    ArchiveLog.objects.create(
+        archive=archive_info,
+        cmd=cmd_args.replace(s_ins.password, '***').replace(
+            d_ins.password, '***') if mode == 'dest' else cmd_args.replace(s_ins.password, '***'),
+        condition=condition,
+        mode=mode,
+        no_delete=no_delete,
+        sleep=sleep,
+        select_cnt=select_cnt,
+        insert_cnt=select_cnt,
+        delete_cnt=delete_cnt,
+        statistics=statistics,
+        success=success,
+        error_info=error_info,
+        start_time=t.start,
+        end_time=t.end
+    )
+    if not success:
+        raise Exception(f'{error_info}\n{statistics}')
+
+
+def archive_log(request):
+    """获取归档日志列表"""
+    limit = int(request.GET.get('limit', 0))
+    offset = int(request.GET.get('offset', 0))
+    limit = offset + limit
+    archive_id = request.GET.get('archive_id')
+
+    archive_logs = ArchiveLog.objects.filter(archive=archive_id).annotate(
+        info=Concat('cmd', V('\n'), 'statistics', output_field=TextField()))
+    count = archive_logs.count()
+    lists = archive_logs.order_by('-id')[offset:limit].values(
+        'cmd', 'info', 'condition', 'mode', 'no_delete', 'select_cnt',
+        'insert_cnt', 'delete_cnt', 'success', 'error_info', 'start_time', 'end_time'
+    )
+    # QuerySet 序列化
+    rows = [row for row in lists]
+    result = {"total": count, "rows": rows}
+    # 返回查询结果
+    return HttpResponse(json.dumps(result, cls=ExtendJSONEncoder, bigint_as_string=True),
+                        content_type='application/json')

--- a/sql/models.py
+++ b/sql/models.py
@@ -536,6 +536,65 @@ class ParamHistory(models.Model):
         verbose_name_plural = u'实例参数修改历史'
 
 
+class ArchiveConfig(models.Model):
+    """
+    归档配置表
+    """
+    title = models.CharField('归档配置说明', max_length=50)
+    resource_group = models.ForeignKey(ResourceGroup, on_delete=models.CASCADE)
+    audit_auth_groups = models.CharField('审批权限组列表', max_length=255)
+    src_instance = models.ForeignKey(Instance, related_name='src_instance', on_delete=models.CASCADE)
+    src_db_name = models.CharField('源数据库', max_length=64)
+    src_table_name = models.CharField('源表', max_length=64)
+    dest_instance = models.ForeignKey(Instance, related_name='dest_instance', on_delete=models.CASCADE, null=True)
+    dest_db_name = models.CharField('目标数据库', max_length=64, blank=True, null=True)
+    dest_table_name = models.CharField('目标表', max_length=64, blank=True, null=True)
+    condition = models.CharField('归档条件，where条件', max_length=1000)
+    mode = models.CharField('归档模式', max_length=10, choices=(('file', '文件'), ('dest', '其他实例'), ('purge', '直接删除')))
+    no_delete = models.BooleanField('是否保留源数据')
+    sleep = models.IntegerField('归档limit行记录后的休眠秒数', default=0)
+    status = models.IntegerField('审核状态', choices=workflow_status_choices)
+    state = models.BooleanField('是否启用归档')
+    user_name = models.CharField('申请人', max_length=30)
+    user_display = models.CharField('申请人中文名', max_length=50, default='')
+    create_time = models.DateTimeField('创建时间', auto_now_add=True)
+    last_archive_time = models.DateTimeField('最近归档时间', null=True)
+    sys_time = models.DateTimeField('系统时间修改', auto_now=True)
+
+    class Meta:
+        managed = True
+        db_table = 'archive_config'
+        verbose_name = u'归档配置表'
+        verbose_name_plural = u'归档配置表'
+
+
+class ArchiveLog(models.Model):
+    """
+    归档日志表
+    """
+    archive = models.ForeignKey(ArchiveConfig, on_delete=models.CASCADE)
+    cmd = models.CharField('归档命令', max_length=2000)
+    condition = models.CharField('归档条件，where条件', max_length=1000)
+    mode = models.CharField('归档模式', max_length=10, choices=(('file', '文件'), ('dest', '其他实例'), ('purge', '直接删除')))
+    no_delete = models.BooleanField('是否保留源数据')
+    sleep = models.IntegerField('归档limit行记录后的休眠秒数', default=0)
+    select_cnt = models.IntegerField('查询数量')
+    insert_cnt = models.IntegerField('插入数量')
+    delete_cnt = models.IntegerField('删除数量')
+    statistics = models.TextField('归档统计日志')
+    success = models.BooleanField('是否归档成功')
+    error_info = models.TextField('错误信息')
+    start_time = models.DateTimeField('开始时间', auto_now_add=True)
+    end_time = models.DateTimeField('结束时间')
+    sys_time = models.DateTimeField('系统时间修改', auto_now=True)
+
+    class Meta:
+        managed = True
+        db_table = 'archive_log'
+        verbose_name = u'归档日志表'
+        verbose_name_plural = u'归档日志表'
+
+
 class Config(models.Model):
     """
     配置信息表
@@ -595,6 +654,7 @@ class Permission(models.Model):
             ('menu_param', '菜单 参数配置'),
             ('menu_data_dictionary', '菜单 数据字典'),
             ('menu_tools', '菜单 工具插件'),
+            ('menu_archive', '菜单 数据归档'),
             ('menu_binlog2sql', '菜单 Binlog2SQL'),
             ('menu_schemasync', '菜单 SchemaSync'),
             ('menu_system', '菜单 系统管理'),
@@ -621,7 +681,9 @@ class Permission(models.Model):
             ('instance_account_manage', '管理实例账号'),
             ('param_view', '查看实例参数列表'),
             ('param_edit', '修改实例参数'),
-            ('data_dictionary_export', '导出数据字典')
+            ('data_dictionary_export', '导出数据字典'),
+            ('archive_apply', '提交归档申请'),
+            ('archive_review', '审核归档申请'),
         )
 
 

--- a/sql/plugins/pt_archiver.py
+++ b/sql/plugins/pt_archiver.py
@@ -1,0 +1,52 @@
+# -*- coding: UTF-8 -*-
+""" 
+@author: hhyo
+@license: Apache Licence
+@file: pt_archiver.py
+@time: 2020/01/10
+"""
+from common.config import SysConfig
+from sql.plugins.plugin import Plugin
+
+__author__ = 'hhyo'
+
+
+class PtArchiver(Plugin):
+    """
+    pt-archiver归档数据
+    """
+
+    def __init__(self):
+        self.path = 'pt-archiver'
+        self.required_args = []
+        self.disable_args = ['analyze']
+        super(Plugin, self).__init__()
+
+    def generate_args2cmd(self, args, shell):
+        """
+        转换请求参数为命令行
+        :param args:
+        :param shell:
+        :return:
+        """
+        k_options = ['no-version-check', 'statistics', 'bulk-insert', 'bulk-delete', 'purge', 'no-delete']
+        kv_options = ['source', 'dest', 'file', 'where', 'progress', 'charset', 'limit', 'txn-size', 'sleep']
+        if shell:
+            cmd_args = self.path if self.path else ''
+            for name, value in args.items():
+                if name in k_options and value:
+                    cmd_args += f' --{name}'
+                elif name in kv_options:
+                    if name == 'where':
+                        cmd_args += f' --{name} "{value}"'
+                    else:
+                        cmd_args += f' --{name} {value}'
+        else:
+            cmd_args = [self.path]
+            for name, value in args.items():
+                if name in k_options and value:
+                    cmd_args.append(f'--{name}')
+                elif name in kv_options:
+                    cmd_args.append(f'--{name}')
+                    cmd_args.append(f'{value}')
+        return cmd_args

--- a/sql/plugins/tests.py
+++ b/sql/plugins/tests.py
@@ -14,6 +14,7 @@ from sql.plugins.binglog2sql import Binlog2Sql
 from sql.plugins.schemasync import SchemaSync
 from sql.plugins.soar import Soar
 from sql.plugins.sqladvisor import SQLAdvisor
+from sql.plugins.pt_archiver import PtArchiver
 
 from common.config import SysConfig
 
@@ -196,6 +197,28 @@ class TestPlugin(TestCase):
         cmd_args = binlog2sql.generate_args2cmd(args, False)
         self.assertIsInstance(cmd_args, list)
         cmd_args = binlog2sql.generate_args2cmd(args, True)
+        self.assertIsInstance(cmd_args, str)
+
+    def test_pt_archiver_generate_args2cmd(self):
+        """
+        测试pt_archiver参数转换
+        :return:
+        """
+        args = {
+            "no-version-check": True,
+            "source": '',
+            "where": '',
+            "progress": 5000,
+            "statistics": True,
+            "charset": 'UTF8',
+            "limit": 10000,
+            "txn-size": 1000,
+            "sleep": 1
+        }
+        pt_archiver = PtArchiver()
+        cmd_args = pt_archiver.generate_args2cmd(args, False)
+        self.assertIsInstance(cmd_args, list)
+        cmd_args = pt_archiver.generate_args2cmd(args, True)
         self.assertIsInstance(cmd_args, str)
 
     @patch('sql.plugins.plugin.subprocess')

--- a/sql/resource_group.py
+++ b/sql/resource_group.py
@@ -125,9 +125,14 @@ def instances(request):
     group_name = request.POST.get('group_name')
     group_id = ResourceGroup.objects.get(group_name=group_name).group_id
     tag_code = request.POST.get('tag_code')
+    db_type = request.POST.get('db_type')
 
     # 先获取资源组关联所有实例列表
     instances = ResourceGroup.objects.get(group_id=group_id).instances
+
+    # 过滤db_type
+    if db_type:
+        instances = instances.filter(db_type=db_type)
 
     # 过滤tag
     if tag_code:

--- a/sql/templates/archive.html
+++ b/sql/templates/archive.html
@@ -1,0 +1,637 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <!-- 自定义操作按钮-->
+    <div id="toolbar" class="form-inline pull-left">
+        <div class="form-group">
+            <select id="filter_instance_id" class="form-control selectpicker"
+                    data-live-search="true">
+                <option value="" selected="selected">全部实例</option>
+                {% for ins in ins_list %}
+                    <option value="{{ ins.id }}">{{ ins.instance_name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="form-group">
+            <select id="state" class="form-control selectpicker">
+                <option value="" selected="selected">启用状态</option>
+                <option value="true">启用</option>
+                <option value="false">未启用</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <button id="btn_add" type="button" class="btn btn-default"
+                    data-toggle="modal" data-target="#apply">
+                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                <span aria-hidden="true"></span>申请归档
+            </button>
+        </div>
+    </div>
+    <!-- 申请列表的表格-->
+    <div class="table-responsive">
+        <table id="archive-list" data-toggle="table" class="table table-striped table-hover"
+               style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+        </table>
+    </div>
+    <!-- 申请权限的模态框-->
+    <div class="modal fade" id="apply" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="myModalLabel">申请数据归档</h4>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <input type="text" autocomplete="off" class="form-control" id="title"
+                               placeholder="对归档进行简单描述，审核通过后会按计划进行归档">
+                    </div>
+                    <div class="form-group">
+                        <select id="group_name" name="group_name"
+                                class="selectpicker show-tick form-control bs-select-hidden"
+                                title="请选择组:"
+                                data-live-search="true" required>
+                            {% for group in group_list %}
+                                <option value="{{ group.group_name }}">{{ group.group_name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <select id="src_instance_name" name="src_instance_name"
+                                class="selectpicker show-tick form-control bs-select-hidden" data-live-search="true"
+                                title="请选择源实例:"
+                                data-placeholder="请选择实例:" required>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <select id="src_db_name" name="src_db_name"
+                                class="form-control selectpicker show-tick bs-select-hidden"
+                                title="请选择源数据库:"
+                                data-live-search="true" data-placeholder="请选择数据库:" required>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <select id="src_table_name" name="src_table_name"
+                                class="form-control selectpicker show-tick bs-select-hidden"
+                                data-live-search="true"
+                                data-name="请选择需要归档的表:"
+                                title="请选择需要归档的表:"
+                                data-placeholder="请选择需要归档的表:" required>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <select id="mode" name="mode"
+                                class="form-control selectpicker show-tick bs-select-hidden"
+                                data-name="请选择归档模式:"
+                                title="请选择归档模式:"
+                                data-placeholder="请选择归档模式:" required>
+                            <option value='file'>归档到文件</option>
+                            <option value='dest'>归档其他实例</option>
+                            <option value='purge'>直接删除</option>
+                        </select>
+                    </div>
+                    <div class="form-group" id="no_delete-div" style="display: none">
+                        <div class="form-group">
+                            <select id="no_delete" name="no_delete"
+                                    class="selectpicker show-tick form-control bs-select-hidden"
+                                    title="归档后是否保留源数据:"
+                                    data-placeholder="归档后是否保留源数据:" required>
+                                <option value='' disabled>归档后是否保留源数据</option>
+                                <option value='true'>保留</option>
+                                <option value='false'>删除</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-group" id="dest-div" style="display: none">
+                        <div class="form-group">
+                            <select id="dest_instance_name" name="dest_instance_name"
+                                    class="selectpicker show-tick form-control bs-select-hidden" data-live-search="true"
+                                    title="请选择目标实例:"
+                                    data-placeholder="请选择目标实例:" required>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <select id="dest_db_name" name="dest_db_name"
+                                    class="form-control selectpicker show-tick bs-select-hidden"
+                                    title="请选择目标数据库:"
+                                    data-live-search="true" data-placeholder="请选择对应数据库:" required>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <select id="dest_table_name" name="dest_table_name"
+                                    class="form-control selectpicker show-tick bs-select-hidden"
+                                    data-live-search="true"
+                                    data-name="请选择目标表:"
+                                    title="请选择目标表:"
+                                    data-placeholder="请选择需目标表:" required>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <textarea id="condition" name="condition" class="form-control"
+                                  placeholder="请输入归档条件，就是SQL语句的WHERE条件"></textarea>
+                    </div>
+                    <div class="form-group">
+                        <input type="number" autocomplete="off" name="sleep" class="form-control" id="sleep"
+                               placeholder="归档10000行记录后的休眠秒数">
+                    </div>
+                    <!--审批流程-->
+                    <div id="div-workflow_auditors" class="form-group" style="display: none">
+                        <p class="bg-primary">&nbsp&nbsp&nbsp审批流程：<b id="workflow_auditors"></b></p>
+                    </div>
+                    <p class="text-info">提示：源表和目标表结构必须保持一致，否则将会归档失败</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">取消</button>
+                    <button type="button" class="btn btn-success" onclick="archive_apply()">提交申请</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- 日志信息-->
+    <div class="modal fade" id="logs">
+        <div class="modal-dialog">
+            <div class="modal-content message_align">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">×</span></button>
+                    <h4 class="modal-title text-danger">工单日志</h4>
+                </div>
+                <div class="modal-body">
+                    <div class="table-responsive">
+                        <table id="log-list" data-toggle="table" class="table table-striped table-hover"
+                               style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+                        </table>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}
+
+{% block js %}
+    <!--group -->
+    <script>
+        // 获取实例信息和审批流程
+        $("#group_name").change(function () {
+            $.ajax({
+                type: "post",
+                url: "/group/instances/",
+                dataType: "json",
+                data: {
+                    group_name: $("#group_name").val(),
+                    tag_code: 'can_read',
+                    db_type: 'mysql'
+                },
+                complete: function () {
+                },
+                success: function (data) {
+                    if (data.status === 0) {
+                        let result = data['data'];
+                        $("#src_instance_name").empty();
+                        $("#dest_instance_name").empty();
+                        for (let i = 0; i < result.length; i++) {
+                            let instance = "<option value=\"" + result[i]['instance_name'] + "\">" + result[i]['instance_name'] + "</option>";
+                            $("#src_instance_name").append(instance);
+                            $("#dest_instance_name").append(instance);
+                        }
+                        $('#src_instance_name').selectpicker('render');
+                        $('#src_instance_name').selectpicker('refresh');
+                        $('#dest_instance_name').selectpicker('render');
+                        $('#dest_instance_name').selectpicker('refresh');
+                    } else {
+                        alert(data.msg);
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            });
+            $.ajax({
+                type: "post",
+                url: "/group/auditors/",
+                dataType: "json",
+                data: {
+                    group_name: $("#group_name").val(),
+                    workflow_type: 3
+                },
+                complete: function () {
+                },
+                success: function (data) {
+                    if (data.status === 0) {
+                        var result = data.data;
+                        $("#div-workflow_auditors").show();
+                        $("#workflow_auditors").val(result['auditors']);
+                        $("#workflow_auditors").text(result['auditors_display']);
+                    } else {
+                        alert(data.msg);
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            });
+        });
+
+    </script>
+    <script>
+        //筛选变动自动刷新
+        $("#filter_instance_id").change(function () {
+            archive_apply_list();
+        });
+        //筛选变动自动刷新
+        $("#state").change(function () {
+            archive_apply_list();
+        });
+
+        //获取申请列表
+        function archive_apply_list() {
+            $('#archive-list').bootstrapTable('destroy').bootstrapTable({
+                escape: true,
+                method: 'get',
+                contentType: "application/x-www-form-urlencoded",
+                url: "/archive/list/",
+                striped: true,                      //是否显示行间隔色
+                cache: false,                       //是否使用缓存，默认为true，所以一般情况下需要设置一下这个属性（*）
+                pagination: true,                   //是否显示分页（*）
+                sortable: true,                     //是否启用排序
+                sortOrder: "asc",                   //排序方式
+                sidePagination: "server",           //分页方式：client客户端分页，server服务端分页（*）
+                pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
+                pageSize: 14,                     //每页的记录行数（*）
+                pageList: [20, 30, 50, 100],       //可供选择的每页的行数（*）
+                search: true,                      //是否显示表格搜索
+                strictSearch: false,                //是否全匹配搜索
+                showColumns: true,                  //是否显示所有的列（选择显示的列）
+                showRefresh: true,                  //是否显示刷新按钮
+                minimumCountColumns: 2,             //最少允许的列数
+                clickToSelect: true,                //是否启用点击选中行
+                uniqueId: "id",                     //每一行的唯一标识，一般为主键列
+                showToggle: true,                   //是否显示详细视图和列表视图的切换按钮
+                cardView: false,                    //是否显示详细视图
+                detailView: false,                  //是否显示父子表
+                locale: 'zh-CN',                    //本地化
+                toolbar: "#toolbar",               //指明自定义的toolbar
+                queryParamsType: 'limit',
+                //请求服务数据时所传参数
+                queryParams:
+                    function (params) {
+                        return {
+                            filter_instance_id: $("#filter_instance_id").val(),
+                            state: $("#state").val(),
+                            limit: params.limit,
+                            offset: params.offset,
+                            search: params.search
+                        }
+                    },
+                columns: [{
+                    title: '工单名称',
+                    field: 'title',
+                    formatter: function (value, row, index) {
+                        var span = document.createElement('span');
+                        span.setAttribute('title', value);
+                        if (value.length > 10) {
+                            span.innerHTML = "<a href=\"/archive/" + row.id + "/\">" + value.substr(0, 10) + '...';
+                            +"</a>";
+                        } else {
+                            span.innerHTML = "<a href=\"/archive/" + row.id + "/\">" + value + "</a>";
+                        }
+                        return span.outerHTML;
+                    }
+                }, {
+                    title: '实例',
+                    field: 'src_instance__instance_name'
+                }, {
+                    title: '数据库',
+                    field: 'src_db_name'
+                }, {
+                    title: '表',
+                    field: 'src_table_name'
+                }, {
+                    title: '归档模式',
+                    field: 'mode'
+                }, {
+                    title: '源数据',
+                    field: 'no_delete',
+                    formatter: function (value, row, index) {
+                        if (value === true) {
+                            return '保留'
+                        } else {
+                            return '删除'
+                        }
+                    }
+                }, {
+                    title: '休眠(秒)',
+                    field: 'sleep'
+                }, {
+                    title: '启用状态',
+                    field: 'state',
+                    formatter: function (value, row, index) {
+                        if (value === true) {
+                            return "<span class=\"label label-success\">" + '启用' + "</span>"
+                        } else {
+                            return "<span class=\"label label-danger\">" + '关闭' + "</span>"
+                        }
+                    }
+                }, {
+                    title: '工单状态',
+                    field: 'status',
+                    formatter: function (value, row, index) {
+                        return workflow_status_formatter(value)
+                    },
+                    visible: false // 默认不显示
+                }, {
+                    title: '申请人',
+                    field: 'user_display'
+                }, {
+                    title: '申请时间',
+                    field: 'create_time'
+                }, {
+                    title: '组',
+                    field: 'resource_group__group_name',
+                    visible: false // 默认不显示
+                }, {
+                    title: '操作',
+                    field: 'operation',
+                    formatter: function (value, row, index) {
+                        return "<button class=\"btn btn-info btn-xs\" workflow_id=\"" + row.id + "\"\n" + "onclick=\"getLog(this)\" >操作日志\n" + "</button>"
+                    }
+                }],
+                onLoadSuccess: function () {
+                },
+                onLoadError: function () {
+                    alert("数据加载失败！请检查接口返回信息和错误日志！");
+                },
+                onSearch: function (e) {
+                    //传搜索参数给服务器
+                    queryParams(e)
+                },
+                responseHandler: function (res) {
+                    //在ajax获取到数据，渲染表格之前，修改数据源
+                    return res;
+                }
+            });
+
+        }
+
+        //实例变更获取数据库列表
+        $("#src_instance_name").change(function () {
+            $.ajax({
+                type: "get",
+                url: "/instance/instance_resource/",
+                dataType: "json",
+                data: {
+                    instance_name: $("#src_instance_name").val(),
+                    resource_type: "database"
+                },
+                complete: function () {
+
+                },
+                success: function (data) {
+                    if (data.status === 0) {
+                        var result = data.data;
+                        $("#src_db_name").empty();
+                        for (var i = 0; i < result.length; i++) {
+                            var name = "<option value=\"" + result[i] + "\">" + result[i] + "</option>";
+                            $("#src_db_name").append(name);
+                        }
+                        $('#src_db_name').selectpicker('render');
+                        $('#src_db_name').selectpicker('refresh');
+                    } else {
+                        alert(data.msg);
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            });
+        });
+        $("#dest_instance_name").change(function () {
+            $.ajax({
+                type: "get",
+                url: "/instance/instance_resource/",
+                dataType: "json",
+                data: {
+                    instance_name: $("#dest_instance_name").val(),
+                    resource_type: "database"
+                },
+                complete: function () {
+
+                },
+                success: function (data) {
+                    if (data.status === 0) {
+                        var result = data.data;
+                        $("#dest_db_name").empty();
+                        for (var i = 0; i < result.length; i++) {
+                            var name = "<option value=\"" + result[i] + "\">" + result[i] + "</option>";
+                            $("#dest_db_name").append(name);
+                        }
+                        $('#dest_db_name').selectpicker('render');
+                        $('#dest_db_name').selectpicker('refresh');
+                    } else {
+                        alert(data.msg);
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            });
+        });
+
+        //数据库变更获取表名称
+        $("#src_db_name").change(function () {
+            $.ajax({
+                type: "get",
+                url: "/instance/instance_resource/",
+                dataType: "json",
+                data: {
+                    instance_name: $("#src_instance_name").val(),
+                    db_name: $("#src_db_name").val(),
+                    resource_type: "table"
+                },
+                complete: function () {
+                },
+                success: function (data) {
+                    if (data.status === 0) {
+                        var result = data.data;
+                        $("#src_table_name").empty();
+                        for (var i = 0; i < result.length; i++) {
+                            var name = "<option>" + result[i] + "</option>";
+                            $("#src_table_name").append(name);
+                        }
+                        $('#src_table_name').selectpicker('render');
+                        $('#src_table_name').selectpicker('refresh');
+                    } else {
+                        alert(data.msg);
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            });
+        });
+        $("#dest_db_name").change(function () {
+            $.ajax({
+                type: "get",
+                url: "/instance/instance_resource/",
+                dataType: "json",
+                data: {
+                    instance_name: $("#dest_instance_name").val(),
+                    db_name: $("#dest_db_name").val(),
+                    resource_type: "table"
+                },
+                complete: function () {
+                },
+                success: function (data) {
+                    if (data.status === 0) {
+                        var result = data.data;
+                        $("#dest_table_name").empty();
+                        for (var i = 0; i < result.length; i++) {
+                            var name = "<option>" + result[i] + "</option>";
+                            $("#dest_table_name").append(name);
+                        }
+                        $('#dest_table_name').selectpicker('render');
+                        $('#dest_table_name').selectpicker('refresh');
+                    } else {
+                        alert(data.msg);
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            });
+        });
+
+        //判断页面显示
+        $("#mode").change(function () {
+            //库权限
+            let mode = $("#mode").val();
+            if (mode === 'dest') {
+                $("#dest-div").show();
+            } else {
+                $("#dest-div").hide();
+            }
+            if (mode !== 'purge') {
+                $("#no_delete-div").show()
+            } else {
+                $("#no_delete-div").hide()
+            }
+        });
+
+        //提交权限申请
+        function archive_apply() {
+            //禁用按钮
+            $('button[type=button]').addClass('disabled');
+            $('button[type=button]').prop('disabled', true);
+            //提交请求
+            $.ajax({
+                type: "post",
+                url: "/archive/apply/",
+                dataType: "json",
+                data: {
+                    title: $("#title").val(),
+                    group_name: $("#group_name").val(),
+                    src_instance_name: $("#src_instance_name").val(),
+                    src_table_name: $("#src_table_name").val(),
+                    src_db_name: $("#src_db_name").val(),
+                    mode: $("#mode").val(),
+                    dest_instance_name: $("#dest_instance_name").val(),
+                    dest_db_name: $("#dest_db_name").val(),
+                    dest_table_name: $("#dest_table_name").val(),
+                    condition: $("#condition").val(),
+                    no_delete: $("#no_delete").val(),
+                },
+                complete: function () {
+                    $('button[type=button]').removeClass('disabled');
+                    $('button[type=button]').prop('disabled', false);
+                },
+                success: function (data) {
+                    if (data.status === 0) {
+                        $('#apply').modal('hide');
+                        location.href = '/archive/'
+                    } else {
+                        alert(data.msg)
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            });
+        }
+
+        // 获取操作日志
+        function getLog(obj) {
+            var workflow_id = $(obj).attr("workflow_id");
+            var workflow_type = 3;
+            $.ajax({
+                type: "post",
+                url: "/workflow/log/",
+                dataType: "json",
+                data: {
+                    workflow_id: workflow_id,
+                    workflow_type: workflow_type,
+                },
+                complete: function () {
+                },
+                success: function (data) {
+                    //初始化table
+                    $('#logs').modal('show');
+                    $('#log-list').bootstrapTable('destroy').bootstrapTable({
+                        escape: true,
+                        striped: true,                      //是否显示行间隔色
+                        cache: false,                       //是否使用缓存，默认为true，所以一般情况下需要设置一下这个属性（*）
+                        pagination: false,                   //是否显示分页（*）
+                        sortable: false,                     //是否启用排序
+                        sortOrder: "asc",                   //排序方式
+                        sidePagination: "client",           //分页方式：client客户端分页，server服务端分页（*）
+                        pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
+                        pageSize: 14,                     //每页的记录行数（*）
+                        pageList: [20, 30, 50, 100],       //可供选择的每页的行数（*）
+                        search: false,                      //是否显示表格搜索
+                        strictSearch: false,                //是否全匹配搜索
+                        showColumns: false,                  //是否显示所有的列（选择显示的列）
+                        showRefresh: false,                  //是否显示刷新按钮
+                        minimumCountColumns: 2,             //最少允许的列数
+                        clickToSelect: false,                //是否启用点击选中行
+                        uniqueId: "id",                     //每一行的唯一标识，一般为主键列
+                        showToggle: false,                   //是否显示详细视图和列表视图的切换按钮
+                        cardView: false,                    //是否显示详细视图
+                        detailView: false,                  //是否显示父子表
+                        locale: 'zh-CN',                    //本地化
+                        data: data.rows,
+                        columns: [{
+                            title: '操作',
+                            field: 'operation_type_desc'
+                        }, {
+                            title: '操作人',
+                            field: 'operator_display'
+                        }, {
+                            title: '操作时间',
+                            field: 'operation_time'
+                        }, {
+                            title: '操作信息',
+                            field: 'operation_info'
+                        }],
+                        onLoadSuccess: function () {
+                        },
+                        onLoadError: function () {
+                            alert("数据加载失败！请检查接口返回信息和错误日志！");
+                        }
+                    });
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            })
+        }
+
+        //初始化数据
+        $(document).ready(function () {
+            archive_apply_list();
+        });
+
+    </script>
+{% endblock %}

--- a/sql/templates/archivedetail.html
+++ b/sql/templates/archivedetail.html
@@ -1,0 +1,394 @@
+{% extends "base.html" %}
+{% load format_tags %}
+{% block content %}
+    <h4 style="display: inline;">工单名称：<span>{{ archive_config.title }}</span></h4>
+    &nbsp;&nbsp;&nbsp;
+    <!--只允许发起人提交其他实例-->
+    {% if user.username == archive_config.engineer %}
+        <a type='button' id="btnSubmitOtherCluster" class='btn btn-warning' href="/submitotherinstance/">上线其他实例</a>
+    {% endif %}
+    <input type="hidden" id="sqlMaxRowNumber" value="{{ rows|length }}">
+    <input type="hidden" id="editSqlContent" value="{{ archive_config.sql_content }}"/>
+    <hr>
+    <table data-toggle="table" class="table table-striped table-hover"
+           style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+        <thead>
+        <tr>
+            <th>
+                申请人
+            </th>
+            <th>
+                审批流程
+            </th>
+            <th>
+                当前审批
+            </th>
+            <th>
+                实例
+            </th>
+            <th>
+                数据库
+            </th>
+            <th>
+                表
+            </th>
+            <th>
+                归档模式
+            </th>
+            <th>
+                源数据
+            </th>
+            <th>
+                启用状态
+            </th>
+            <th>
+                申请时间
+            </th>
+            <th>
+                最近归档时间
+            </th>
+            <th>
+                当前状态
+            </th>
+            <th>
+                组
+            </th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr class="success">
+            <td>
+                {{ archive_config.user_display }}
+            </td>
+            <td>
+                {{ audit_auth_group }}
+            </td>
+            <td>
+                {{ current_audit_auth_group }}
+            </td>
+            <td>
+                {{ archive_config.src_instance }}
+            </td>
+            <td>
+                {{ archive_config.src_db_name }}
+            </td>
+            <td>
+                {{ archive_config.src_table_name }}
+            </td>
+            <td>
+                {{ archive_config.mode }}
+            </td>
+            <td>
+                {% if archive_config.no_delete %}
+                    保留
+                {% else %}
+                    删除
+                {% endif %}
+            </td>
+            <td>
+                {% if archive_config.no_delete %}
+                    启用
+                {% else %}
+                    删除
+                {% endif %}
+            </td>
+            <td>
+                {{ archive_config.create_time }}
+            </td>
+            <td>
+                {{ archive_config.last_archive_time }}
+            </td>
+            <td>
+                {% if archive_config.status == 0 %}
+                    <b style="color: red">待审核</b>
+                {% elif archive_config.status == 1 %}
+                    <b style="color: green">审核通过</b>
+                {% elif archive_config.status == 2 %}
+                    <b style="color: red">审核不通过</b>
+                {% elif archive_config.status == 3 %}
+                    <b style="color: red">审核取消</b>
+                {% endif %}
+            </td>
+            <td>
+                {{ archive_config.resource_group }}
+            </td>
+        </tr>
+        </tbody>
+    </table>
+    <br>
+    <!-- Nav tabs -->
+    <ul id="nav-tabs" class="nav nav-tabs" role="tablist">
+        <li id="detail_tab" class="active">
+            <a href="#detail" role="tab" data-toggle="tab">归档配置信息</a>
+        </li>
+        <li id="logs_tab">
+            <a href="#logs" role="tab" data-toggle="tab">归档日志</a>
+        </li>
+    </ul>
+    <!-- Tab panes -->
+    <div id="tab-content" class="tab-content">
+        <!-- 归档配置信息-->
+        <div id="detail" role="tabpanel" class="panel-body tab-pane fade in active">
+            <h4><b>实例信息</b></h4>
+            <hr/>
+            <div class="col-sm-6">
+                <h5 style="color: darkgrey"><b>源信息</b></h5>
+                <hr/>
+                <div class="form-horizontal">
+                    <div class="form-group">
+                        <label class="col-sm-3 control-label">源实例</label>
+                        <div class="col-sm-9">
+                            <p class="form-control-static">{{ archive_config.src_instance }}</p>
+                        </div>
+                        <label class="col-sm-3 control-label">源数据库</label>
+                        <div class="col-sm-9">
+                            <p class="form-control-static">{{ archive_config.src_db_name }}</p>
+                        </div>
+                        <label class="col-sm-3 control-label">源表</label>
+                        <div class="col-sm-9">
+                            <p class="form-control-static">{{ archive_config.src_db_name }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6">
+                <h5 style="color: darkgrey"><b>目标信息</b></h5>
+                <hr/>
+                <div class="form-horizontal">
+                    <div class="form-group">
+                        <label class="col-sm-3 control-label">目标实例</label>
+                        <div class="col-sm-9">
+                            <p class="form-control-static">{{ archive_config.dest_instance }}</p>
+                        </div>
+                        <label class="col-sm-3 control-label">目标数据库</label>
+                        <div class="col-sm-9">
+                            <p class="form-control-static">{{ archive_config.dest_db_name }}</p>
+                        </div>
+                        <label class="col-sm-3 control-label">目标表</label>
+                        <div class="col-sm-9">
+                            <p class="form-control-static">{{ archive_config.dest_table_name }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <h4><b>归档条件</b></h4>
+            <hr/>
+            <div class="form-horizontal">
+                <div class="form-group">
+                    <div class="col-sm-9">
+                        <p class="form-control-static"><code>{{ archive_config.condition }}</code></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!-- 归档日志-->
+        <div id="logs" role="tabpanel" class="tab-pane fade table-responsive">
+            <table id="tb-logs" data-toggle="table" class="table table-hover"
+                   style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+            </table>
+        </div>
+    </div>
+    <!--最后操作信息-->
+    {% if last_operation_info %}
+        <table data-toggle="table" class="table table-striped table-hover"
+               style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+            <thead>
+            <tr>
+                <th>
+                    操作信息
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>
+                    {{ last_operation_info }}
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <br>
+    {% endif %}
+    {% if archive_config.status == 0 %}
+        {% if is_can_review %}
+            <textarea id="remark" name="remark" class="form-control" data-name="审核备注"
+                      placeholder="请填写审核备注" rows=3></textarea>
+            <br>
+            <form action="/archive/audit/" method="post" style="display:inline-block;">
+                {% csrf_token %}
+                <input type="hidden" name="archive_id" value="{{ archive_config.id }}">
+                <input type="hidden" id="audit_status" name="audit_status" value="1">
+                <input type="submit" id="btnPass" onclick="loading(this)" class="btn btn-success" value="审核通过"/>
+            </form>
+
+            <form id="form-cancel" action="/archive/audit/" method="post" style="display:inline-block;">
+                {% csrf_token %}
+                <input type="hidden" name="archive_id" value="{{ archive_config.id }}">
+                <input type="hidden" id="audit_status" name="audit_status" value="2">
+                <input type="hidden" id="audit_remark" name="audit_remark" value="">
+                <input type="button" id="btnReject" class="btn btn-default" value="终止流程"/>
+            </form>
+        {% endif %}
+    {% endif %}
+{% endblock content %}
+
+{% block js %}
+    <script>
+        // 获取日志日志
+        function get_logs() {
+            //初始化table
+            $('#tb-logs').bootstrapTable('destroy').bootstrapTable({
+                escape: true,
+                method: 'get',
+                contentType: "application/x-www-form-urlencoded",
+                url: "/archive/log/",
+                striped: true,                      //是否显示行间隔色
+                cache: true,                       //是否使用缓存，默认为true，所以一般情况下需要设置一下这个属性（*）
+                pagination: true,                   //是否显示分页（*）
+                sortable: false,                     //是否启用排序
+                sortOrder: "asc",                   //排序方式
+                sidePagination: "server",           //分页方式：client客户端分页，server服务端分页（*）
+                pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
+                pageSize: 14,                     //每页的记录行数（*）
+                pageList: [20, 30, 50, 100],       //可供选择的每页的行数（*）
+                search: true,                      //是否显示表格搜索
+                strictSearch: false,                //是否全匹配搜索
+                showColumns: false,                  //是否显示所有的列（选择显示的列）
+                showRefresh: false,                  //是否显示刷新按钮
+                minimumCountColumns: 2,             //最少允许的列数
+                clickToSelect: false,                //是否启用点击选中行
+                uniqueId: "id",                     //每一行的唯一标识，一般为主键列
+                showToggle: false,                   //是否显示详细视图和列表视图的切换按钮
+                cardView: false,                    //是否显示详细视图
+                detailView: true,                  //是否显示父子表
+                //格式化详情
+                detailFormatter: function (index, row) {
+                    var html = [];
+                    $.each(row, function (key, value) {
+                        if (key === 'info') {
+                            //替换标签
+                            value = value.replace(/&/g, "&amp;");
+                            value = value.replace(/</g, "&lt;");
+                            value = value.replace(/>/g, "&gt;");
+                            value = value.replace(/"/g, "&quot;");
+                            //替换所有的换行符
+                            value = value.replace(/\r\n/g, "<br>");
+                            value = value.replace(/\n/g, "<br>");
+                            //替换所有的空格
+                            value = value.replace(/\s/g, "&nbsp;");
+                            html.push('<span>' + value + '</span>');
+                        }
+                    });
+                    return html.join('');
+                },
+                queryParamsType: 'limit',
+                //请求服务数据时所传参数
+                queryParams:
+                    function (params) {
+                        return {
+                            archive_id: "{{ archive_config.id }}",
+                            limit: params.limit,
+                            offset: params.offset,
+                            search: params.search
+                        }
+                    },
+                locale: 'zh-CN',                    //本地化
+                columns: [{
+                    title: '归档命令',
+                    field: 'cmd',
+                    visible: false // 默认不显示
+                }, {
+                    title: '归档模式',
+                    field: 'mode'
+                }, {
+                    title: '归档条件',
+                    field: 'condition'
+                }, {
+                    title: '源数据',
+                    field: 'no_delete',
+                    formatter: function (value, row, index) {
+                        if (value === true) {
+                            return '保留'
+                        } else {
+                            return '删除'
+                        }
+                    }
+                }, {
+                    title: '状态',
+                    field: 'success',
+                    formatter: function (value, row, index) {
+                        if (value === true) {
+                            return "<span class=\"label label-success\">" + '成功' + "</span>"
+                        } else {
+                            return "<span class=\"label label-danger\">" + '失败' + "</span>"
+                        }
+                    }
+                }, {
+                    title: '查询',
+                    field: 'select_cnt'
+                }, {
+                    title: '插入',
+                    field: 'insert_cnt'
+                }, {
+                    title: '删除',
+                    field: 'delete_cnt'
+                }, {
+                    title: '开始时间',
+                    field: 'start_time'
+                }, {
+                    title: '结束时间',
+                    field: 'end_time'
+                }, {
+                    title: '统计日志',
+                    field: 'statistics',
+                    visible: false // 默认不显示
+                }],
+                onLoadSuccess: function () {
+                },
+                onLoadError: function () {
+                    alert("数据加载失败！请检查接口返回信息和错误日志！");
+                }
+            });
+        }
+
+        // 按钮禁用
+        function loading(obj) {
+            $(obj).button('loading').delay(2500).queue(function () {
+                $(obj).button('reset');
+                $(obj).dequeue();
+            });
+        }
+
+        // 校验备注
+        $("#btnReject").click(function () {
+            //获取form对象，判断输入，通过则提交
+            $("#audit_remark").val($("#remark").val());
+            var formCancel = $("#form-cancel");
+            if ($("#audit_remark").val()) {
+                $(this).button('loading').delay(2500).queue(function () {
+                    $(this).button('reset');
+                    $(this).dequeue();
+                });
+                formCancel.submit();
+            } else {
+                alert('请填写审核备注')
+            }
+        })
+    </script>
+    <!--TAB控制 -->
+    <script>
+        //tab切换,保留当前激活的标签id
+        $(function () {
+            $("#nav-tabs").on('shown.bs.tab', "li", function (e) {
+                var active_li_id = $(e.target).parents().attr('id');
+                sessionStorage.setItem('archive_active_li_id', active_li_id);
+                //当前激活的标签id
+                if (active_li_id === 'detail_tab') {
+                } else if (active_li_id === 'logs_tab') {
+                    get_logs();
+                }
+            });
+        });
+    </script>
+
+{% endblock %}

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -11,15 +11,236 @@ from django.test import Client, TestCase, TransactionTestCase
 import sql.query_privileges
 from common.config import SysConfig
 from common.utils.const import WorkflowDict
+from sql.archiver import add_archive_task, archive
 from sql.binlog import binlog2sql_file
 from sql.engines.models import ResultSet, ReviewSet, ReviewResult
 from sql.notify import notify_for_audit, notify_for_execute, notify_for_binlog2sql
 from sql.utils.execute_sql import execute_callback
 from sql.query import kill_query_conn
 from sql.models import Instance, QueryPrivilegesApply, QueryPrivileges, SqlWorkflow, SqlWorkflowContent, \
-    ResourceGroup, ResourceGroup2User, ParamTemplate, WorkflowAudit, QueryLog
+    ResourceGroup, ResourceGroup2User, ParamTemplate, WorkflowAudit, QueryLog, WorkflowLog, WorkflowAuditSetting, \
+    ArchiveConfig
 
 User = get_user_model()
+
+
+class TestView(TestCase):
+    """测试view视图"""
+
+    def setUp(self):
+        """
+        准备用户和配置
+        """
+        self.sys_config = SysConfig()
+        self.client = Client()
+        self.superuser = User.objects.create(username='super', is_superuser=True)
+        self.client.force_login(self.superuser)
+        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql',
+                                           host='some_host',
+                                           port=3306, user='ins_user', password='some_str')
+        self.res_group = ResourceGroup.objects.create(group_id=1, group_name='group_name')
+        self.wf = SqlWorkflow.objects.create(
+            workflow_name='some_name',
+            group_id=1,
+            group_name='g1',
+            engineer_display='',
+            audit_auth_groups='some_audit_group',
+            status='workflow_finish',
+            is_backup=True,
+            instance=self.ins,
+            db_name='some_db',
+            syntax_type=1
+        )
+        SqlWorkflowContent.objects.create(workflow=self.wf,
+                                          sql_content='some_sql',
+                                          execute_result='')
+        self.query_apply = QueryPrivilegesApply.objects.create(
+            group_id=1,
+            group_name='some_name',
+            title='some_title1',
+            user_name='some_user',
+            instance=self.ins,
+            db_list='some_db,some_db2',
+            limit_num=100,
+            valid_date='2020-01-1',
+            priv_type=1,
+            status=0,
+            audit_auth_groups='some_audit_group'
+        )
+        self.audit = WorkflowAudit.objects.create(
+            group_id=1,
+            group_name='some_group',
+            workflow_id=1,
+            workflow_type=1,
+            workflow_title='申请标题',
+            workflow_remark='申请备注',
+            audit_auth_groups='1,2,3',
+            current_audit='1',
+            next_audit='2',
+            current_status=0)
+        self.wl = WorkflowLog.objects.create(audit_id=self.audit.audit_id,
+                                             operation_type=1)
+
+    def tearDown(self):
+        self.sys_config.purge()
+        User.objects.all().delete()
+        SqlWorkflow.objects.all().delete()
+        SqlWorkflowContent.objects.all().delete()
+        WorkflowAudit.objects.all().delete()
+        WorkflowLog.objects.all().delete()
+        QueryPrivilegesApply.objects.all().delete()
+        ResourceGroup.objects.all().delete()
+
+    def test_index(self):
+        """测试index页面"""
+        data = {}
+        r = self.client.get('/index/', data=data)
+        self.assertRedirects(r, f'/sqlworkflow/', fetch_redirect_response=False)
+
+    def test_dashboard(self):
+        """测试dashboard页面"""
+        data = {}
+        r = self.client.get('/dashboard/', data=data)
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, 'SQL上线工单')
+
+    def test_sqlworkflow(self):
+        """测试sqlworkflow页面"""
+        data = {}
+        r = self.client.get('/sqlworkflow/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_submitsql(self):
+        """测试submitsql页面"""
+        data = {}
+        r = self.client.get('/submitsql/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_rollback(self):
+        """测试rollback页面"""
+        data = {"workflow_id": self.wf.id}
+        r = self.client.get('/rollback/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_sqlanalyze(self):
+        """测试sqlanalyze页面"""
+        data = {}
+        r = self.client.get('/sqlanalyze/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_sqlquery(self):
+        """测试sqlquery页面"""
+        data = {}
+        r = self.client.get('/sqlquery/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_queryapplylist(self):
+        """测试queryapplylist页面"""
+        data = {}
+        r = self.client.get('/queryapplylist/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_queryuserprivileges(self):
+        """测试queryuserprivileges页面"""
+        data = {}
+        r = self.client.get(f'/queryuserprivileges/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_sqladvisor(self):
+        """测试sqladvisor页面"""
+        data = {}
+        r = self.client.get(f'/sqladvisor/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_slowquery(self):
+        """测试slowquery页面"""
+        data = {}
+        r = self.client.get(f'/slowquery/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_instance(self):
+        """测试instance页面"""
+        data = {}
+        r = self.client.get(f'/instance/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_instanceaccount(self):
+        """测试instanceaccount页面"""
+        data = {}
+        r = self.client.get(f'/instanceaccount/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_database(self):
+        """测试database页面"""
+        data = {}
+        r = self.client.get(f'/database/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_dbdiagnostic(self):
+        """测试dbdiagnostic页面"""
+        data = {}
+        r = self.client.get(f'/dbdiagnostic/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_instanceparam(self):
+        """测试instance_param页面"""
+        data = {}
+        r = self.client.get(f'/instanceparam/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_binlog2sql(self):
+        """测试binlog2sql页面"""
+        data = {}
+        r = self.client.get(f'/binlog2sql/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_schemasync(self):
+        """测试schemasync页面"""
+        data = {}
+        r = self.client.get(f'/schemasync/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_archive(self):
+        """测试archive页面"""
+        data = {}
+        r = self.client.get(f'/archive/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_config(self):
+        """测试config页面"""
+        data = {}
+        r = self.client.get(f'/config/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_group(self):
+        """测试group页面"""
+        data = {}
+        r = self.client.get(f'/group/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_groupmgmt(self):
+        """测试groupmgmt页面"""
+        data = {}
+        r = self.client.get(f'/grouprelations/{self.res_group.group_id}/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_workflows(self):
+        """测试workflows页面"""
+        data = {}
+        r = self.client.get(f'/workflow/', data=data)
+        self.assertEqual(r.status_code, 200)
+
+    def test_workflowsdetail(self):
+        """测试workflows页面"""
+        data = {}
+        r = self.client.get(f'/workflow/{self.audit.audit_id}/', data=data)
+        self.assertRedirects(r, f'/queryapplydetail/1/', fetch_redirect_response=False)
+
+    def test_dbaprinciples(self):
+        """测试workflows页面"""
+        data = {}
+        r = self.client.get(f'/dbaprinciples/', data=data)
+        self.assertEqual(r.status_code, 200)
 
 
 class TestSignUp(TestCase):
@@ -1438,6 +1659,230 @@ class TestSchemaSync(TestCase):
         self.assertEqual(json.loads(r.content)['status'], 0)
 
 
+class TestArchiver(TestCase):
+    """
+    测试Archive
+    """
+
+    def setUp(self):
+        self.superuser = User.objects.create(username='super', is_superuser=True)
+        self.u1 = User.objects.create(username='u1', is_superuser=False)
+        self.u2 = User.objects.create(username='u2', is_superuser=False)
+        menu_archive = Permission.objects.get(codename='menu_archive')
+        archive_review = Permission.objects.get(codename='archive_review')
+        self.u1.user_permissions.add(menu_archive)
+        self.u2.user_permissions.add(menu_archive)
+        self.u2.user_permissions.add(archive_review)
+        # 使用 travis.ci 时实例和测试service保持一致
+        self.ins = Instance.objects.create(instance_name='test_instance', type='master', db_type='mysql',
+                                           host=settings.DATABASES['default']['HOST'],
+                                           port=settings.DATABASES['default']['PORT'],
+                                           user=settings.DATABASES['default']['USER'],
+                                           password=settings.DATABASES['default']['PASSWORD'])
+        self.res_group = ResourceGroup.objects.create(group_id=1, group_name='group_name')
+        self.archive_apply = ArchiveConfig.objects.create(
+            title='title',
+            resource_group=self.res_group,
+            audit_auth_groups='some_audit_group',
+            src_instance=self.ins,
+            src_db_name='src_db_name',
+            src_table_name='src_table_name',
+            dest_instance=self.ins,
+            dest_db_name='src_db_name',
+            dest_table_name='src_table_name',
+            condition='1=1',
+            mode='file',
+            no_delete=True,
+            sleep=1,
+            status=WorkflowDict.workflow_status['audit_wait'],
+            state=False,
+            user_name='some_user',
+            user_display='display',
+        )
+        self.sys_config = SysConfig()
+        self.client = Client()
+
+    def tearDown(self):
+        User.objects.all().delete()
+        ResourceGroup.objects.all().delete()
+        ArchiveConfig.objects.all().delete()
+        WorkflowAuditSetting.objects.all().delete()
+        self.ins.delete()
+        self.sys_config.purge()
+
+    def test_archive_list_super(self):
+        """
+        测试管理员获取归档申请列表
+        :return:
+        """
+        data = {"filter_instance_id": self.ins.id,
+                "state": 'false',
+                "search": "text"}
+        self.client.force_login(self.superuser)
+        r = self.client.get(path='/archive/list/', data=data)
+        self.assertDictEqual(json.loads(r.content), {"total": 0, "rows": []})
+
+    def test_archive_list_own(self):
+        """
+        测试非管理员和审核人获取归档申请列表
+        :return:
+        """
+        data = {"filter_instance_id": self.ins.id,
+                "state": 'false',
+                "search": "text"}
+        self.client.force_login(self.u1)
+        r = self.client.get(path='/archive/list/', data=data)
+        self.assertDictEqual(json.loads(r.content), {"total": 0, "rows": []})
+
+    def test_archive_list_review(self):
+        """
+        测试审核人获取归档申请列表
+        :return:
+        """
+        data = {"filter_instance_id": self.ins.id,
+                "state": 'false',
+                "search": "text"}
+        self.client.force_login(self.u2)
+        r = self.client.get(path='/archive/list/', data=data)
+        self.assertDictEqual(json.loads(r.content), {"total": 0, "rows": []})
+
+    def test_archive_apply_not_param(self):
+        """
+        测试申请归档实例数据，参数不完整
+        :return:
+        """
+        data = {
+            "group_name": self.res_group.group_name,
+            "src_instance_name": self.ins.instance_name,
+            "src_db_name": 'src_db_name',
+            "src_table_name": 'src_table_name',
+            "mode": 'dest',
+            "dest_instance_name": self.ins.instance_name,
+            "dest_db_name": 'dest_db_name',
+            "dest_table_name": 'dest_table_name',
+            "condition": '1=1',
+            "no_delete": 'true',
+            "sleep": 10
+        }
+        self.client.force_login(self.superuser)
+        r = self.client.post(path='/archive/apply/', data=data)
+        self.assertDictEqual(json.loads(r.content), {'status': 1, 'msg': '请填写完整！', 'data': {}})
+
+    def test_archive_apply_not_dest_param(self):
+        """
+        测试申请归档实例数据，目标实例不完整
+        :return:
+        """
+        data = {
+            "title": 'title',
+            "group_name": self.res_group.group_name,
+            "src_instance_name": self.ins.instance_name,
+            "src_db_name": 'src_db_name',
+            "src_table_name": 'src_table_name',
+            "mode": 'dest',
+            "condition": '1=1',
+            "no_delete": 'true',
+            "sleep": 10
+        }
+        self.client.force_login(self.superuser)
+        r = self.client.post(path='/archive/apply/', data=data)
+        self.assertDictEqual(json.loads(r.content), {'status': 1, 'msg': '归档到实例时目标实例信息必选！', 'data': {}})
+
+    def test_archive_apply_not_exist_review(self):
+        """
+        测试申请归档实例数据，未配置审批流程
+        :return:
+        """
+        data = {"title": 'title',
+                "group_name": self.res_group.group_name,
+                "src_instance_name": self.ins.instance_name,
+                "src_db_name": 'src_db_name',
+                "src_table_name": 'src_table_name',
+                "mode": 'dest',
+                "dest_instance_name": self.ins.instance_name,
+                "dest_db_name": 'dest_db_name',
+                "dest_table_name": 'dest_table_name',
+                "condition": '1=1',
+                "no_delete": 'true',
+                "sleep": 10
+                }
+        self.client.force_login(self.superuser)
+        r = self.client.post(path='/archive/apply/', data=data)
+        self.assertDictEqual(json.loads(r.content), {'data': {}, 'msg': '审批流程不能为空，请先配置审批流程', 'status': 1})
+
+    @patch('sql.archiver.async_task')
+    def test_archive_apply(self, _async_task):
+        """
+        测试申请归档实例数据
+        :return:
+        """
+        WorkflowAuditSetting.objects.create(workflow_type=3, group_id=1, audit_auth_groups='1')
+        data = {"title": 'title',
+                "group_name": self.res_group.group_name,
+                "src_instance_name": self.ins.instance_name,
+                "src_db_name": 'src_db_name',
+                "src_table_name": 'src_table_name',
+                "mode": 'dest',
+                "dest_instance_name": self.ins.instance_name,
+                "dest_db_name": 'dest_db_name',
+                "dest_table_name": 'dest_table_name',
+                "condition": '1=1',
+                "no_delete": 'true',
+                "sleep": 10
+                }
+        self.client.force_login(self.superuser)
+        r = self.client.post(path='/archive/apply/', data=data)
+        self.assertEqual(json.loads(r.content)['status'], 0)
+
+    @patch('sql.archiver.Audit')
+    @patch('sql.archiver.async_task')
+    def test_archive_audit(self, _async_task, _audit):
+        """
+        测试审核归档实例数据
+        :return:
+        """
+        _audit.detail_by_workflow_id.return_value.audit_id = 1
+        _audit.audit.return_value = {'status': 0, 'msg': 'ok', 'data': {'workflow_status': 1}}
+        data = {
+            "archive_id": self.archive_apply.id,
+            "audit_status": WorkflowDict.workflow_status['audit_success'],
+            "audit_remark": 'xxxx'
+        }
+        self.client.force_login(self.superuser)
+        r = self.client.post(path='/archive/audit/', data=data)
+        self.assertRedirects(r, f'/archive/{self.archive_apply.id}/', fetch_redirect_response=False)
+
+    @patch('sql.archiver.async_task')
+    def test_add_archive_task(self, _async_task):
+        """
+        测试添加异步归档任务
+        :return:
+        """
+        add_archive_task()
+
+    @patch('sql.archiver.async_task')
+    def test_add_archive(self, _async_task):
+        """
+        测试执行归档任务
+        :return:
+        """
+        with self.assertRaises(Exception):
+            archive(self.archive_apply.id)
+
+    @patch('sql.archiver.async_task')
+    def test_add_archive(self, _async_task):
+        """
+        测试获取归档日志
+        :return:
+        """
+        data = {
+            "archive_id": self.archive_apply.id,
+        }
+        self.client.force_login(self.superuser)
+        r = self.client.post(path='/archive/log/', data=data)
+        self.assertDictEqual(json.loads(r.content), {"total": 0, "rows": []})
+
+
 class TestAsync(TestCase):
 
     def setUp(self):
@@ -2152,7 +2597,7 @@ class TestNotify(TestCase):
         self.wf.save()
         r = notify_for_execute(self.wf)
         self.assertIsNone(r)
-        _msg_sender.assert_called_once()
+        _msg_sender.assert_called()
 
     @patch('sql.notify.MsgSender')
     def test_notify_for_binlog2sql_disable(self, _msg_sender):

--- a/sql/urls.py
+++ b/sql/urls.py
@@ -8,7 +8,7 @@ import sql.query_privileges
 import sql.sql_optimize
 from common import auth, config, workflow, dashboard, check
 from sql import views, sql_workflow, sql_analyze, query, slowlog, instance, instance_account, db_diagnostic, \
-    resource_group, binlog, data_dictionary
+    resource_group, binlog, data_dictionary, archiver
 from sql.utils import tasks
 from common.utils import ding_api
 
@@ -52,6 +52,8 @@ urlpatterns = [
     path('instanceparam/', views.instance_param),
     path('binlog2sql/', views.binlog2sql),
     path('schemasync/', views.schemasync),
+    path('archive/', views.archive),
+    path('archive/<int:id>/', views.archive_detail, name='archive_detail'),
     path('config/', views.config),
 
     path('authenticate/', auth.authenticate_entry),
@@ -137,6 +139,11 @@ urlpatterns = [
     path('db_diagnostic/tablesapce/', db_diagnostic.tablesapce),
     path('db_diagnostic/trxandlocks/', db_diagnostic.trxandlocks),
     path('db_diagnostic/innodb_trx/', db_diagnostic.innodb_trx),
+
+    path('archive/list/', archiver.archive_list),
+    path('archive/apply/', archiver.archive_apply),
+    path('archive/audit/', archiver.archive_audit),
+    path('archive/log/', archiver.archive_log),
 
     path('4admin/sync_ding_user/', ding_api.sync_ding_user)
 ]

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -6,7 +6,7 @@ from sql.utils.resource_group import user_groups, auth_group_users
 from sql.utils.sql_review import is_auto_review
 from common.utils.const import WorkflowDict
 from sql.models import WorkflowAudit, WorkflowAuditDetail, WorkflowAuditSetting, WorkflowLog, ResourceGroup, \
-    SqlWorkflow, QueryPrivilegesApply, Users
+    SqlWorkflow, QueryPrivilegesApply, Users, ArchiveConfig
 from common.config import SysConfig
 
 
@@ -40,6 +40,15 @@ class Audit(object):
             group_name = workflow_detail.group_name
             create_user = workflow_detail.engineer
             create_user_display = workflow_detail.engineer_display
+            audit_auth_groups = workflow_detail.audit_auth_groups
+            workflow_remark = ''
+        elif workflow_type == WorkflowDict.workflow_type['archive']:
+            workflow_detail = ArchiveConfig.objects.get(pk=workflow_id)
+            workflow_title = workflow_detail.title
+            group_id = workflow_detail.resource_group.group_id
+            group_name = workflow_detail.resource_group.group_name
+            create_user = workflow_detail.user_name
+            create_user_display = workflow_detail.user_display
             audit_auth_groups = workflow_detail.audit_auth_groups
             workflow_remark = ''
         else:
@@ -329,6 +338,9 @@ class Audit(object):
                         result = True
                 elif workflow_type == 2:
                     if user.has_perm('sql.sql_review'):
+                        result = True
+                elif workflow_type == 3:
+                    if user.has_perm('sql.archive_review'):
                         result = True
         return result
 

--- a/src/docker/Dockerfile-base
+++ b/src/docker/Dockerfile-base
@@ -41,6 +41,7 @@ RUN yum -y install libffi-devel wget gcc make zlib-devel openssl openssl-devel n
     && yum -y install cmake bison gcc-c++ git mysql-devel libaio-devel  glib2 glib2-devel \
     && yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm \
     && yum -y install Percona-Server-devel-56 Percona-Server-shared-56  Percona-Server-client-56 \
+    && yum -y install percona-toolkit \
     && cd /opt \
     && git clone https://github.com/hhyo/SQLAdvisor.git --depth 3 \
     && cd /opt/SQLAdvisor/ \

--- a/src/init_sql/v1.7.4_v1.7.5.sql
+++ b/src/init_sql/v1.7.4_v1.7.5.sql
@@ -1,0 +1,61 @@
+-- 增加归档相关权限
+set @content_type_id=(select id from django_content_type where app_label='sql' and model='permission');
+insert IGNORE INTO auth_permission (name, content_type_id, codename) VALUES
+('菜单 数据归档', @content_type_id, 'menu_archive'),
+('提交归档申请', @content_type_id, 'archive_apply'),
+('审核归档申请', @content_type_id, 'archive_audit');
+
+-- 归档配置表
+CREATE TABLE `archive_config` (
+  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `title` varchar(50) NOT NULL COMMENT '归档配置说明',
+  `resource_group_id` int(11) NOT NULL COMMENT '资源组',
+  `audit_auth_groups` varchar(255) NOT NULL COMMENT '审批权限组列表',
+  `src_instance_id` int(11) NOT NULL COMMENT '源实例',
+  `src_db_name` varchar(64) NOT NULL COMMENT '源数据库',
+  `src_table_name` varchar(64) NOT NULL COMMENT '源表',
+  `dest_instance_id` int(11) DEFAULT NULL COMMENT '目标实例',
+  `dest_db_name` varchar(64) DEFAULT NULL COMMENT '目标数据库',
+  `dest_table_name` varchar(64) DEFAULT NULL COMMENT '目标表',
+  `condition` varchar(1000) NOT NULL COMMENT '归档条件，where条件',
+  `mode` varchar(10) NOT NULL COMMENT '归档模式',
+  `no_delete` tinyint(1) NOT NULL COMMENT '是否保留源数据',
+  `sleep` int(11) NOT NULL COMMENT '归档limit行记录后的休眠秒数',
+  `status` int(11) NOT NULL COMMENT '审核状态',
+  `state` tinyint(1) NOT NULL COMMENT '是否启用归档',
+  `user_name` varchar(30) NOT NULL COMMENT '申请人',
+  `user_display` varchar(50) NOT NULL COMMENT '申请人中文名',
+  `create_time` datetime(6) NOT NULL COMMENT '创建时间',
+  `last_archive_time` datetime(6) DEFAULT NULL COMMENT '最近归档时间',
+  `sys_time` datetime(6) NOT NULL COMMENT '系统时间修改',
+  PRIMARY KEY (`id`),
+  KEY `idx_dest_instance_id` (`dest_instance_id`),
+  KEY `idx_resource_group_id` (`resource_group_id`),
+  KEY `idx_src_instance_id` (`src_instance_id`),
+  CONSTRAINT `fk_archive_instance_id` FOREIGN KEY (`dest_instance_id`) REFERENCES `sql_instance` (`id`),
+  CONSTRAINT `fk_archive_resource_id` FOREIGN KEY (`resource_group_id`) REFERENCES `resource_group` (`group_id`),
+  CONSTRAINT `fk_archive_instance_id` FOREIGN KEY (`src_instance_id`) REFERENCES `sql_instance` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT '归档配置表';
+
+-- 归档日志表
+CREATE TABLE `archive_log` (
+  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `archive_id` int(11) NOT NULL COMMENT '归档配置ID',
+  `cmd` varchar(2000) NOT NULL COMMENT '归档命令',
+  `condition` varchar(1000) NOT NULL COMMENT '归档条件',
+  `mode` varchar(10) NOT NULL COMMENT '归档模式',
+  `no_delete` tinyint(1) NOT NULL COMMENT '是否保留源数据',
+  `sleep` int(11) NOT NULL COMMENT '归档limit行记录后的休眠秒数',
+  `select_cnt` int(11) NOT NULL COMMENT '查询数量',
+  `insert_cnt` int(11) NOT NULL COMMENT '插入数量',
+  `delete_cnt` int(11) NOT NULL COMMENT '删除数量',
+  `statistics` longtext NOT NULL COMMENT '归档统计日志',
+  `success` tinyint(1) NOT NULL COMMENT '是否归档成功',
+  `error_info` longtext NOT NULL COMMENT '错误信息',
+  `start_time` datetime(6) NOT NULL COMMENT '开始时间',
+  `end_time` datetime(6) NOT NULL COMMENT '结束时间',
+  `sys_time` datetime(6) NOT NULL COMMENT '系统时间修改',
+  PRIMARY KEY (`id`),
+  KEY `idx_archive_id` (`archive_id`),
+  CONSTRAINT `fk_archive_config_id` FOREIGN KEY (`archive_id`) REFERENCES `archive_config` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT '归档日志表';


### PR DESCRIPTION
必须要安装percona-tools工具，同时没有可执行文件路径配置项，需要添加到全局变量中

- 在工具插件模块下新增PTArchiver菜单
- 工作流类型新增【数据归档申请】
- 支持提交数据归档申请，审核通过后即可变更为有效的归档配置
- 在后台增加Scheduled Task，func设置为`sql.archiver.add_archive_task`即可按照配置定时归档数据，并在归档配置详情查看详细归档日志
- 优化消息发送的处理，简化调用
