### PR TITLE
支持配置多个阿里云认证信息

### DIFF
--- a/common/templates/base.html
+++ b/common/templates/base.html
@@ -62,7 +62,7 @@
                 <ul class="dropdown-menu dropdown-user">
                     {% if user.is_superuser %}
                         <li>
-                            <a target="_blank" href="/api/debug?full=true"><i class="fa fa-info fa-fw"></i> 系统信息</a>
+                            <a target="_blank" href="/api/debug"><i class="fa fa-info fa-fw"></i> 系统信息</a>
                         </li>
                         <li>
                             <a target="_blank" href="/admin"><i class="fa fa-sitemap fa-fw"></i> 管理后台</a>

--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -686,35 +686,6 @@
                         <br>
                         <h4 style="color: darkgrey"><b>其他配置</b></h4>
                         <hr/>
-                        <h5 style="color: darkgrey"><b>阿里云认证信息</b></h5>
-                        <h6 style="color:red">注：实例关联RDS实例ID后，会调用RDS接口获取慢日志、进程、表空间，其中进程和表空间需要管理权限的key</h6>
-                        <hr/>
-                        <div class="form-horizontal">
-                            <div class="form-group">
-                                <label for="aliyun_ak"
-                                       class="col-sm-4 control-label">AccessKeyID</label>
-                                <div class="col-sm-5">
-                                    <input type="password" class="form-control"
-                                           id="aliyun_ak"
-                                           key="aliyun_ak"
-                                           value="{{ config.aliyun_ak }}"
-                                           placeholder="AccessKeyID">
-                                </div>
-                            </div>
-                            <div class="form-group">
-                                <label for="aliyun_secret"
-                                       class="col-sm-4 control-label">AccessKeySecret</label>
-                                <div class="col-sm-5">
-                                    <input type="password" class="form-control"
-                                           id="aliyun_secret"
-                                           key="aliyun_secret"
-                                           value="{{ config.aliyun_secret }}"
-                                           placeholder="AccessKeySecret">
-                                </div>
-                            </div>
-                        </div>
-                        <h5 style="color: darkgrey"><b>其他</b></h5>
-                        <hr/>
                         <div class="form-horizontal">
                             <div class="form-group">
                                 <label for="index_path_url"

--- a/sql/admin.py
+++ b/sql/admin.py
@@ -4,7 +4,7 @@ from django.contrib.auth.admin import UserAdmin
 
 # Register your models here.
 from .models import Users, Instance, SqlWorkflow, SqlWorkflowContent, QueryLog, DataMaskingColumns, DataMaskingRules, \
-    AliyunRdsConfig, ResourceGroup, QueryPrivilegesApply, \
+    AliyunRdsConfig, CloudAccessKey, ResourceGroup, QueryPrivilegesApply, \
     QueryPrivileges, InstanceAccount, InstanceDatabase, ArchiveConfig, \
     WorkflowAudit, WorkflowLog, ParamTemplate, ParamHistory, InstanceTag
 
@@ -206,8 +206,7 @@ class ArchiveConfigAdmin(admin.ModelAdmin):
               'mode', 'condition', 'sleep', 'no_delete', 'state', 'user_name', 'user_display')
 
 
-# 阿里云实例配置信息
-@admin.register(AliyunRdsConfig)
-class AliRdsConfigAdmin(admin.ModelAdmin):
-    list_display = ('instance', 'rds_dbinstanceid', 'is_enable')
-    search_fields = ['instance__instance_name', 'rds_dbinstanceid']
+# 云服务认证信息配置
+@admin.register(CloudAccessKey)
+class CloudAccessKeyAdmin(admin.ModelAdmin):
+    list_display = ('type', 'key_id', 'key_secret', 'remark')

--- a/sql/aliyun_rds.py
+++ b/sql/aliyun_rds.py
@@ -30,7 +30,7 @@ def slowquery_review(request):
     # 通过实例名称获取关联的rds实例id
     instance_info = AliyunRdsConfig.objects.get(instance__instance_name=instance_name)
     # 调用aliyun接口获取SQL慢日志统计
-    slowsql = Aliyun().DescribeSlowLogs(instance_info.rds_dbinstanceid, start_time, end_time, **values)
+    slowsql = Aliyun(rds=instance_info).DescribeSlowLogs(start_time, end_time, **values)
 
     # 解决table数据丢失精度、格式化时间
     sql_slow_log = json.loads(slowsql)['Items']['SQLSlowLog']
