### PR TITLE
手动执行按钮改名为“已手动完成”

### DIFF
--- a/sql/templates/detail.html
+++ b/sql/templates/detail.html
@@ -207,7 +207,7 @@
                 <input type="hidden" name="mode" value="manual">
                 <input type="hidden" name="workflow_id" value="{{ workflow_detail.id }}">
                 <input type="button" id="btnExecuteOnly-manual" class="btn btn-warning"
-                       value="手动执行"/>
+                       value="已手动完成"/>
             </form>
         {% endif %}
     {% endif %}


### PR DESCRIPTION
“手动执行”按钮改名为“已手动完成”，以免误导