### PR TITLE
fix the template of inception and goinception

### DIFF
--- a/src/charts/charts/goinception/templates/deployment.yaml
+++ b/src/charts/charts/goinception/templates/deployment.yaml
@@ -33,13 +33,13 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: {{ (index .Values.volumes 0).name }}
+            - name: goinception-config-volume
               subPath: config.toml
               mountPath: /etc/config.toml
-       {{- with .Values.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}  
+        - name: goinception-config-volume
+          configMap:
+            name: goinception-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/src/charts/charts/goinception/templates/deployment.yaml
+++ b/src/charts/charts/goinception/templates/deployment.yaml
@@ -32,12 +32,10 @@ spec:
               port: goinception
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-         {{- with .Values.volumeMounts }}
           volumeMounts:
-            - name: goinception-config-volume
+            - name: {{ (index .Values.volumes 0).name }}
               subPath: config.toml
               mountPath: /etc/config.toml
-       {{- end }}
        {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/src/charts/charts/goinception/values.yaml
+++ b/src/charts/charts/goinception/values.yaml
@@ -155,7 +155,3 @@ tolerations: []
 
 affinity: {}
 
-volumes:
-  - name: goinception-config-volume
-    configMap:
-      name: goinception-config

--- a/src/charts/charts/inception/templates/deployment.yaml
+++ b/src/charts/charts/inception/templates/deployment.yaml
@@ -32,12 +32,10 @@ spec:
               port: inception
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-         {{- with .Values.volumeMounts }}
           volumeMounts:
-            - name: inception-config-volume
+            - name: {{ (index .Values.volumes 0).name }}
               subPath: inc.cnf
               mountPath: /etc/inc.cnf
-       {{- end }}
        {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/src/charts/charts/inception/templates/deployment.yaml
+++ b/src/charts/charts/inception/templates/deployment.yaml
@@ -33,13 +33,13 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: {{ (index .Values.volumes 0).name }}
+            - name: inception-config-volume
               subPath: inc.cnf
               mountPath: /etc/inc.cnf
-       {{- with .Values.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}      
+        - name: inception-config-volume
+          configMap:
+            name: inception-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/src/charts/charts/inception/values.yaml
+++ b/src/charts/charts/inception/values.yaml
@@ -75,8 +75,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-volumes:
-  - name: inception-config-volume
-    configMap:
-      name: inception-config


### PR DESCRIPTION
* inception 和 goinception 的 template 有点问题，因为 `values` 里没有定义 `volumeMounts` 会导致生成的 deployment 里其实没有把  configMap 挂载到 pod, 这样 configMap 就没法使用了
* 现在修复的方式是修改 with 使用的变量，并且动态匹配 volume 的 name 