### PR TITLE
调整资源组和实例标签的多对多模型，使用Django默认的中间表

### DIFF
--- a/archery/__init__.py
+++ b/archery/__init__.py
@@ -1,2 +1,2 @@
-version = (1, 7, 6)
+version = (1, 7, 7)
 display_version = '.'.join(str(i) for i in version)

--- a/common/auth.py
+++ b/common/auth.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 
 from common.config import SysConfig
 from common.utils.ding_api import get_ding_user_id
-from sql.models import Users, ResourceGroup,ResourceGroup2User
+from sql.models import Users, ResourceGroup
 
 logger = logging.getLogger('default')
 
@@ -35,9 +35,7 @@ def init_user(user):
     default_resource_group = SysConfig().get('default_resource_group', '')
     if default_resource_group:
         try:
-            ResourceGroup2User.objects.get_or_create(
-                user_id=user.id,
-                resource_group_id=ResourceGroup.objects.get(group_name=default_resource_group).group_id)
+            user.resource_group.add(ResourceGroup.objects.get(group_name=default_resource_group))
         except ResourceGroup.DoesNotExist:
             logger.info(f'无name为[{default_resource_group}]的资源组，无法默认关联，请到系统设置进行配置')
 

--- a/common/tests.py
+++ b/common/tests.py
@@ -491,7 +491,7 @@ class AuthTest(TestCase):
     def test_init_user(self):
         """用户初始化测试测试"""
         init_user(self.u1)
-        self.assertEqual(self.u1, self.resource_group1.users.get(pk=self.u1.pk))
+        self.assertEqual(self.u1, self.resource_group1.users_set.get(pk=self.u1.pk))
         # init 需要是无状态的, 可以重复执行, 执行一次和执行n次结果一样
         init_user(self.u1)
-        self.assertEqual(self.u1, self.resource_group1.users.get(pk=self.u1.pk))
+        self.assertEqual(self.u1, self.resource_group1.users_set.get(pk=self.u1.pk))

--- a/sql/admin.py
+++ b/sql/admin.py
@@ -4,9 +4,9 @@ from django.contrib.auth.admin import UserAdmin
 
 # Register your models here.
 from .models import Users, Instance, SqlWorkflow, SqlWorkflowContent, QueryLog, DataMaskingColumns, DataMaskingRules, \
-    AliyunRdsConfig, ResourceGroup, ResourceGroup2User, ResourceGroup2Instance, QueryPrivilegesApply, \
+    AliyunRdsConfig, ResourceGroup, QueryPrivilegesApply, \
     QueryPrivileges, InstanceAccount, InstanceDatabase, ArchiveConfig, \
-    WorkflowAudit, WorkflowLog, ParamTemplate, ParamHistory, InstanceTag, InstanceTagRelations
+    WorkflowAudit, WorkflowLog, ParamTemplate, ParamHistory, InstanceTag
 
 
 # 用户管理
@@ -21,20 +21,17 @@ class UsersAdmin(UserAdmin):
         ('认证信息', {'fields': ('username', 'password')}),
         ('个人信息', {'fields': ('display', 'email', 'ding_user_id', 'wx_user_id')}),
         ('权限信息', {'fields': ('is_superuser', 'is_active', 'is_staff', 'groups', 'user_permissions')}),
-        ('其他信息', {'fields': ('date_joined',)}),
+        ('资源组', {'fields': ('resource_group',)}),
     )
     # 添加页显示内容
     add_fieldsets = (
         ('认证信息', {'fields': ('username', 'password1', 'password2')}),
         ('个人信息', {'fields': ('display', 'email')}),
-        ('权限信息', {'fields': ('is_superuser', 'is_active', 'is_staff', 'groups',)}),
+        ('权限信息', {'fields': ('is_superuser', 'is_active', 'is_staff', 'groups', 'user_permissions')}),
+        ('资源组', {'fields': ('resource_group',)}),
     )
-
-    # 用户资源组关联配置
-    class ResourceGroup2UserInline(admin.TabularInline):
-        model = ResourceGroup2User
-
-    inlines = [ResourceGroup2UserInline]
+    filter_horizontal = ('groups', 'user_permissions', 'resource_group')
+    list_filter = ('is_staff', 'is_superuser', 'is_active', 'groups', 'resource_group')
 
 
 # 资源组管理