@@ -71,7 +71,7 @@ def slowquery_review_history(request):
     # 通过实例名称获取关联的rds实例id
     instance_info = AliyunRdsConfig.objects.get(instance__instance_name=instance_name)
     # 调用aliyun接口获取SQL慢日志统计
-    slowsql = Aliyun().DescribeSlowLogRecords(instance_info.rds_dbinstanceid, start_time, end_time, **values)
+    slowsql = Aliyun(rds=instance_info).DescribeSlowLogRecords(start_time, end_time, **values)
 
     # 格式化时间\过滤HostAddress
     sql_slow_record = json.loads(slowsql)['Items']['SQLSlowRecord']
@@ -98,8 +98,8 @@ def process_status(request):
     # 通过实例名称获取关联的rds实例id
     instance_info = AliyunRdsConfig.objects.get(instance__instance_name=instance_name)
     # 调用aliyun接口获取进程数据
-    process_info = Aliyun().RequestServiceOfCloudDBA(instance_info.rds_dbinstanceid, 'ShowProcessList',
-                                                     {"Language": "zh", "Command": command_type})
+    process_info = Aliyun(rds=instance_info).RequestServiceOfCloudDBA(
+        'ShowProcessList', {"Language": "zh", "Command": command_type})
 
     # 提取进程列表
     process_list = json.loads(process_info)['AttrData']
@@ -120,8 +120,8 @@ def create_kill_session(request):
     # 通过实例名称获取关联的rds实例id
     instance_info = AliyunRdsConfig.objects.get(instance__instance_name=instance_name)
     # 调用aliyun接口获取进程数据
-    request_info = Aliyun().RequestServiceOfCloudDBA(instance_info.rds_dbinstanceid, 'CreateKillSessionRequest',
-                                                     {"Language": "zh", "ThreadIDs": json.loads(thread_ids)})
+    request_info = Aliyun(rds=instance_info).RequestServiceOfCloudDBA(
+        'CreateKillSessionRequest', {"Language": "zh", "ThreadIDs": json.loads(thread_ids)})
 
     # 提取进程列表
     request_list = json.loads(request_info)['AttrData']
@@ -143,8 +143,7 @@ def kill_session(request):
     # 调用aliyun接口获取终止进程
     request_params = json.loads(request_params)
     service_request_param = dict({"Language": "zh"}, **request_params)
-    kill_result = Aliyun().RequestServiceOfCloudDBA(instance_info.rds_dbinstanceid, 'ConfirmKillSessionRequest',
-                                                    service_request_param)
+    kill_result = Aliyun(rds=instance_info).RequestServiceOfCloudDBA('ConfirmKillSessionRequest', service_request_param)
 
     # 获取处理结果
     kill_result = json.loads(kill_result)['AttrData']
@@ -162,8 +161,8 @@ def sapce_status(request):
     # 通过实例名称获取关联的rds实例id
     instance_info = AliyunRdsConfig.objects.get(instance__instance_name=instance_name)
     # 调用aliyun接口获取进程数据
-    space_info = Aliyun().RequestServiceOfCloudDBA(instance_info.rds_dbinstanceid, 'GetSpaceStatForTables',
-                                                   {"Language": "zh", "OrderType": "Data"})
+    space_info = Aliyun(rds=instance_info).RequestServiceOfCloudDBA(
+        'GetSpaceStatForTables', {"Language": "zh", "OrderType": "Data"})
 
     # 提取进程列表
     space_list = json.loads(space_info)['ListData']

--- a/src/init_sql/v1.7.10_v1.7.11.sql
+++ b/src/init_sql/v1.7.10_v1.7.11.sql
@@ -1,0 +1,14 @@
+-- 云服务认证信息配置
+create table cloud_access_key(
+  id int not null auto_increment primary key comment 'id',
+  type varchar(20) not null default '' comment 'type',
+  key_id varchar(200) not null default '' comment 'key_id',
+  key_secret varchar(200) not null default '' comment 'key_secret',
+  remark varchar(50) not null default '' comment 'remark'
+) comment '云服务认证信息配置';
+
+-- 阿里云RDS配置关联认证信息
+set foreign_key_checks=0;
+alter table aliyun_rds_config add ak_id int not null default 0 comment 'ak_id',
+  add  CONSTRAINT `fk_aliyun_rds_ak_id` FOREIGN KEY (`ak_id`) REFERENCES `cloud_access_key` (`id`);
+set foreign_key_checks=1;


### PR DESCRIPTION
相关issue #596

- 新增云服务认证信息配置表，支持配置多个认证信息
- rds配置表关联认证信息，使用实例初始化rds sdk，获取关联的认证信息
- 认证信息加密保存，前端也展示为加密