### PR TITLE
解决工单重复执行的问题

### DIFF
--- a/common/static/dist/js/formatter.js
+++ b/common/static/dist/js/formatter.js
@@ -3,7 +3,9 @@ workflow_type = {
     'query': 1,
     'query_display': '查询权限申请',
     'sqlreview': 2,
-    'sqlreview_display': 'SQL上线申请'
+    'sqlreview_display': 'SQL上线申请',
+    'archive': 3,
+    'archive_display': '数据归档申请',
 }
 
 // 0.待审核 1.审核通过/等待执行 2.审核不通过 3.审核取消 101执行中，102执行成功，103执行失败
@@ -58,6 +60,9 @@ function workflow_type_formatter(value) {
     }
     else if (value === workflow_type.sqlreview) {
         return workflow_type.sqlreview_display
+    }
+    else if (value === workflow_type.archive) {
+        return workflow_type.archive_display
     }
     else {
         return '未知状态'

--- a/sql/engines/goinception.py
+++ b/sql/engines/goinception.py
@@ -13,6 +13,14 @@ logger = logging.getLogger('default')
 
 
 class GoInceptionEngine(EngineBase):
+    @property
+    def name(self):
+        return 'GoInception'
+
+    @property
+    def info(self):
+        return 'GoInception engine'
+
     def get_connection(self, db_name=None):
         if self.conn:
             return self.conn
@@ -94,7 +102,7 @@ class GoInceptionEngine(EngineBase):
                 break
         return execute_result
 
-    def query(self, db_name=None, sql='', limit_num=0, close_conn=True):
+    def query(self, db_name=None, sql='', limit_num=0, close_conn=True, **kwargs):
         """返回 ResultSet """
         result_set = ResultSet(full_sql=sql)
         conn = self.get_connection()

--- a/sql/engines/inception.py
+++ b/sql/engines/inception.py
@@ -15,6 +15,14 @@ logger = logging.getLogger('default')
 
 
 class InceptionEngine(EngineBase):
+    @property
+    def name(self):
+        return 'Inception'
+
+    @property
+    def info(self):
+        return 'Inception engine'
+
     def get_connection(self, db_name=None):
         if self.conn:
             return self.conn
@@ -47,27 +55,6 @@ class InceptionEngine(EngineBase):
     def execute_check(self, instance=None, db_name=None, sql=''):
         """inception check"""
         check_result = ReviewSet(full_sql=sql)
-        # 检查 inception 不支持的函数
-        check_result.rows = []
-        line = 1
-        for statement in sqlparse.split(sql):
-            # 删除注释语句
-            statement = sqlparse.format(statement, strip_comments=True)
-            if re.match(r"(\s*)alter(\s+)table(\s+)(\S+)(\s*);|(\s*)alter(\s+)table(\s+)(\S+)\.(\S+)(\s*);",
-                        statement.lower() + ";"):
-                result = ReviewResult(id=line,
-                                      errlevel=2,
-                                      stagestatus='SQL语法错误',
-                                      errormessage='ALTER TABLE 必须带有选项',
-                                      sql=statement)
-                check_result.is_critical = True
-            else:
-                result = ReviewResult(id=line, errlevel=0, sql=statement)
-            check_result.rows += [result]
-            line += 1
-        if check_result.is_critical:
-            return check_result
-
         # inception 校验
         check_result.rows = []
         inception_sql = f"""/*--user={instance.user};--password={instance.password};--host={instance.host};
@@ -143,7 +130,7 @@ class InceptionEngine(EngineBase):
                 break
         return execute_result
 
-    def query(self, db_name=None, sql='', limit_num=0, close_conn=True):
+    def query(self, db_name=None, sql='', limit_num=0, close_conn=True, **kwargs):
         """返回 ResultSet """
         result_set = ResultSet(full_sql=sql)
         conn = self.get_connection()

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -940,16 +940,6 @@ class TestInception(TestCase):
         new_engine.get_backup_connection()
         _connect.assert_called_once()
 
-    def test_execute_check_critical_sql(self):
-        sql = 'alter table user'
-        row = ReviewResult(id=1, errlevel=2, stagestatus='SQL语法错误',
-                           errormessage='ALTER TABLE 必须带有选项',
-                           sql=sql)
-        new_engine = InceptionEngine()
-        check_result = new_engine.execute_check(db_name=0, sql=sql)
-        self.assertIsInstance(check_result, ReviewSet)
-        self.assertEqual(check_result.rows[0].__dict__, row.__dict__)
-
     @patch('sql.engines.inception.InceptionEngine.query')
     def test_execute_check_normal_sql(self, _query):
         sql = 'update user set id=100'

--- a/sql/sql_workflow.py
+++ b/sql/sql_workflow.py
@@ -390,36 +390,30 @@ def execute(request):
         return render(request, 'error.html', context)
     # 根据执行模式进行对应修改
     mode = request.POST.get('mode')
+    # 交由系统执行
     if mode == "auto":
-        status = "workflow_executing"
-        operation_type = 5
-        operation_type_desc = '执行工单'
-        operation_info = "自动操作执行"
-        finish_time = None
-    else:
-        status = "workflow_finish"
-        operation_type = 6
-        operation_type_desc = '手工工单'
-        operation_info = "确认手工执行结束"
-        finish_time = datetime.datetime.now()
-    # 将流程状态修改为对应状态
-    SqlWorkflow(id=workflow_id, status=status, finish_time=finish_time).save(update_fields=['status', 'finish_time'])
-
-    # 增加工单日志
-    audit_id = Audit.detail_by_workflow_id(workflow_id=workflow_id,
-                                           workflow_type=WorkflowDict.workflow_type['sqlreview']).audit_id
-    Audit.add_log(audit_id=audit_id,
-                  operation_type=operation_type,
-                  operation_type_desc=operation_type_desc,
-                  operation_info=operation_info,
-                  operator=request.user.username,
-                  operator_display=request.user.display
-                  )
-    if mode == "auto":
+        # 删除定时执行任务
+        schedule_name = f"sqlreview-timing-{workflow_id}"
+        del_schedule(schedule_name)
         # 加入执行队列
-        async_task('sql.utils.execute_sql.execute', workflow_id, hook='sql.utils.execute_sql.execute_callback',
+        async_task('sql.utils.execute_sql.execute', workflow_id, request.user,
+                   hook='sql.utils.execute_sql.execute_callback',
                    timeout=-1, task_name=f'sqlreview-execute-{workflow_id}')
 
+    # 线下手工执行
+    elif mode == "manual":
+        # 将流程状态修改为执行结束
+        SqlWorkflow(id=workflow_id, status="workflow_finish", finish_time=datetime.datetime.now()
+                    ).save(update_fields=['status', 'finish_time'])
+        # 增加工单日志
+        audit_id = Audit.detail_by_workflow_id(workflow_id=workflow_id,
+                                               workflow_type=WorkflowDict.workflow_type['sqlreview']).audit_id
+        Audit.add_log(audit_id=audit_id,
+                      operation_type=6,
+                      operation_type_desc='手工工单',
+                      operation_info='确认手工执行结束',
+                      operator=request.user.username,
+                      operator_display=request.user.display)
     return HttpResponseRedirect(reverse('sql:detail', args=(workflow_id,)))
 
 

--- a/sql/utils/tasks.py
+++ b/sql/utils/tasks.py
@@ -31,11 +31,11 @@ def add_sync_ding_user_schedule():
 
 
 def del_schedule(name):
-    """删除task"""
+    """删除schedule"""
     try:
         sql_schedule = Schedule.objects.get(name=name)
         Schedule.delete(sql_schedule)
-        # logger.debug(f'删除task：{name}')
+        logger.debug(f'删除schedule：{name}')
     except Schedule.DoesNotExist:
         pass
 


### PR DESCRIPTION
相关issue：#697 #712
主要解决工单重复执行的问题，还有Inception检测效率的优化

- 用户点击执行工单时，不再直接修改状态为执行中（这里后续可以加个排队状态），而是在django_q调用执行任务时才去修改
- 提交执行工单任务时删除定时任务
- 执行函数前置判断逻辑增加事物，事物内对工单增加排他锁`select for update`，同时判断并修改工单状态
- 用户是否可执行工单的判断也使用排他锁，避免多次提交任务，导致正确执行结果被覆盖