@@ -42,18 +39,6 @@ class UsersAdmin(UserAdmin):
 class ResourceGroupAdmin(admin.ModelAdmin):
     list_display = ('group_id', 'group_name', 'ding_webhook', 'is_deleted')
     exclude = ('group_parent_id', 'group_sort', 'group_level',)
-
-
-# 资源组关联用户关系管理
-@admin.register(ResourceGroup2User)
-class ResourceGroup2UserAdmin(admin.ModelAdmin):
-    list_display = ('id', 'resource_group', 'user', 'create_time')
-
-
-# 资源组关联实例关系管理
-@admin.register(ResourceGroup2Instance)
-class ResourceGroup2InstanceAdmin(admin.ModelAdmin):
-    list_display = ('id', 'resource_group', 'instance', 'create_time')
 
 
 # 实例标签配置
@@ -68,33 +53,21 @@ class InstanceTagAdmin(admin.ModelAdmin):
         return ('tag_code',) if obj else ()
 
 
-# 实例标签关系配置
-@admin.register(InstanceTagRelations)
-class InstanceTagRelationsAdmin(admin.ModelAdmin):
-    list_display = ('instance', 'instance_tag', 'active', 'create_time')
-    list_filter = ('instance', 'instance_tag', 'active')
-
-
 # 实例管理
 @admin.register(Instance)
 class InstanceAdmin(admin.ModelAdmin):
     list_display = ('id', 'instance_name', 'db_type', 'type', 'host', 'port', 'user', 'create_time')
     search_fields = ['instance_name', 'host', 'port', 'user']
-    list_filter = ('db_type', 'type')
+    list_filter = ('db_type', 'type', 'instance_tag')
 
     # 阿里云实例关系配置
     class AliRdsConfigInline(admin.TabularInline):
         model = AliyunRdsConfig
 
-    # 实例标签关系配置
-    class InstanceTagRelationsInline(admin.TabularInline):
-        model = InstanceTagRelations
-
     # 实例资源组关联配置
-    class ResourceGroup2InstanceInline(admin.TabularInline):
-        model = ResourceGroup2Instance
+    filter_horizontal = ('resource_group', 'instance_tag',)
 
-    inlines = [InstanceTagRelationsInline, ResourceGroup2InstanceInline, AliRdsConfigInline]
+    inlines = [AliRdsConfigInline]
 
 
 # SQL工单内容

--- a/sql/admin.py
+++ b/sql/admin.py
@@ -22,6 +22,7 @@ class UsersAdmin(UserAdmin):
         ('个人信息', {'fields': ('display', 'email', 'ding_user_id', 'wx_user_id')}),
         ('权限信息', {'fields': ('is_superuser', 'is_active', 'is_staff', 'groups', 'user_permissions')}),
         ('资源组', {'fields': ('resource_group',)}),
