### PR TITLE
Removing the master and slave language

### DIFF
--- a/common/tests.py
+++ b/common/tests.py
@@ -214,9 +214,9 @@ class CheckTest(TestCase):
         self.superuser1 = User(username='test_user', display='中文显示', is_active=True, is_superuser=True,
                                email='XXX@xxx.com')
         self.superuser1.save()
-        self.slave1 = Instance(instance_name='some_name', host='some_host', type='slave', db_type='mysql',
+        self.subordinate1 = Instance(instance_name='some_name', host='some_host', type='subordinate', db_type='mysql',
                                user='some_user', port=1234, password='some_str')
-        self.slave1.save()
+        self.subordinate1.save()
 
     def tearDown(self):
         self.superuser1.delete()
@@ -319,7 +319,7 @@ class CheckTest(TestCase):
             rows=(('test1',), ('test2',)))
         c = Client()
         c.force_login(self.superuser1)
-        r = c.post('/check/instance/', data={'instance_id': self.slave1.id})
+        r = c.post('/check/instance/', data={'instance_id': self.subordinate1.id})
         r_json = r.json()
         self.assertEqual(r_json['status'], 0)
 
@@ -368,9 +368,9 @@ class ChartTest(TestCase):
         cls.superuser1 = User(username='super1', is_superuser=True)
         cls.superuser1.save()
         cls.now = datetime.datetime.now()
-        cls.slave1 = Instance(instance_name='test_slave_instance', type='slave', db_type='mysql',
+        cls.subordinate1 = Instance(instance_name='test_subordinate_instance', type='subordinate', db_type='mysql',
                               host='testhost', port=3306, user='mysql_user', password='mysql_password')
-        cls.slave1.save()
+        cls.subordinate1.save()
         # 批量创建数据 ddl ,u1 ,g1, yesterday 组, 2 个数据
         ddl_workflow = [SqlWorkflow(
             workflow_name='ddl %s' % i,
@@ -382,7 +382,7 @@ class ChartTest(TestCase):
             create_time=cls.now - datetime.timedelta(days=1),
             status='workflow_finish',
             is_backup=True,
-            instance=cls.slave1,
+            instance=cls.subordinate1,
             db_name='some_db',
             syntax_type=1
         ) for i in range(2)]
@@ -397,7 +397,7 @@ class ChartTest(TestCase):
             create_time=cls.now - datetime.timedelta(days=2),
             status='workflow_finish',
             is_backup=True,
-            instance=cls.slave1,
+            instance=cls.subordinate1,
             db_name='some_db',
             syntax_type=2
         ) for i in range(3)]
@@ -426,7 +426,7 @@ class ChartTest(TestCase):
         cls.u1.delete()
         cls.u2.delete()
         cls.superuser1.delete()
-        cls.slave1.delete()
+        cls.subordinate1.delete()
 
     def testGetDateList(self):
         dao = ChartDao()

--- a/sql/binlog.py
+++ b/sql/binlog.py
@@ -64,7 +64,7 @@ def del_binlog(request):
 
     if binlog:
         query_engine = get_engine(instance=instance)
-        query_result = query_engine.query(sql=fr"purge master logs to '{binlog}';")
+        query_result = query_engine.query(sql=fr"purge main logs to '{binlog}';")
         if query_result.error is None:
             result = {'status': 0, 'msg': '清理成功', 'data': ''}
         else:

--- a/sql/completer/tests.py
+++ b/sql/completer/tests.py
@@ -23,13 +23,13 @@ class TestCompleter(TestCase):
         :return:
         """
         # 使用 travis.ci 时实例和测试service保持一致
-        cls.master = Instance(instance_name='test_instance', type='master', db_type='mysql',
+        cls.main = Instance(instance_name='test_instance', type='main', db_type='mysql',
                               host=settings.DATABASES['default']['HOST'],
                               port=settings.DATABASES['default']['PORT'],
                               user=settings.DATABASES['default']['USER'],
                               password=settings.DATABASES['default']['PASSWORD'])
-        cls.master.save()
-        cls.comp_engine = get_comp_engine(instance=cls.master, db_name=settings.DATABASES['default']['TEST']['NAME'])
+        cls.main.save()
+        cls.comp_engine = get_comp_engine(instance=cls.main, db_name=settings.DATABASES['default']['TEST']['NAME'])
         # 等待completion_refresher刷新完成
         while cls.comp_engine.completion_refresher.is_refreshing():
             import time
@@ -40,7 +40,7 @@ class TestCompleter(TestCase):
         """
         :return:
         """
-        cls.master.delete()
+        cls.main.delete()
         cls.comp_engine.refresh_completions(reset=True)
 
     def test_table_names_after_from(self):

--- a/sql/engines/__init__.py
+++ b/sql/engines/__init__.py
@@ -55,7 +55,7 @@ class EngineBase:
         return False
 
     @property
-    def seconds_behind_master(self):
+    def seconds_behind_main(self):
         """实例同步延迟情况"""
         return None
 

--- a/sql/engines/mssql.py
+++ b/sql/engines/mssql.py
@@ -24,10 +24,10 @@ client charset = UTF-8;connect timeout=10;CHARSET={4};""".format(self.host, self
 
     def get_all_databases(self):
         """获取数据库列表, 返回一个ResultSet"""
-        sql = "SELECT name FROM master.sys.databases"
+        sql = "SELECT name FROM main.sys.databases"
         result = self.query(sql=sql)
         db_list = [row[0] for row in result.rows
-                   if row[0] not in ('master', 'msdb', 'tempdb', 'model')]
+                   if row[0] not in ('main', 'msdb', 'tempdb', 'model')]
         result.rows = db_list
         return result
 

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -61,9 +61,9 @@ class MysqlEngine(EngineBase):
         return True
 
     @property
-    def seconds_behind_master(self):
-        slave_status = self.query(sql='show slave status', close_conn=False, cursorclass=MySQLdb.cursors.DictCursor)
-        return slave_status.rows[0].get('Seconds_Behind_Master') if slave_status.rows else None
+    def seconds_behind_main(self):
+        subordinate_status = self.query(sql='show subordinate status', close_conn=False, cursorclass=MySQLdb.cursors.DictCursor)
+        return subordinate_status.rows[0].get('Seconds_Behind_Main') if subordinate_status.rows else None
 
     @property
     def server_version(self):

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -35,7 +35,7 @@ class TestEngineBase(TestCase):
     def setUpClass(cls):
         cls.u1 = User(username='some_user', display='用户1')
         cls.u1.save()
