### PR TITLE
修复inception/goinception 连接ssh隧道bug

### DIFF
--- a/sql/engines/__init__.py
+++ b/sql/engines/__init__.py
@@ -35,6 +35,31 @@ class EngineBase:
     def __del__(self):
         if hasattr(self, 'ssh'):
             del self.ssh
+        if hasattr(self, 'remotessh'):
+            del self.remotessh
+
+    def remote_instance_conn(self, instance=None):
+        # 判断如果配置了隧道则连接隧道
+        if not hasattr(self, 'remotessh') and instance.tunnel:
+            self.remotessh = SSHConnection(
+                instance.host,
+                instance.port,
+                instance.tunnel.host,
+                instance.tunnel.port,
+                instance.tunnel.user,
+                instance.tunnel.password,
+                instance.tunnel.pkey_path,
+                instance.tunnel.pkey_password,
+            )
+            self.remote_host, self.remote_port = self.remotessh.get_ssh()
+            self.remote_user = instance.user
+            self.remote_password = instance.password
+        elif not instance.tunnel:
+            self.remote_host = instance.host
+            self.remote_port = instance.port
+            self.remote_user = instance.user
+            self.remote_password = instance.password
+        return self.remote_host, self.remote_port, self.remote_user, self.remote_password
 
     def get_connection(self, db_name=None):
         """返回一个conn实例"""

--- a/sql/engines/goinception.py
+++ b/sql/engines/goinception.py
@@ -8,6 +8,7 @@ from common.config import SysConfig
 from sql.utils.sql_utils import get_syntax_type
 from . import EngineBase
 from .models import ResultSet, ReviewSet, ReviewResult
+from sql.utils.ssh_tunnel import SSHConnection
 
 logger = logging.getLogger('default')
 
@@ -66,6 +67,21 @@ class GoInceptionEngine(EngineBase):
     def execute(self, workflow=None):
         """执行上线单"""
         instance = workflow.instance
+        # 判断如果配置了隧道则连接隧道
+        host = instance.host
+        port = instance.port
+        if instance.tunnel:
+            ssh = SSHConnection(
+                instance.host,
+                instance.port,
+                instance.tunnel.host,
+                instance.tunnel.port,
+                instance.tunnel.user,
+                instance.tunnel.password,
+                instance.tunnel.pkey_path,
+                instance.tunnel.pkey_password,
+            )
+            host,port = ssh.get_ssh()
         execute_result = ReviewSet(full_sql=workflow.sqlworkflowcontent.sql_content)
         if workflow.is_backup:
             str_backup = "--backup=1"
@@ -73,12 +89,14 @@ class GoInceptionEngine(EngineBase):
             str_backup = "--backup=0"
 
         # 提交inception执行
-        sql_execute = f"""/*--user='{instance.user}';--password='{instance.password}';--host='{instance.host}';--port={instance.port};--execute=1;--ignore-warnings=1;{str_backup};--sleep=200;--sleep_rows=100*/
+        sql_execute = f"""/*--user='{instance.user}';--password='{instance.password}';--host='{host}';--port={port};--execute=1;--ignore-warnings=1;{str_backup};--sleep=200;--sleep_rows=100*/
                             inception_magic_start;
                             use `{workflow.db_name}`;
                             {workflow.sqlworkflowcontent.sql_content.rstrip(';')};
                             inception_magic_commit;"""
         inception_result = self.query(sql=sql_execute)
+        if instance.tunnel:
+            del ssh
 
         # 执行报错，inception crash或者执行中连接异常的场景
         if inception_result.error and not execute_result.rows:
@@ -129,12 +147,29 @@ class GoInceptionEngine(EngineBase):
         """
         打印语法树。
         """
-        sql = f"""/*--user='{instance.user}';--password='{instance.password}';--host='{instance.host}';--port={instance.port};--enable-query-print;*/
+        # 判断如果配置了隧道则连接隧道
+        host = instance.host
+        port = instance.port
+        if instance.tunnel:
+            ssh = SSHConnection(
+                instance.host,
+                instance.port,
+                instance.tunnel.host,
+                instance.tunnel.port,
+                instance.tunnel.user,
+                instance.tunnel.password,
+                instance.tunnel.pkey_path,
+                instance.tunnel.pkey_password,
+            )
+            host,port = ssh.get_ssh()   
+        sql = f"""/*--user='{instance.user}';--password='{instance.password}';--host='{host}';--port={port};--enable-query-print;*/
                           inception_magic_start;\
                           use `{db_name}`;
                           {sql.rstrip(';')};
                           inception_magic_commit;"""
         print_info = self.query(db_name=db_name, sql=sql).to_dict()[1]
+        if instance.tunnel:
+            del ssh
         if print_info.get('errmsg'):
             raise RuntimeError(print_info.get('errmsg'))
         return print_info

--- a/sql/engines/inception.py
+++ b/sql/engines/inception.py
@@ -123,7 +123,7 @@ class InceptionEngine(EngineBase):
         else:
             str_backup = "--disable-remote-backup"
         # 根据inception的要求，执行之前最好先split一下
-        sql_split = f"""/*--user={instance.user};--password={instance.password};--host={host}; 
+        sql_split = f"""/*--user={instance.user};--password={instance.password};--host={host};
                          --port={port};--enable-ignore-warnings;--enable-split;*/
                          inception_magic_start;
                          use `{workflow.db_name}`;

--- a/sql/engines/inception.py
+++ b/sql/engines/inception.py
@@ -10,7 +10,6 @@ from common.config import SysConfig
 from sql.utils.sql_utils import get_syntax_type
 from . import EngineBase
 from .models import ResultSet, ReviewSet, ReviewResult