+        ('其他信息', {'fields': ('date_joined',)}),
     )
     # 添加页显示内容
     add_fieldsets = (

--- a/sql/instance.py
+++ b/sql/instance.py
@@ -42,9 +42,7 @@ def lists(request):
     # 过滤标签，返回同时包含全部标签的实例，TODO 循环会生成多表JOIN，如果数据量大会存在效率问题
     if tags:
         for tag in tags:
-            instances = instances.filter(instancetagrelations__instance_tag=tag,
-                                         instancetag__active=True,
-                                         instancetagrelations__active=True)
+            instances = instances.filter(instance_tag=tag, instance_tag__active=True)
 
     count = instances.count()
     instances = instances[offset:limit].values("id", "instance_name", "db_type", "type", "host", "port", "user")

--- a/sql/resource_group.py
+++ b/sql/resource_group.py
@@ -9,7 +9,7 @@ from django.db.models import F, Value, IntegerField
 from django.http import HttpResponse
 from common.utils.extend_json_encoder import ExtendJSONEncoder
 from common.utils.permission import superuser_required
-from sql.models import ResourceGroup, ResourceGroup2Instance, ResourceGroup2User, Users, Instance
+from sql.models import ResourceGroup, Users, Instance
 from sql.utils.resource_group import user_instances
 from sql.utils.workflow_audit import Audit
 
@@ -49,32 +49,33 @@ def associated_objects(request):
     offset = int(request.POST.get('offset'))
     limit = offset + limit
     search = request.POST.get('search')
-    rows_users = ResourceGroup2User.objects.filter(resource_group__group_id=group_id)
-    rows_instances = ResourceGroup2Instance.objects.filter(resource_group__group_id=group_id)
+
+    # 获取关联数据
+    resource_group = ResourceGroup.objects.get(group_id=group_id)
+    rows_users = resource_group.users_set.all().filter()
+    rows_instances = resource_group.instance_set.all()
     # 过滤搜索
     if search:
-        rows_users = rows_users.filter(user__display__contains=search)
-        rows_instances = rows_instances.filter(instance__instance_name__contains=search)
+        rows_users = rows_users.filter(display__contains=search)
+        rows_instances = rows_instances.filter(instance_name__contains=search)
     rows_users = rows_users.annotate(
-        object_id=F('user_id'),
+        object_id=F('id'),
         object_type=Value(0, output_field=IntegerField()),
-        object_name=F('user__display'),
+        object_name=F('display'),
         group_id=F('resource_group__group_id'),
         group_name=F('resource_group__group_name')
     ).values(
-        'id',
         'object_type', 'object_id', 'object_name',
-        'group_id', 'group_name', 'create_time')
+        'group_id', 'group_name')
     rows_instances = rows_instances.annotate(
-        object_id=F('instance_id'),
+        object_id=F('id'),
         object_type=Value(1, output_field=IntegerField()),
-        object_name=F('instance__instance_name'),
+        object_name=F('instance_name'),
         group_id=F('resource_group__group_id'),
         group_name=F('resource_group__group_name')
     ).values(
-        'id',
         'object_type', 'object_id', 'object_name',
-        'group_id', 'group_name', 'create_time')
+        'group_id', 'group_name')
     # 过滤对象类型
     if object_type == '0':
         rows_obj = rows_users
