### PR TITLE
修复common/utils/ding_api.py的get_access_token返回bytes导致钉钉url拼接不正确

### DIFF
--- a/common/utils/ding_api.py
+++ b/common/utils/ding_api.py
@@ -23,7 +23,7 @@ def get_access_token():
         logger.error(f"获取钉钉access_token缓存出错:{e}")
         access_token = None
     if access_token:
-        return access_token
+        return access_token.decode()
     # 请求钉钉接口获取
     sys_config = SysConfig()
     app_key = sys_config.get('ding_app_key')


### PR DESCRIPTION
从redis缓存中获取的数据为bytes类型,bytes类型格式化后为b'xxx', 导致dingding url拼接不正确，比如https://oapi.dingtalk.com/user/getDeptMember?access_token=b'sdfasdfsdf'&deptId=65464
。访问接口返回{'errcode': 40014, 'errmsg': '不合法的access_token'}