-from sql.utils.ssh_tunnel import SSHConnection
 
 logger = logging.getLogger('default')
 
@@ -56,32 +55,17 @@ class InceptionEngine(EngineBase):
     def execute_check(self, instance=None, db_name=None, sql=''):
         """inception check"""
         # 判断如果配置了隧道则连接隧道
-        host = instance.host
-        port = instance.port
-        if instance.tunnel:
-            ssh = SSHConnection(
-                instance.host,
-                instance.port,
-                instance.tunnel.host,
-                instance.tunnel.port,
-                instance.tunnel.user,
-                instance.tunnel.password,
-                instance.tunnel.pkey_path,
-                instance.tunnel.pkey_password,
-            )
-            host,port = ssh.get_ssh()
+        host, port, user, password = self.remote_instance_conn(instance)
         check_result = ReviewSet(full_sql=sql)
         # inception 校验
         check_result.rows = []
-        inception_sql = f"""/*--user={instance.user};--password={instance.password};--host={host};
+        inception_sql = f"""/*--user={user};--password={password};--host={host};
                             --port={port};--enable-check=1;*/
                             inception_magic_start;
                             use `{db_name}`;
                             {sql}
                             inception_magic_commit;"""
         inception_result = self.query(sql=inception_sql)
-        if instance.tunnel:
-            del ssh
         check_result.syntax_type = 2  # TODO 工单类型 0、其他 1、DDL，2、DML 仅适用于MySQL，待调整
         for r in inception_result.rows:
             check_result.rows += [ReviewResult(inception_result=r)]
@@ -103,27 +87,14 @@ class InceptionEngine(EngineBase):
         """执行上线单"""
         instance = workflow.instance
         # 判断如果配置了隧道则连接隧道
-        host = instance.host
-        port = instance.port
-        if instance.tunnel:
-            ssh = SSHConnection(
-                instance.host,
-                instance.port,
-                instance.tunnel.host,
-                instance.tunnel.port,
-                instance.tunnel.user,
-                instance.tunnel.password,
-                instance.tunnel.pkey_path,
-                instance.tunnel.pkey_password,
-            )
-            host,port = ssh.get_ssh()
+        host, port, user, password = self.remote_instance_conn(instance)
         execute_result = ReviewSet(full_sql=workflow.sqlworkflowcontent.sql_content)
         if workflow.is_backup:
             str_backup = "--enable-remote-backup"
         else:
             str_backup = "--disable-remote-backup"
         # 根据inception的要求，执行之前最好先split一下
-        sql_split = f"""/*--user={instance.user};--password={instance.password};--host={host};
+        sql_split = f"""/*--user={user};--password={password};--host={host};
                          --port={port};--enable-ignore-warnings;--enable-split;*/
                          inception_magic_start;
                          use `{workflow.db_name}`;
@@ -134,7 +105,7 @@ class InceptionEngine(EngineBase):
         # 对于split好的结果，再次交给inception执行，保持长连接里执行.
         for splitRow in split_result.rows:
             sql_tmp = splitRow[1]
-            sql_execute = f"""/*--user={instance.user};--password={instance.password};--host={host};
+            sql_execute = f"""/*--user={user};--password={password};--host={host};
                                 --port={port};--enable-execute;--enable-ignore-warnings;{str_backup};*/
                                 inception_magic_start;
                                 {sql_tmp}
@@ -155,10 +126,6 @@ class InceptionEngine(EngineBase):
             # 把结果转换为ReviewSet
             for r in one_line_execute_result.rows:
                 execute_result.rows += [ReviewResult(inception_result=r)]
-
-        if instance.tunnel:
-            del ssh
-
         # 如果发现任何一个行执行结果里有errLevel为1或2，并且状态列没有包含Execute Successfully，则最终执行结果为有异常.
         for r in execute_result.rows:
             if r.errlevel in (1, 2) and not re.search(r"Execute Successfully", r.stagestatus):
@@ -194,29 +161,14 @@ class InceptionEngine(EngineBase):
         将sql交给inception打印语法树。
         """
         # 判断如果配置了隧道则连接隧道
-        host = instance.host
-        port = instance.port
-        if instance.tunnel:
-            ssh = SSHConnection(
-                instance.host,
-                instance.port,
-                instance.tunnel.host,
-                instance.tunnel.port,
-                instance.tunnel.user,
-                instance.tunnel.password,
-                instance.tunnel.pkey_path,
-                instance.tunnel.pkey_password,
-            )
-            host,port = ssh.get_ssh()
-        sql = f"""/*--user={instance.user};--password={instance.password};--host={host};
+        host, port, user, password = self.remote_instance_conn(instance)
+        sql = f"""/*--user={user};--password={password};--host={host};
                           --port={port};--enable-query-print;*/
                           inception_magic_start;\
                           use `{db_name}`;
                           {sql}
                           inception_magic_commit;"""
         print_info = self.query(db_name=db_name, sql=sql).to_dict()[0]
-        if instance.tunnel:
-            del ssh
         # 兼容语法错误时errlevel=0的场景
         if print_info['errlevel'] == 0 and print_info['errmsg'] == 'None':
             return json.loads(_repair_json_str(print_info['query_tree']))


### PR DESCRIPTION
我发现没有查询权限的用户在申请查询权限后，会通过inception/goinception审核权限类型，此时的instance如果配置了隧道，并不会通过隧道连接，导致连接失败。
为此我在sql/engines/inception.py/   sql/engines/goinception.py 对instance增加了隧道判断和连接隧道的代码，修复该bug。