@@ -99,16 +100,14 @@ def unassociated_objects(request):
     """
     group_id = int(request.POST.get('group_id'))
     object_type = int(request.POST.get('object_type'))
+    # 获取关联数据
+    resource_group = ResourceGroup.objects.get(group_id=group_id)
     if object_type == 0:
-        associated_user_ids = [user['user_id'] for user in
-                               ResourceGroup2User.objects.filter(
-                                   resource_group_id=group_id).values('user_id')]
+        associated_user_ids = [user.id for user in resource_group.users_set.all()]
         rows = Users.objects.exclude(pk__in=associated_user_ids).annotate(
             object_id=F('pk'), object_name=F('display')).values('object_id', 'object_name')
     elif object_type == 1:
-        associated_instance_ids = [ins['instance_id'] for ins in
-                                   ResourceGroup2Instance.objects.filter(
-                                       resource_group_id=group_id).values('instance_id')]
+        associated_instance_ids = [ins.id for ins in resource_group.instance_set.all()]
         rows = Instance.objects.exclude(pk__in=associated_instance_ids).annotate(
             object_id=F('pk'), object_name=F('instance_name')
         ).values('object_id', 'object_name')
@@ -136,9 +135,8 @@ def instances(request):
     if db_type:
         filter_dict['db_type'] = db_type
     if tag_code:
-        filter_dict['instancetag__tag_code'] = tag_code
-        filter_dict['instancetag__active'] = True
-        filter_dict['instancetagrelations__active'] = True
+        filter_dict['instance_tag__tag_code'] = tag_code
+        filter_dict['instance_tag__active'] = True
     ins = ins.filter(**filter_dict).values('id', 'type', 'db_type', 'instance_name')
     rows = [row for row in ins]
     result = {'status': 0, 'msg': 'ok', "data": rows}
@@ -167,16 +165,12 @@ def addrelation(request):
     object_type = request.POST.get('object_type')
     object_list = json.loads(request.POST.get('object_info'))
     try:
+        resource_group = ResourceGroup.objects.get(group_id=group_id)
+        obj_ids = [int(obj.split(',')[0]) for obj in object_list]
         if object_type == '0':  # 用户
-            ResourceGroup2User.objects.bulk_create(
-                [ResourceGroup2User(
-                    user_id=int(obj.split(',')[0]), resource_group_id=group_id
-                ) for obj in object_list])
+            resource_group.users_set.add(*Users.objects.filter(pk__in=obj_ids))
         elif object_type == '1':  # 实例
-            ResourceGroup2Instance.objects.bulk_create(
-                [ResourceGroup2Instance(
-                    instance_id=int(obj.split(',')[0]), resource_group_id=group_id
-                ) for obj in object_list])
+            resource_group.instance_set.add(*Instance.objects.filter(pk__in=obj_ids))
         result = {'status': 0, 'msg': 'ok'}
     except Exception as e:
         logger.error(traceback.format_exc())

--- a/sql/resource_group.py
+++ b/sql/resource_group.py
@@ -52,7 +52,7 @@ def associated_objects(request):
 
     # 获取关联数据
     resource_group = ResourceGroup.objects.get(group_id=group_id)
-    rows_users = resource_group.users_set.all().filter()
+    rows_users = resource_group.users_set.all()
     rows_instances = resource_group.instance_set.all()
     # 过滤搜索
     if search:

--- a/sql/templates/groupmgmt.html
+++ b/sql/templates/groupmgmt.html
@@ -149,28 +149,7 @@
                 }, {
                     title: '资源组',
                     field: 'group_name'
-                }, {
-                    title: '关联时间',
-                    field: 'create_time'
                 }
-                    , {
-                        title: '操作',
-                        field: '',
-                        formatter: function (value, row, index) {
-                            switch (row.object_type) {
-                                case 0:
-                                    return "<button class=\"btn btn-danger btn-xs\" " +
-                                        "onclick=\"window.location.href='/admin/sql/resourcegroup2user/" + row.id + "/delete/'\" >删除</button>\n"
-                                    break;
-                                case 1:
-                                    return "<button class=\"btn btn-danger btn-xs\" " +
-                                        "onclick=\"window.location.href='/admin/sql/resourcegroup2instance/" + row.id + "/delete/'\" >删除</button>\n"
-                                    break;
-                                default:
-                                    return "未知"
-                            }
-                        }
-                    }
                 ],
                 onLoadSuccess: function () {
                 },

--- a/sql/utils/resource_group.py
+++ b/sql/utils/resource_group.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 
-from sql.models import Users, Instance, ResourceGroup, ResourceGroup2Instance
+from sql.models import Users, Instance, ResourceGroup
 
 
 def user_groups(user):
@@ -12,7 +12,7 @@ def user_groups(user):
     if user.is_superuser:
         group_list = [group for group in ResourceGroup.objects.filter(is_deleted=0)]
     else:
-        group_list = [group for group in Users.objects.get(id=user.id).resourcegroup_set.filter(is_deleted=0)]
+        group_list = [group for group in Users.objects.get(id=user.id).resource_group.filter(is_deleted=0)]
     return group_list
 
 
@@ -31,10 +31,8 @@ def user_instances(user, type=None, db_type=None, tag_codes=None):
     else:
         # 先获取用户关联的资源组
         resource_groups = ResourceGroup.objects.filter(users=user, is_deleted=0)
-        # 再获取资源组和实例的关联关系
-        resource_group2instance = ResourceGroup2Instance.objects.filter(resource_group__in=resource_groups)
         # 再获取实例
-        instances = Instance.objects.filter(resourcegroup2instance__in=resource_group2instance)
+        instances = Instance.objects.filter(resource_group__in=resource_groups)
     # 过滤type
     if type:
         instances = instances.filter(type=type)
@@ -46,10 +44,7 @@ def user_instances(user, type=None, db_type=None, tag_codes=None):
     # 过滤tag
     if tag_codes:
         for tag_code in tag_codes:
-            instances = instances.filter(instancetag__tag_code=tag_code,
-                                         instancetag__active=True,
-                                         instancetagrelations__active=True)
-
+            instances = instances.filter(instance_tag__tag_code=tag_code, instance_tag__active=True)
     return instances.distinct()
 
 
@@ -61,7 +56,7 @@ def auth_group_users(auth_group_names, group_id):
     :return:
     """
     # 获取资源组关联的用户