-        cls.ins1 = Instance(instance_name='some_ins', type='master', db_type='mssql', host='some_host',
+        cls.ins1 = Instance(instance_name='some_ins', type='main', db_type='mssql', host='some_host',
                             port=1366, user='ins_user', password='some_str')
         cls.ins1.save()
         cls.wf1 = SqlWorkflow.objects.create(
@@ -77,7 +77,7 @@ class TestMssql(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.ins1 = Instance(instance_name='some_ins', type='slave', db_type='mssql', host='some_host',
+        cls.ins1 = Instance(instance_name='some_ins', type='subordinate', db_type='mssql', host='some_host',
                             port=1366, user='ins_user', password='some_str')
         cls.ins1.save()
         cls.engine = MssqlEngine(instance=cls.ins1)
@@ -221,7 +221,7 @@ class TestMssql(TestCase):
 class TestMysql(TestCase):
 
     def setUp(self):
-        self.ins1 = Instance(instance_name='some_ins', type='slave', db_type='mysql', host='some_host',
+        self.ins1 = Instance(instance_name='some_ins', type='subordinate', db_type='mysql', host='some_host',
                              port=1366, user='ins_user', password='some_str')
         self.ins1.save()
         self.sys_config = SysConfig()
@@ -529,17 +529,17 @@ class TestMysql(TestCase):
         _query.assert_called_once_with(sql="kill 100")
 
     @patch.object(MysqlEngine, 'query')
-    def test_seconds_behind_master(self, _query):
+    def test_seconds_behind_main(self, _query):
         new_engine = MysqlEngine(instance=self.ins1)
-        new_engine.seconds_behind_master
-        _query.assert_called_once_with(sql="show slave status", close_conn=False,
+        new_engine.seconds_behind_main
+        _query.assert_called_once_with(sql="show subordinate status", close_conn=False,
                                        cursorclass=MySQLdb.cursors.DictCursor)
 
 
 class TestRedis(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ins = Instance(instance_name='some_ins', type='slave', db_type='redis', host='some_host',
+        cls.ins = Instance(instance_name='some_ins', type='subordinate', db_type='redis', host='some_host',
                            port=1366, user='ins_user', password='some_str')
         cls.ins.save()
 
@@ -661,7 +661,7 @@ class TestRedis(TestCase):
 class TestPgSQL(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ins = Instance(instance_name='some_ins', type='slave', db_type='pgsql', host='some_host',
+        cls.ins = Instance(instance_name='some_ins', type='subordinate', db_type='pgsql', host='some_host',
                            port=1366, user='ins_user', password='some_str')
         cls.ins.save()
         cls.sys_config = SysConfig()
@@ -904,9 +904,9 @@ class TestModel(TestCase):
 
 class TestInception(TestCase):
     def setUp(self):
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql', host='some_host',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql', host='some_host',
                                            port=3306, user='ins_user', password='some_str')
-        self.ins_inc = Instance.objects.create(instance_name='some_ins_inc', type='slave', db_type='inception',
+        self.ins_inc = Instance.objects.create(instance_name='some_ins_inc', type='subordinate', db_type='inception',
                                                host='some_host', port=6669)
         self.wf = SqlWorkflow.objects.create(
             workflow_name='some_name',
@@ -1090,10 +1090,10 @@ class TestInception(TestCase):
 
 class TestGoInception(TestCase):
     def setUp(self):
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql',
                                            host='some_host',
                                            port=3306, user='ins_user', password='some_str')
-        self.ins_inc = Instance.objects.create(instance_name='some_ins_inc', type='slave', db_type='goinception',
+        self.ins_inc = Instance.objects.create(instance_name='some_ins_inc', type='subordinate', db_type='goinception',
                                                host='some_host', port=4000)
         self.wf = SqlWorkflow.objects.create(
             workflow_name='some_name',
@@ -1236,7 +1236,7 @@ class TestOracle(TestCase):
     """Oracle 测试"""
 
     def setUp(self):
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='oracle',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='oracle',
                                            host='some_host', port=3306, user='ins_user', password='some_str',
                                            sid='some_id')
         self.wf = SqlWorkflow.objects.create(
@@ -1560,7 +1560,7 @@ class TestOracle(TestCase):
 
 class MongoTest(TestCase):
     def setUp(self) -> None:
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mongo',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mongo',
                                            host='some_host', port=3306, user='ins_user')
         self.engine = MongoEngine(instance=self.ins)
 

--- a/sql/models.py
+++ b/sql/models.py
@@ -119,7 +119,7 @@ class Instance(models.Model):
     各个线上实例配置
     """
     instance_name = models.CharField('实例名称', max_length=50, unique=True)
-    type = models.CharField('实例类型', max_length=6, choices=(('master', '主库'), ('slave', '从库')))
+    type = models.CharField('实例类型', max_length=6, choices=(('main', '主库'), ('subordinate', '从库')))
     db_type = models.CharField('数据库类型', max_length=20, choices=DB_TYPE_CHOICES)
     host = models.CharField('实例连接', max_length=200)
     port = models.IntegerField('端口', default=0)

--- a/sql/query.py
+++ b/sql/query.py
@@ -94,7 +94,7 @@ def query(request):
             add_kill_conn_schedule(schedule_name, run_date, instance.id, thread_id)
         with FuncTimer() as t:
             # 获取主从延迟信息
-            seconds_behind_master = query_engine.seconds_behind_master
+            seconds_behind_main = query_engine.seconds_behind_main
             query_result = query_engine.query(db_name, sql_content, limit_num,
                                               schema_name=schema_name,
                                               tb_name=tb_name,
@@ -144,7 +144,7 @@ def query(request):
 
         # 仅将成功的查询语句记录存入数据库
         if not query_result.error:
-            result['data']['seconds_behind_master'] = seconds_behind_master
+            result['data']['seconds_behind_main'] = seconds_behind_main
             if int(limit_num) == 0:
                 limit_num = int(query_result.affected_rows)
             else:

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -34,7 +34,7 @@ class TestView(TestCase):
         self.client = Client()
         self.superuser = User.objects.create(username='super', is_superuser=True)
         self.client.force_login(self.superuser)
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql',
                                            host='some_host',
                                            port=3306, user='ins_user', password='some_str')
         self.res_group = ResourceGroup.objects.create(group_id=1, group_name='group_name')
@@ -389,7 +389,7 @@ class TestQueryPrivilegesCheck(TestCase):
         self.user_can_query_all.user_permissions.add(query_all_instance_perm)
         self.user = User.objects.create(username='user')
         # 使用 travis.ci 时实例和测试service保持一致
-        self.slave = Instance.objects.create(instance_name='test_instance', type='slave', db_type='mysql',
+        self.subordinate = Instance.objects.create(instance_name='test_instance', type='subordinate', db_type='mysql',
                                              host=settings.DATABASES['default']['HOST'],
                                              port=settings.DATABASES['default']['PORT'],
                                              user=settings.DATABASES['default']['USER'],
@@ -412,7 +412,7 @@ class TestQueryPrivilegesCheck(TestCase):
         """
         self.sys_config.set('admin_query_limit', '50')
         self.sys_config.get_all_config()
-        r = sql.query_privileges._db_priv(user=self.superuser, instance=self.slave, db_name=self.db_name)
+        r = sql.query_privileges._db_priv(user=self.superuser, instance=self.subordinate, db_name=self.db_name)
         self.assertEqual(r, 50)
 
     def test_db_priv_user_priv_not_exist(self):
@@ -420,7 +420,7 @@ class TestQueryPrivilegesCheck(TestCase):
         测试普通用户验证数据库权限，用户无权限
         :return:
         """
-        r = sql.query_privileges._db_priv(user=self.user, instance=self.slave, db_name=self.db_name)
+        r = sql.query_privileges._db_priv(user=self.user, instance=self.subordinate, db_name=self.db_name)
         self.assertFalse(r)
 
     def test_db_priv_user_priv_exist(self):
@@ -429,12 +429,12 @@ class TestQueryPrivilegesCheck(TestCase):
         :return:
         """
         QueryPrivileges.objects.create(user_name=self.user.username,
-                                       instance=self.slave,
+                                       instance=self.subordinate,
                                        db_name=self.db_name,
                                        valid_date=date.today() + timedelta(days=1),
                                        limit_num=10,
                                        priv_type=1)
-        r = sql.query_privileges._db_priv(user=self.user, instance=self.slave, db_name=self.db_name)
+        r = sql.query_privileges._db_priv(user=self.user, instance=self.subordinate, db_name=self.db_name)
         self.assertTrue(r)
 
     def test_tb_priv_super(self):
@@ -444,7 +444,7 @@ class TestQueryPrivilegesCheck(TestCase):
         """
         self.sys_config.set('admin_query_limit', '50')
         self.sys_config.get_all_config()
-        r = sql.query_privileges._tb_priv(user=self.superuser, instance=self.slave, db_name=self.db_name,
+        r = sql.query_privileges._tb_priv(user=self.superuser, instance=self.subordinate, db_name=self.db_name,
                                           tb_name='table_name')
         self.assertEqual(r, 50)
 
@@ -453,7 +453,7 @@ class TestQueryPrivilegesCheck(TestCase):
         测试普通用户验证表权限，用户无权限
         :return:
         """
-        r = sql.query_privileges._tb_priv(user=self.user, instance=self.slave, db_name=self.db_name,
+        r = sql.query_privileges._tb_priv(user=self.user, instance=self.subordinate, db_name=self.db_name,
                                           tb_name='table_name')
         self.assertFalse(r)
 
@@ -463,13 +463,13 @@ class TestQueryPrivilegesCheck(TestCase):
         :return:
         """
         QueryPrivileges.objects.create(user_name=self.user.username,
-                                       instance=self.slave,
+                                       instance=self.subordinate,
                                        db_name=self.db_name,
                                        table_name='table_name',
                                        valid_date=date.today() + timedelta(days=1),
                                        limit_num=10,
                                        priv_type=2)
-        r = sql.query_privileges._tb_priv(user=self.user, instance=self.slave, db_name=self.db_name,
+        r = sql.query_privileges._tb_priv(user=self.user, instance=self.subordinate, db_name=self.db_name,
                                           tb_name='table_name')
         self.assertTrue(r)
 
@@ -480,7 +480,7 @@ class TestQueryPrivilegesCheck(TestCase):
         :return:
         """
         __db_priv.return_value = 10
-        r = sql.query_privileges._priv_limit(user=self.user, instance=self.slave, db_name=self.db_name)
+        r = sql.query_privileges._priv_limit(user=self.user, instance=self.subordinate, db_name=self.db_name)
         self.assertEqual(r, 10)
 
     @patch('sql.query_privileges._tb_priv')
@@ -492,7 +492,7 @@ class TestQueryPrivilegesCheck(TestCase):
         """
         __db_priv.return_value = 10
         __tb_priv.return_value = 1
-        r = sql.query_privileges._priv_limit(user=self.user, instance=self.slave, db_name=self.db_name, tb_name='test')
+        r = sql.query_privileges._priv_limit(user=self.user, instance=self.subordinate, db_name=self.db_name, tb_name='test')
         self.assertEqual(r, 1)
 
     @patch('sql.engines.goinception.GoInceptionEngine.query_print')
@@ -504,7 +504,7 @@ class TestQueryPrivilegesCheck(TestCase):
         _query_print.return_value = {'id': 2, 'statement': 'select * from sql_users limit 100', 'errlevel': 0,
                                      'query_tree': '{"text":"select * from sql_users limit 100","resultFields":null,"SQLCache":true,"CalcFoundRows":false,"StraightJoin":false,"Priority":0,"Distinct":false,"From":{"text":"","TableRefs":{"text":"","resultFields":null,"Left":{"text":"","Source":{"text":"","resultFields":null,"Schema":{"O":"","L":""},"Name":{"O":"sql_users","L":"sql_users"},"DBInfo":null,"TableInfo":null,"IndexHints":null},"AsName":{"O":"","L":""}},"Right":null,"Tp":0,"On":null,"Using":null,"NaturalJoin":false,"StraightJoin":false}},"Where":null,"Fields":{"text":"","Fields":[{"text":"","Offset":33,"WildCard":{"text":"","Table":{"O":"","L":""},"Schema":{"O":"","L":""}},"Expr":null,"AsName":{"O":"","L":""},"Auxiliary":false}]},"GroupBy":null,"Having":null,"OrderBy":null,"Limit":{"text":"","Count":{"text":"","k":2,"collation":0,"decimal":0,"length":0,"i":100,"b":null,"x":null,"Type":{"Tp":8,"Flag":160,"Flen":3,"Decimal":0,"Charset":"binary","Collate":"binary","Elems":null},"flag":0,"projectionOffset":-1},"Offset":null},"LockTp":0,"TableHints":null,"IsAfterUnionDistinct":false,"IsInBraces":false}',
                                      'errmsg': None}
-        r = sql.query_privileges._table_ref('select * from sql_users limit 100;', self.slave, self.db_name)
+        r = sql.query_privileges._table_ref('select * from sql_users limit 100;', self.subordinate, self.db_name)
         self.assertListEqual(r, [{'schema': 'test_archery', 'name': 'sql_users'}])
 
     @patch('sql.engines.goinception.GoInceptionEngine.query_print')
@@ -515,7 +515,7 @@ class TestQueryPrivilegesCheck(TestCase):
         """
         _query_print.side_effect = RuntimeError('语法错误')
         with self.assertRaises(RuntimeError):
-            sql.query_privileges._table_ref('select * from archery.sql_users;', self.slave, self.db_name)
+            sql.query_privileges._table_ref('select * from archery.sql_users;', self.subordinate, self.db_name)
 
     def test_query_priv_check_super(self):
         """
@@ -523,12 +523,12 @@ class TestQueryPrivilegesCheck(TestCase):
         :return:
         """
         r = sql.query_privileges.query_priv_check(user=self.superuser,
-                                                  instance=self.slave, db_name=self.db_name,
+                                                  instance=self.subordinate, db_name=self.db_name,
                                                   sql_content="select * from archery.sql_users;",
                                                   limit_num=100)
         self.assertDictEqual(r, {'status': 0, 'msg': 'ok', 'data': {'priv_check': True, 'limit_num': 100}})
         r = sql.query_privileges.query_priv_check(user=self.user_can_query_all,
-                                                  instance=self.slave, db_name=self.db_name,
+                                                  instance=self.subordinate, db_name=self.db_name,
                                                   sql_content="select * from archery.sql_users;",
                                                   limit_num=100)
         self.assertDictEqual(r, {'status': 0, 'msg': 'ok', 'data': {'priv_check': True, 'limit_num': 100}})
@@ -536,7 +536,7 @@ class TestQueryPrivilegesCheck(TestCase):
     def test_query_priv_check_explain_or_show_create(self):
         """测试用户权限校验，explain和show create不做校验"""
         r = sql.query_privileges.query_priv_check(user=self.user,
-                                                  instance=self.slave, db_name=self.db_name,
+                                                  instance=self.subordinate, db_name=self.db_name,
                                                   sql_content="show create table archery.sql_users;",
                                                   limit_num=100)
         self.assertTrue(r)
@@ -550,7 +550,7 @@ class TestQueryPrivilegesCheck(TestCase):
         :return:
         """
         r = sql.query_privileges.query_priv_check(user=self.user,
-                                                  instance=self.slave, db_name=self.db_name,
+                                                  instance=self.subordinate, db_name=self.db_name,
                                                   sql_content="select * from archery.sql_users;",
                                                   limit_num=100)
         self.assertDictEqual(r, {'status': 1, 'msg': '你无archery.sql_users表的查询权限！请先到查询权限管理进行申请',
@@ -565,7 +565,7 @@ class TestQueryPrivilegesCheck(TestCase):
         :return:
         """
         r = sql.query_privileges.query_priv_check(user=self.user,
-                                                  instance=self.slave, db_name=self.db_name,
+                                                  instance=self.subordinate, db_name=self.db_name,
                                                   sql_content="select * from archery.sql_users;",
                                                   limit_num=100)
         self.assertDictEqual(r, {'data': {'limit_num': 100, 'priv_check': True}, 'msg': 'ok', 'status': 0})
@@ -579,7 +579,7 @@ class TestQueryPrivilegesCheck(TestCase):
         :return:
         """
         r = sql.query_privileges.query_priv_check(user=self.user,
-                                                  instance=self.slave, db_name=self.db_name,
+                                                  instance=self.subordinate, db_name=self.db_name,
                                                   sql_content="select * from archery.sql_users;",
                                                   limit_num=100)
         self.assertDictEqual(r, {'data': {'limit_num': 10, 'priv_check': True}, 'msg': 'ok', 'status': 0})
@@ -595,7 +595,7 @@ class TestQueryPrivilegesCheck(TestCase):
         __table_ref.side_effect = RuntimeError('语法错误')
         self.sys_config.get_all_config()
         r = sql.query_privileges.query_priv_check(user=self.user,
-                                                  instance=self.slave, db_name=self.db_name,
+                                                  instance=self.subordinate, db_name=self.db_name,
                                                   sql_content="select * from archery.sql_users;",
                                                   limit_num=100)
         self.assertDictEqual(r, {'status': 1,
@@ -608,7 +608,7 @@ class TestQueryPrivilegesCheck(TestCase):
         测试用户权限校验，非mysql实例、普通用户 有库权限
         :return:
         """
-        mssql_instance = Instance(instance_name='mssql', type='slave', db_type='mssql',
+        mssql_instance = Instance(instance_name='mssql', type='subordinate', db_type='mssql',
                                   host='some_host', port=3306, user='some_user', password='some_str')
         r = sql.query_privileges.query_priv_check(user=self.user,
                                                   instance=mssql_instance, db_name=self.db_name,
@@ -622,7 +622,7 @@ class TestQueryPrivilegesCheck(TestCase):
         测试用户权限校验，非mysql实例、普通用户 无库权限
         :return:
         """
-        mssql_instance = Instance(instance_name='mssql', type='slave', db_type='oracle',
+        mssql_instance = Instance(instance_name='mssql', type='subordinate', db_type='oracle',
                                   host='some_host', port=3306, user='some_user', password='some_str')
         r = sql.query_privileges.query_priv_check(user=self.user,
                                                   instance=mssql_instance, db_name=self.db_name,
@@ -640,7 +640,7 @@ class TestQueryPrivilegesApply(TestCase):
         self.superuser = User.objects.create(username='super', is_superuser=True)
         self.user = User.objects.create(username='user')
         # 使用 travis.ci 时实例和测试service保持一致
-        self.slave = Instance.objects.create(instance_name='test_instance', type='slave', db_type='mysql',
+        self.subordinate = Instance.objects.create(instance_name='test_instance', type='subordinate', db_type='mysql',
                                              host=settings.DATABASES['default']['HOST'],
                                              port=settings.DATABASES['default']['PORT'],
                                              user=settings.DATABASES['default']['USER'],
@@ -655,7 +655,7 @@ class TestQueryPrivilegesApply(TestCase):
             group_name=self.group.group_name,
             title='some_title1',
             user_name='some_user',
-            instance=self.slave,
+            instance=self.subordinate,
             db_list='some_db,some_db2',
             limit_num=100,
             valid_date=tomorrow,
@@ -668,7 +668,7 @@ class TestQueryPrivilegesApply(TestCase):
             group_name='some_group2',
             title='some_title2',
             user_name='some_user',
-            instance=self.slave,
+            instance=self.subordinate,
             db_list='some_db',
             table_list='some_table,some_tb2',
             limit_num=100,
@@ -786,7 +786,7 @@ class TestQueryPrivilegesApply(TestCase):
         }
         QueryPrivileges.objects.create(user_name=self.user.username,
                                        user_display='user2',
-                                       instance=self.slave,
+                                       instance=self.subordinate,
                                        db_name=self.db_name,
                                        table_name='table_name',
                                        valid_date=date.today() + timedelta(days=1),
@@ -811,7 +811,7 @@ class TestQueryPrivilegesApply(TestCase):
         }
         QueryPrivileges.objects.create(user_name='some_name',
                                        user_display='user2',
-                                       instance=self.slave,
+                                       instance=self.subordinate,
                                        db_name=self.db_name,
                                        table_name='table_name',
                                        valid_date=date.today() + timedelta(days=1),
@@ -841,7 +841,7 @@ class TestQueryPrivilegesApply(TestCase):
         }
         QueryPrivileges.objects.create(user_name='some_name',
                                        user_display='user2',
-                                       instance=self.slave,
+                                       instance=self.subordinate,
                                        db_name=self.db_name,
                                        table_name='table_name',
                                        valid_date=date.today() + timedelta(days=1),
@@ -857,16 +857,16 @@ class TestQueryPrivilegesApply(TestCase):
 
 class TestQuery(TransactionTestCase):
     def setUp(self):
-        self.slave1 = Instance(instance_name='test_slave_instance', type='slave', db_type='mysql',
+        self.subordinate1 = Instance(instance_name='test_subordinate_instance', type='subordinate', db_type='mysql',
                                host='testhost', port=3306, user='mysql_user', password='mysql_password')
-        self.slave2 = Instance(instance_name='test_instance_non_mysql', type='slave', db_type='mssql',
+        self.subordinate2 = Instance(instance_name='test_instance_non_mysql', type='subordinate', db_type='mssql',
                                host='some_host2', port=3306, user='some_user', password='some_str')
-        self.slave1.save()
-        self.slave2.save()
+        self.subordinate1.save()
+        self.subordinate2.save()
         self.superuser1 = User.objects.create(username='super1', is_superuser=True)
         self.u1 = User.objects.create(username='test_user', display='中文显示', is_active=True)
         self.u2 = User.objects.create(username='test_user2', display='中文显示', is_active=True)
-        self.query_log = QueryLog.objects.create(instance_name=self.slave1.instance_name,
+        self.query_log = QueryLog.objects.create(instance_name=self.subordinate1.instance_name,
                                                  db_name='some_db',
                                                  sqllog='select 1;',
                                                  effect_row=10,
@@ -881,8 +881,8 @@ class TestQuery(TransactionTestCase):
         self.u1.delete()
         self.u2.delete()
         self.superuser1.delete()
-        self.slave1.delete()
-        self.slave2.delete()
+        self.subordinate1.delete()
+        self.subordinate2.delete()
         archer_config = SysConfig()
         archer_config.set('disable_star', False)
 
@@ -895,7 +895,7 @@ class TestQuery(TransactionTestCase):
         some_db = 'some_db'
         some_limit = 100
         c.force_login(self.u1)
-        r = c.post('/query/', data={'instance_name': self.slave1.instance_name,
+        r = c.post('/query/', data={'instance_name': self.subordinate1.instance_name,
                                     'sql_content': some_sql,
                                     'db_name': some_db,
                                     'limit_num': some_limit})
@@ -907,10 +907,10 @@ class TestQuery(TransactionTestCase):
             'msg': '', 'bad_query': False, 'filtered_sql': some_sql, 'has_star': False}
         _get_engine.return_value.filter_sql.return_value = some_sql
         _get_engine.return_value.query.return_value = q_result
-        _get_engine.return_value.seconds_behind_master = 100
+        _get_engine.return_value.seconds_behind_main = 100
         _priv_check.return_value = {'status': 0, 'data': {'limit_num': 100, 'priv_check': True}}
-        _user_instances.return_value.get.return_value = self.slave1
-        r = c.post('/query/', data={'instance_name': self.slave1.instance_name,
+        _user_instances.return_value.get.return_value = self.subordinate1
+        r = c.post('/query/', data={'instance_name': self.subordinate1.instance_name,
                                     'sql_content': some_sql,
                                     'db_name': some_db,
                                     'limit_num': some_limit})
@@ -920,7 +920,7 @@ class TestQuery(TransactionTestCase):
         print(r_json)
         self.assertEqual(r_json['data']['rows'], ['value'])
         self.assertEqual(r_json['data']['column_list'], ['some'])
-        self.assertEqual(r_json['data']['seconds_behind_master'], 100)
+        self.assertEqual(r_json['data']['seconds_behind_main'], 100)
 
     @patch('sql.query.user_instances')
     @patch('sql.query.get_engine')
@@ -939,8 +939,8 @@ class TestQuery(TransactionTestCase):
         _get_engine.return_value.filter_sql.return_value = sql_with_limit
         _get_engine.return_value.query.return_value = q_result
         _priv_check.return_value = {'status': 0, 'data': {'limit_num': 100, 'priv_check': True}}
-        _user_instances.return_value.get.return_value = self.slave1
-        r = c.post('/query/', data={'instance_name': self.slave1.instance_name,
+        _user_instances.return_value.get.return_value = self.subordinate1
+        r = c.post('/query/', data={'instance_name': self.subordinate1.instance_name,
                                     'sql_content': sql_without_limit,
                                     'db_name': some_db,
                                     'limit_num': some_limit})
@@ -955,7 +955,7 @@ class TestQuery(TransactionTestCase):
         filtered_sql_with_star = 'select * from some_table limit {0};'.format(some_limit)
         _get_engine.return_value.filter_sql.return_value = filtered_sql_with_star
         _get_engine.return_value.query.reset_mock()
-        c.post('/query/', data={'instance_name': self.slave1.instance_name,
+        c.post('/query/', data={'instance_name': self.subordinate1.instance_name,
                                 'sql_content': sql_with_star,
                                 'db_name': some_db,
                                 'limit_num': some_limit})
@@ -972,7 +972,7 @@ class TestQuery(TransactionTestCase):
         _priv_check.return_value = {'status': 0, 'data': {'limit_num': 100, 'priv_check': True}}
         archer_config = SysConfig()
         archer_config.set('disable_star', True)
-        r = c.post('/query/', data={'instance_name': self.slave1.instance_name,
+        r = c.post('/query/', data={'instance_name': self.subordinate1.instance_name,
                                     'sql_content': sql_with_star,
                                     'db_name': some_db,
                                     'limit_num': some_limit})
@@ -982,7 +982,7 @@ class TestQuery(TransactionTestCase):
 
     @patch('sql.query.get_engine')
     def test_kill_query_conn(self, _get_engine):
-        kill_query_conn(self.slave1.id, 10)
+        kill_query_conn(self.subordinate1.id, 10)
         _get_engine.return_value.kill_connection.return_value = ResultSet()
 
     def test_query_log(self):
@@ -1043,9 +1043,9 @@ class TestWorkflowView(TransactionTestCase):
                                             can_execute_resource_permission)
         self.superuser1 = User(username='super1', is_superuser=True)
         self.superuser1.save()
-        self.master1 = Instance(instance_name='test_master_instance', type='master', db_type='mysql',
+        self.main1 = Instance(instance_name='test_main_instance', type='main', db_type='mysql',
                                 host='testhost', port=3306, user='mysql_user', password='mysql_password')
-        self.master1.save()
+        self.main1.save()
         self.wf1 = SqlWorkflow.objects.create(
             workflow_name='some_name',
             group_id=1,
@@ -1056,7 +1056,7 @@ class TestWorkflowView(TransactionTestCase):
             create_time=self.now - timedelta(days=1),
             status='workflow_finish',
             is_backup=True,
-            instance=self.master1,
+            instance=self.main1,
             db_name='some_db',
             syntax_type=1,
         )
@@ -1078,7 +1078,7 @@ class TestWorkflowView(TransactionTestCase):
             create_time=self.now - timedelta(days=1),
             status='workflow_manreviewing',
             is_backup=True,
-            instance=self.master1,
+            instance=self.main1,
             db_name='some_db',
             syntax_type=1
         )
@@ -1098,7 +1098,7 @@ class TestWorkflowView(TransactionTestCase):
     def tearDown(self):
         SqlWorkflowContent.objects.all().delete()
         SqlWorkflow.objects.all().delete()
-        self.master1.delete()
+        self.main1.delete()
         self.u1.delete()
         self.superuser1.delete()
         self.resource_group1.delete()
@@ -1116,7 +1116,7 @@ class TestWorkflowView(TransactionTestCase):
         """测试工单检测，参数内容为空"""
         c = Client()
         c.force_login(self.superuser1)
-        data = {"instance_name": self.master1.instance_name}
+        data = {"instance_name": self.main1.instance_name}
         r = c.post('/simplecheck/', data=data)
         self.assertDictEqual(json.loads(r.content),
                              {'status': 1, 'msg': '页面提交参数可能为空', 'data': {}})
@@ -1128,7 +1128,7 @@ class TestWorkflowView(TransactionTestCase):
         c.force_login(self.superuser1)
         data = {
             "sql_content": "update sql_users set email = ''where id > 0;",
-            "instance_name": self.master1.instance_name,
+            "instance_name": self.main1.instance_name,
             "db_name": "archery",
         }
         _get_engine.side_effect = RuntimeError('RuntimeError')
@@ -1145,7 +1145,7 @@ class TestWorkflowView(TransactionTestCase):
         c.force_login(self.superuser1)
         data = {
             "sql_content": "update sql_users set email = ''where id > 0;",  #
-            "instance_name": self.master1.instance_name,
+            "instance_name": self.main1.instance_name,
             "db_name": "archery",
         }
         column_list = [
@@ -1181,7 +1181,7 @@ class TestWorkflowView(TransactionTestCase):
         data = {"sql_content": "update sql_users set email='' where id>0;",
                 "workflow_name": "【回滚工单】原工单Id:163+,3434434343",
                 "group_name": self.resource_group1.group_name,
-                "instance_name": self.master1.instance_name,
+                "instance_name": self.main1.instance_name,
                 "run_date_start": "",
                 "run_date_end": "",
                 "workflow_auditors": "11"}
@@ -1199,13 +1199,13 @@ class TestWorkflowView(TransactionTestCase):
         data = {"sql_content": "update sql_users set email='' where id>0;",
                 "workflow_name": "【回滚工单】原工单Id:163+,3434434343",
                 "group_name": self.resource_group1.group_name,
-                "instance_name": self.master1.instance_name,
+                "instance_name": self.main1.instance_name,
                 "db_name": "archery",
                 "demand_url": 'test_url',
                 "run_date_start": "",
                 "run_date_end": "",
                 "workflow_auditors": "11"}
-        _user_instances.return_value.get.return_value = self.master1
+        _user_instances.return_value.get.return_value = self.main1
         _get_engine.return_value.execute_check.return_value = ReviewSet(
             syntax_type=1,
             warning_count=1,
@@ -1227,13 +1227,13 @@ class TestWorkflowView(TransactionTestCase):
         data = {"sql_content": "update sql_users set email='' where id>0;",
                 "workflow_name": "【回滚工单】原工单Id:163+,3434434343",
                 "group_name": self.resource_group1.group_name,
-                "instance_name": self.master1.instance_name,
+                "instance_name": self.main1.instance_name,
                 "db_name": "archery",
                 "demand_url": 'test_url',
                 "run_date_start": "",
                 "run_date_end": "",
                 "workflow_auditors": "11"}
-        _user_instances.return_value.get.return_value = self.master1
+        _user_instances.return_value.get.return_value = self.main1
         _get_engine.return_value.execute_check.return_value = ReviewSet(
             syntax_type=1,
             warning_count=1,
@@ -1437,7 +1437,7 @@ class TestWorkflowView(TransactionTestCase):
             'workflow_name': 'some_title',
             'group_name': self.resource_group1.group_name,
             'group_id': self.resource_group1.group_id,
-            'instance_name': self.master1.instance_name,
+            'instance_name': self.main1.instance_name,
             "demand_url": 'test_url',
             'db_name': 'some_db',
             'is_backup': True,
@@ -1471,7 +1471,7 @@ class TestWorkflowView(TransactionTestCase):
             'workflow_name': 'some_title_2',
             'group_name': self.resource_group1.group_name,
             'group_id': self.resource_group1.group_id,
-            'instance_name': self.master1.instance_name,
+            'instance_name': self.main1.instance_name,
             'db_name': 'some_db',
             "demand_url": 'test_url',
             'is_backup': False,
@@ -1532,19 +1532,19 @@ class TestOptimize(TestCase):
         self.superuser = User(username='super', is_superuser=True)
         self.superuser.save()
         # 使用 travis.ci 时实例和测试service保持一致
-        self.master = Instance(instance_name='test_instance', type='master', db_type='mysql',
+        self.main = Instance(instance_name='test_instance', type='main', db_type='mysql',
                                host=settings.DATABASES['default']['HOST'],
                                port=settings.DATABASES['default']['PORT'],
                                user=settings.DATABASES['default']['USER'],
                                password=settings.DATABASES['default']['PASSWORD'])
-        self.master.save()
+        self.main.save()
         self.sys_config = SysConfig()
         self.client = Client()
         self.client.force_login(self.superuser)
 
     def tearDown(self):
         self.superuser.delete()
-        self.master.delete()
+        self.main.delete()
         self.sys_config.replace(json.dumps({}))
 
     def test_sqladvisor(self):
@@ -1628,19 +1628,19 @@ class TestSchemaSync(TestCase):
         self.superuser = User(username='super', is_superuser=True)
         self.superuser.save()
         # 使用 travis.ci 时实例和测试service保持一致
-        self.master = Instance(instance_name='test_instance', type='master', db_type='mysql',
+        self.main = Instance(instance_name='test_instance', type='main', db_type='mysql',
                                host=settings.DATABASES['default']['HOST'],
                                port=settings.DATABASES['default']['PORT'],
                                user=settings.DATABASES['default']['USER'],
                                password=settings.DATABASES['default']['PASSWORD'])
-        self.master.save()
+        self.main.save()
         self.sys_config = SysConfig()
         self.client = Client()
         self.client.force_login(self.superuser)
 
     def tearDown(self):
         self.superuser.delete()
-        self.master.delete()
+        self.main.delete()
         self.sys_config.replace(json.dumps({}))
 
     def test_schema_sync(self):
@@ -1673,7 +1673,7 @@ class TestArchiver(TestCase):
         self.u2.user_permissions.add(menu_archive)
         self.u2.user_permissions.add(archive_review)
         # 使用 travis.ci 时实例和测试service保持一致
-        self.ins = Instance.objects.create(instance_name='test_instance', type='master', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='test_instance', type='main', db_type='mysql',
                                            host=settings.DATABASES['default']['HOST'],
                                            port=settings.DATABASES['default']['PORT'],
                                            user=settings.DATABASES['default']['USER'],
@@ -1888,9 +1888,9 @@ class TestAsync(TestCase):
         self.now = datetime.now()
         self.u1 = User(username='some_user', display='用户1')
         self.u1.save()
-        self.master1 = Instance(instance_name='test_master_instance', type='master', db_type='mysql',
+        self.main1 = Instance(instance_name='test_main_instance', type='main', db_type='mysql',
                                 host='testhost', port=3306, user='mysql_user', password='mysql_password')
-        self.master1.save()
+        self.main1.save()
         self.wf1 = SqlWorkflow.objects.create(
             workflow_name='some_name2',
             group_id=1,
@@ -1901,7 +1901,7 @@ class TestAsync(TestCase):
             create_time=self.now - timedelta(days=1),
             status='workflow_executing',
             is_backup=True,
-            instance=self.master1,
+            instance=self.main1,
             db_name='some_db',
             syntax_type=1,
         )
@@ -1925,7 +1925,7 @@ class TestAsync(TestCase):
         self.wf1.delete()
         self.u1.delete()
         self.task_result = None
-        self.master1.delete()
+        self.main1.delete()
 
     @patch('sql.utils.execute_sql.notify_for_execute')
     @patch('sql.utils.execute_sql.Audit')
@@ -1954,19 +1954,19 @@ class TestSQLAnalyze(TestCase):
         self.superuser = User(username='super', is_superuser=True)
         self.superuser.save()
         # 使用 travis.ci 时实例和测试service保持一致
-        self.master = Instance(instance_name='test_instance', type='master', db_type='mysql',
+        self.main = Instance(instance_name='test_instance', type='main', db_type='mysql',
                                host=settings.DATABASES['default']['HOST'],
                                port=settings.DATABASES['default']['PORT'],
                                user=settings.DATABASES['default']['USER'],
                                password=settings.DATABASES['default']['PASSWORD'])
-        self.master.save()
+        self.main.save()
         self.sys_config = SysConfig()
         self.client = Client()
         self.client.force_login(self.superuser)
 
     def tearDown(self):
         self.superuser.delete()
-        self.master.delete()
+        self.main.delete()
         self.sys_config.replace(json.dumps({}))
 
     def test_generate_text_None(self):
@@ -2003,7 +2003,7 @@ class TestSQLAnalyze(TestCase):
         :return:
         """
         text = "select * from sql_user;select * from sql_workflow;"
-        instance_name = self.master.instance_name
+        instance_name = self.main.instance_name
         db_name = settings.DATABASES['default']['TEST']['NAME']
         r = self.client.post(path='/sql_analyze/analyze/',
                              data={"text": text, "instance_name": instance_name, "db_name": db_name})
@@ -2019,19 +2019,19 @@ class TestBinLog(TestCase):
         self.superuser = User(username='super', is_superuser=True)
         self.superuser.save()
         # 使用 travis.ci 时实例和测试service保持一致
-        self.master = Instance(instance_name='test_instance', type='master', db_type='mysql',
+        self.main = Instance(instance_name='test_instance', type='main', db_type='mysql',
                                host=settings.DATABASES['default']['HOST'],
                                port=settings.DATABASES['default']['PORT'],
                                user=settings.DATABASES['default']['USER'],
                                password=settings.DATABASES['default']['PASSWORD'])
-        self.master.save()
+        self.main.save()
         self.sys_config = SysConfig()
         self.client = Client()
         self.client.force_login(self.superuser)
 
     def tearDown(self):
         self.superuser.delete()
-        self.master.delete()
+        self.main.delete()
         self.sys_config.replace(json.dumps({}))
 
     def test_binlog_list_instance_not_exist(self):
@@ -2130,7 +2130,7 @@ class TestBinLog(TestCase):
                 "only_schemas": "",
                 "only_dml": "true",
                 "sql_type": "",
-                "instance": self.master}
+                "instance": self.main}
         _subprocess.Popen.return_value.stdout.return_value.readline.return_value = 'sql'
         _iter.return_value = ''
         r = binlog2sql_file(args=args, user=self.superuser)
@@ -2154,7 +2154,7 @@ class TestBinLog(TestCase):
         :return:
         """
         data = {
-            "instance_id": self.master.id,
+            "instance_id": self.main.id,
             "binlog": ''
         }
         r = self.client.post(path='/binlog/del_log/', data=data)
@@ -2168,7 +2168,7 @@ class TestBinLog(TestCase):
         :return:
         """
         data = {
-            "instance_id": self.master.id,
+            "instance_id": self.main.id,
             "binlog": "mysql-bin.000001"
         }
         _query.return_value = ResultSet(full_sql='select 1')
@@ -2183,7 +2183,7 @@ class TestBinLog(TestCase):
         :return:
         """
         data = {
-            "instance_id": self.master.id,
+            "instance_id": self.main.id,
             "binlog": "mysql-bin.000001"
         }
         _query.return_value = ResultSet(full_sql='select 1')
@@ -2201,18 +2201,18 @@ class TestParam(TestCase):
         self.superuser = User(username='super', is_superuser=True)
         self.superuser.save()
         # 使用 travis.ci 时实例和测试service保持一致
-        self.master = Instance(instance_name='test_instance', type='master', db_type='mysql',
+        self.main = Instance(instance_name='test_instance', type='main', db_type='mysql',
                                host=settings.DATABASES['default']['HOST'],
                                port=settings.DATABASES['default']['PORT'],
                                user=settings.DATABASES['default']['USER'],
                                password=settings.DATABASES['default']['PASSWORD'])
-        self.master.save()
+        self.main.save()
         self.client = Client()
         self.client.force_login(self.superuser)
 
     def tearDown(self):
         self.superuser.delete()
-        self.master.delete()
+        self.main.delete()
         ParamTemplate.objects.all().delete()
 
     def test_param_list_instance_not_exist(self):
@@ -2234,7 +2234,7 @@ class TestParam(TestCase):
         :return:
         """
         data = {
-            "instance_id": self.master.id,
+            "instance_id": self.main.id,
             "editable": True
         }
         r = self.client.post(path='/param/list/', data=data)
@@ -2245,7 +2245,7 @@ class TestParam(TestCase):
         测试获取参数修改历史
         :return:
         """
-        data = {"instance_id": self.master.id,
+        data = {"instance_id": self.main.id,
                 "search": "binlog",
                 "limit": 14,
                 "offset": 0}
@@ -2260,7 +2260,7 @@ class TestParam(TestCase):
         测试参数修改，参数未在模板配置
         :return:
         """
-        data = {"instance_id": self.master.id,
+        data = {"instance_id": self.main.id,
                 "variable_name": "1",
                 "variable_value": "false"}
         r = self.client.post(path='/param/edit/', data=data)
@@ -2282,7 +2282,7 @@ class TestParam(TestCase):
                                      variable_name='binlog_format',
                                      default_value='ROW',
                                      editable=True)
-        data = {"instance_id": self.master.id,
+        data = {"instance_id": self.main.id,
                 "variable_name": "binlog_format",
                 "runtime_value": "ROW"}
         r = self.client.post(path='/param/edit/', data=data)
@@ -2304,7 +2304,7 @@ class TestParam(TestCase):
                                      variable_name='binlog_format',
                                      default_value='ROW',
                                      editable=True)
-        data = {"instance_id": self.master.id,
+        data = {"instance_id": self.main.id,
                 "variable_name": "binlog_format",
                 "runtime_value": "STATEMENT"}
         r = self.client.post(path='/param/edit/', data=data)
@@ -2326,7 +2326,7 @@ class TestParam(TestCase):
                                      variable_name='binlog_format',
                                      default_value='ROW',
                                      editable=True)
-        data = {"instance_id": self.master.id,
+        data = {"instance_id": self.main.id,
                 "variable_name": "binlog_format",
                 "runtime_value": "STATEMENT"}
         r = self.client.post(path='/param/edit/', data=data)
@@ -2343,7 +2343,7 @@ class TestNotify(TestCase):
         self.user = User.objects.create(username='test_user', display='中文显示', is_active=True)
         self.su = User.objects.create(username='s_user', display='中文显示', is_active=True, is_superuser=True)
         tomorrow = datetime.today() + timedelta(days=1)
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql',
                                            host='some_host',
                                            port=3306, user='ins_user', password='some_str')
         self.wf = SqlWorkflow.objects.create(
@@ -2638,7 +2638,7 @@ class TestDataDictionary(TestCase):
         self.client = Client()
         self.client.force_login(self.su)
         # 使用 travis.ci 时实例和测试service保持一致
-        self.ins = Instance.objects.create(instance_name='test_instance', type='slave', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='test_instance', type='subordinate', db_type='mysql',
                                            host=settings.DATABASES['default']['HOST'],
                                            port=settings.DATABASES['default']['PORT'],
                                            user=settings.DATABASES['default']['USER'],

--- a/sql/utils/data_masking.py
+++ b/sql/utils/data_masking.py
@@ -103,7 +103,7 @@ def analyze_query_tree(query_tree, instance):
                 if len(select_item['args']) != 1:
                     raise Exception('不支持该查询语句脱敏！请联系管理员')
 
-        # 处理select_list，为统一的{'type': 'FIELD_ITEM', 'db': 'archery_master', 'table': 'sql_users', 'field': 'email'}格式
+        # 处理select_list，为统一的{'type': 'FIELD_ITEM', 'db': 'archery_main', 'table': 'sql_users', 'field': 'email'}格式
         # 获取select信息的规则，如[*],[*,column_a],[column_a,*],[column_a,a.*,column_b],[a.*,column_a,b.*]
         select_index = []
         select_list = []

--- a/sql/utils/resource_group.py
+++ b/sql/utils/resource_group.py
@@ -20,7 +20,7 @@ def user_instances(user, type=None, db_type=None, tag_codes=None):
     """
     获取用户实例列表（通过资源组间接关联）
     :param user:
-    :param type: 实例类型 all：全部，master主库，salve从库
+    :param type: 实例类型 all：全部，main主库，salve从库
     :param db_type: 数据库类型, ['mysql','mssql']
     :param tag_codes: 标签code列表, ['can_write', 'can_read']
     :return:

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -128,12 +128,12 @@ class TestSQLReview(TestCase):
         self.superuser = User.objects.create(username='super', is_superuser=True)
         self.user = User.objects.create(username='user')
         # 使用 travis.ci 时实例和测试service保持一致
-        self.master = Instance(instance_name='test_instance', type='master', db_type='mysql',
+        self.main = Instance(instance_name='test_instance', type='main', db_type='mysql',
                                host=settings.DATABASES['default']['HOST'],
                                port=settings.DATABASES['default']['PORT'],
                                user=settings.DATABASES['default']['USER'],
                                password=settings.DATABASES['default']['PASSWORD'])
-        self.master.save()
+        self.main.save()
         self.sys_config = SysConfig()
         self.client = Client()
         self.group = ResourceGroup.objects.create(group_id=1, group_name='group_name')
@@ -147,7 +147,7 @@ class TestSQLReview(TestCase):
             create_time=datetime.datetime.now(),
             status='workflow_review_pass',
             is_backup=True,
-            instance=self.master,
+            instance=self.main,
             db_name='db_name',
             syntax_type=1,
         )
@@ -162,7 +162,7 @@ class TestSQLReview(TestCase):
         self.group.delete()
         self.superuser.delete()
         self.user.delete()
-        self.master.delete()
+        self.main.delete()
         self.sys_config.replace(json.dumps({}))
 
     @patch('sql.engines.get_engine')
@@ -464,7 +464,7 @@ class TestSQLReview(TestCase):
 
 class TestExecuteSql(TestCase):
     def setUp(self):
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql',
                                            host='some_host',
                                            port=3306, user='ins_user', password='some_str')
         self.wf = SqlWorkflow.objects.create(
@@ -635,7 +635,7 @@ class TestAudit(TestCase):
         self.user = User.objects.create(username='test_user', display='中文显示', is_active=True)
         self.su = User.objects.create(username='s_user', display='中文显示', is_active=True, is_superuser=True)
         tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql',
                                            host='some_host',
                                            port=3306, user='ins_user', password='some_str')
         self.res_group = ResourceGroup.objects.create(group_id=1, group_name='group_name')
@@ -1092,7 +1092,7 @@ class TestDataMasking(TestCase):
     def setUp(self):
         self.superuser = User.objects.create(username='super', is_superuser=True)
         self.user = User.objects.create(username='user')
-        self.ins = Instance.objects.create(instance_name='some_ins', type='slave', db_type='mysql',
+        self.ins = Instance.objects.create(instance_name='some_ins', type='subordinate', db_type='mysql',
                                            host='some_host',
                                            port=3306, user='ins_user', password='some_str')
         self.sys_config = SysConfig()
@@ -1313,10 +1313,10 @@ class TestResourceGroup(TestCase):
         self.sys_config = SysConfig()
         self.user = User.objects.create(username='test_user', display='中文显示', is_active=True)
         self.su = User.objects.create(username='s_user', display='中文显示', is_active=True, is_superuser=True)
-        self.ins1 = Instance.objects.create(instance_name='some_ins1', type='slave', db_type='mysql',
+        self.ins1 = Instance.objects.create(instance_name='some_ins1', type='subordinate', db_type='mysql',
                                             host='some_host',
                                             port=3306, user='ins_user', password='some_str')
-        self.ins2 = Instance.objects.create(instance_name='some_ins2', type='slave', db_type='mysql',
+        self.ins2 = Instance.objects.create(instance_name='some_ins2', type='subordinate', db_type='mysql',
                                             host='some_host',
                                             port=3306, user='ins_user', password='some_str')
         self.rgp1 = ResourceGroup.objects.create(group_name='group1')


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.