-    users = ResourceGroup.objects.get(group_id=group_id).users.all()
+    users = ResourceGroup.objects.get(group_id=group_id).users_set.all()
     # 过滤在该权限组中的用户
     users = users.filter(groups__name__in=auth_group_names)
     return users

--- a/sql/utils/sql_review.py
+++ b/sql/utils/sql_review.py
@@ -18,7 +18,7 @@ def is_auto_review(workflow_id):
     workflow = SqlWorkflow.objects.get(id=workflow_id)
     auto_review_tags = SysConfig().get('auto_review_tag', '').split(',')
     # TODO 这里也可以放到engine中实现，但是配置项可能会相对复杂
-    if workflow.instance.db_type == 'mysql' and workflow.instance.instancetag_set.filter(
+    if workflow.instance.db_type == 'mysql' and workflow.instance.instance_tag.filter(
             tag_code__in=auto_review_tags).exists():
         # 获取正则表达式
         auto_review_regex = SysConfig().get('auto_review_regex',

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -1040,7 +1040,7 @@ class TestAudit(TestCase):
 
     @patch('sql.utils.workflow_audit.auth_group_users')
     @patch('sql.utils.workflow_audit.Audit.detail_by_workflow_id')
-    def test_can_review_no_prem(self, _detail_by_workflow_id, _auth_group_users):
+    def test_can_review_no_prem_exception(self, _detail_by_workflow_id, _auth_group_users):
         """测试判断用户当前是否是可审核，权限组不存在"""
         Group.objects.create(name='auth_group')
         _detail_by_workflow_id.side_effect = RuntimeError()

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -10,7 +10,6 @@ import json
 from unittest.mock import patch, MagicMock
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission, Group
 from django.test import TestCase, Client
 from django_q.models import Schedule
@@ -18,9 +17,9 @@ from django_q.models import Schedule
 from common.config import SysConfig
 from common.utils.const import WorkflowDict
 from sql.engines.models import ReviewResult, ReviewSet
-from sql.models import SqlWorkflow, SqlWorkflowContent, Instance, ResourceGroup, ResourceGroup2User, \
-    ResourceGroup2Instance, WorkflowLog, WorkflowAudit, WorkflowAuditDetail, WorkflowAuditSetting, \
-    QueryPrivilegesApply, DataMaskingRules, DataMaskingColumns, InstanceTag, InstanceTagRelations, ArchiveConfig
+from sql.models import Users, SqlWorkflow, SqlWorkflowContent, Instance, ResourceGroup, \
+    WorkflowLog, WorkflowAudit, WorkflowAuditDetail, WorkflowAuditSetting, \
+    QueryPrivilegesApply, DataMaskingRules, DataMaskingColumns, InstanceTag, ArchiveConfig
 from sql.utils.resource_group import user_groups, user_instances, auth_group_users
 from sql.utils.sql_review import is_auto_review, can_execute, can_timingtask, can_cancel, on_correct_time_period
 from sql.utils.sql_utils import *
@@ -29,7 +28,7 @@ from sql.utils.tasks import add_sql_schedule, del_schedule, task_info
 from sql.utils.workflow_audit import Audit
 from sql.utils.data_masking import data_masking, brute_mask
 
-User = get_user_model()
+User = Users
 __author__ = 'hhyo'
 
 
@@ -227,9 +226,8 @@ class TestSQLReview(TestCase):
         self.wfc1.sql_content = "update table users set email='';"
         self.wfc1.save(update_fields=('sql_content',))
         # 修改工单实例标签
-        tag = InstanceTag.objects.get_or_create(tag_code='GA', defaults={'tag_name': '生产环境', 'active': True})
-        InstanceTagRelations.objects.get_or_create(instance=self.wf1.instance,
-                                                   defaults={'instance_tag': tag[0], 'active': True})
+        tag, is_created = InstanceTag.objects.get_or_create(tag_code='GA', defaults={'tag_name': '生产环境', 'active': True})
+        self.wf1.instance.instance_tag.add(tag)
         # mock返回值，update影响行数=3
         _execute_check.return_value.to_dict.return_value = [
             {"id": 1, "stage": "CHECKED", "errlevel": 0, "stagestatus": "Audit completed", "errormessage": "None",
@@ -252,7 +250,7 @@ class TestSQLReview(TestCase):
         self.wf1.save(update_fields=('status',))
         sql_execute_for_resource_group = Permission.objects.get(codename='sql_execute_for_resource_group')
         self.user.user_permissions.add(sql_execute_for_resource_group)
-        ResourceGroup2User.objects.create(user=self.user, resource_group=self.group)
+        self.user.resource_group.add(self.group)
         r = can_execute(user=self.user, workflow_id=self.wfc1.workflow_id)
         self.assertTrue(r)
 
@@ -1333,14 +1331,14 @@ class TestResourceGroup(TestCase):
 
     def test_user_groups(self):
         """获取用户关联资源组列表，普通用户"""
-        ResourceGroup2User.objects.create(resource_group=self.rgp1, user=self.user)
+        self.user.resource_group.add(self.rgp1)
         groups = user_groups(self.user)
         self.assertEqual(groups.__len__(), 1)
         self.assertIn(self.rgp1, groups)
 
     def test_user_instances_super(self):
         """获取用户实例列表，超级管理员"""
-        ResourceGroup2Instance.objects.create(resource_group=self.rgp1, instance=self.ins1)
+        self.ins1.resource_group.add(self.rgp1)
         ins = user_instances(self.su)
         self.assertEqual(ins.__len__(), 2)
         self.assertIn(self.ins1, ins)
@@ -1348,15 +1346,15 @@ class TestResourceGroup(TestCase):
 
     def test_user_instances_associated_group(self):
         """获取用户实例列表，普通用户关联资源组"""
-        ResourceGroup2User.objects.create(resource_group=self.rgp1, user=self.user)
-        ResourceGroup2Instance.objects.create(resource_group=self.rgp1, instance=self.ins1)
+        self.user.resource_group.add(self.rgp1)
+        self.ins1.resource_group.add(self.rgp1)
         ins = user_instances(self.user)
         self.assertEqual(ins.__len__(), 1)
         self.assertIn(self.ins1, ins)
 
     def test_user_instances_unassociated_group(self):
         """获取用户实例列表，普通用户未关联资源组"""
-        ResourceGroup2Instance.objects.create(resource_group=self.rgp1, instance=self.ins1)
+        self.ins1.resource_group.add(self.rgp1)
         ins = user_instances(self.user)
         self.assertEqual(ins.__len__(), 0)
 
@@ -1365,7 +1363,7 @@ class TestResourceGroup(TestCase):
         # 用户关联权限组
         self.user.groups.add(self.agp)
         # 用户关联资源组
-        ResourceGroup2User.objects.create(resource_group=self.rgp1, user=self.user)
+        self.user.resource_group.add(self.rgp1)
         # 获取资源组内关联指定权限组的用户
         users = auth_group_users(auth_group_names=[self.agp.name], group_id=self.rgp1.group_id)
         self.assertIn(self.user, users)

--- a/src/init_sql/v1.7.6_v1.7.7.sql
+++ b/src/init_sql/v1.7.6_v1.7.7.sql
@@ -1,0 +1,17 @@
+--  修改多对多的中间表
+alter table resource_group_user
+  rename to sql_users_resource_group,
+  drop create_time,
+  change user_id users_id int(11) NOT NULL COMMENT '用户',
+  change resource_group_id resourcegroup_id int(11) NOT NULL COMMENT '资源组';
+
+alter table resource_group_instance
+  rename to sql_instance_resource_group,
+  drop create_time,
+  change resource_group_id resourcegroup_id int(11) NOT NULL COMMENT '资源组';
+
+alter table sql_instance_tag_relations
+  rename to sql_instance_instance_tag,
+  drop `active`,
+  drop create_time,
+  change instance_tag_id instancetag_id int(11) NOT NULL COMMENT '关联标签ID';


### PR DESCRIPTION
相关pr：#162 #208 

调整模型配置，多对多的选择和权限组一致，配置更方便，也可以避免关联项过多时出现的效率问题
