### PR TITLE
对接受入参的SQL拼接增加参数转义，规避注入风险 fix #979

### DIFF
--- a/sql/binlog.py
+++ b/sql/binlog.py
@@ -1,4 +1,5 @@
 # -*- coding: UTF-8 -*-
+import MySQLdb
 import logging
 import os
 import time
@@ -61,6 +62,9 @@ def del_binlog(request):
     except Instance.DoesNotExist:
         result = {'status': 1, 'msg': '实例不存在', 'data': []}
         return HttpResponse(json.dumps(result), content_type='application/json')
+
+    # escape
+    binlog = MySQLdb.escape_string(binlog).decode('utf-8')
 
     if binlog:
         query_engine = get_engine(instance=instance)

--- a/sql/data_dictionary.py
+++ b/sql/data_dictionary.py
@@ -27,6 +27,9 @@ def table_list(request):
         try:
             instance = Instance.objects.get(instance_name=instance_name, db_type='mysql')
             query_engine = get_engine(instance=instance)
+            # escape
+            db_name = MySQLdb.escape_string(db_name).decode('utf-8')
+
             sql = f"""SELECT
                 TABLE_NAME,
                 TABLE_COMMENT
@@ -62,6 +65,9 @@ def table_info(request):
         try:
             instance = Instance.objects.get(instance_name=instance_name, db_type='mysql')
             query_engine = get_engine(instance=instance)
+            # escape
+            db_name = MySQLdb.escape_string(db_name).decode('utf-8')
+            tb_name = MySQLdb.escape_string(tb_name).decode('utf-8')
 
             sql = f"""SELECT
                 TABLE_NAME as table_name,
@@ -141,6 +147,9 @@ def export(request):
     """导出数据字典"""
     instance_name = request.GET.get('instance_name', '')
     db_name = request.GET.get('db_name', '')
+    # escape
+    db_name = MySQLdb.escape_string(db_name).decode('utf-8')
+
     try:
         instance = user_instances(request.user, db_type=['mysql']).get(instance_name=instance_name)
         query_engine = get_engine(instance=instance)

--- a/sql/db_diagnostic.py
+++ b/sql/db_diagnostic.py
@@ -1,3 +1,5 @@
+import MySQLdb
+
 import simplejson as json
 from django.contrib.auth.decorators import permission_required
 
@@ -29,6 +31,9 @@ def process(request):
     if AliyunRdsConfig.objects.filter(instance=instance, is_enable=True).exists():
         result = aliyun_process_status(request)
     else:
+        # escape
+        command_type = MySQLdb.escape_string(command_type).decode('utf-8')
+
         if command_type == 'All':
             sql = base_sql + ";"
         elif command_type == 'Not Sleep':

--- a/sql/instance.py
+++ b/sql/instance.py
@@ -1,4 +1,5 @@
 # -*- coding: UTF-8 -*-
+import MySQLdb
 import os
 import time
 
@@ -251,9 +252,9 @@ def instance_resource(request):
     """
     instance_id = request.GET.get('instance_id')
     instance_name = request.GET.get('instance_name')
-    db_name = request.GET.get('db_name')
-    schema_name = request.GET.get('schema_name')
-    tb_name = request.GET.get('tb_name')
+    db_name = request.GET.get('db_name', '')
+    schema_name = request.GET.get('schema_name', '')
+    tb_name = request.GET.get('tb_name', '')
 
     resource_type = request.GET.get('resource_type')
     if instance_id:
@@ -267,6 +268,11 @@ def instance_resource(request):
     result = {'status': 0, 'msg': 'ok', 'data': []}
 
     try:
+        # escape
+        db_name = MySQLdb.escape_string(db_name).decode('utf-8')
+        schema_name = MySQLdb.escape_string(schema_name).decode('utf-8')
+        tb_name = MySQLdb.escape_string(tb_name).decode('utf-8')
+
         query_engine = get_engine(instance=instance)
         if resource_type == 'database':
             resource = query_engine.get_all_databases()

--- a/sql/instance_account.py
+++ b/sql/instance_account.py
@@ -1,4 +1,5 @@
 # -*- coding: UTF-8 -*-
+import MySQLdb
 import simplejson as json
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.password_validation import validate_password
@@ -93,6 +94,11 @@ def create(request):
     except ValidationError as msg:
         return JsonResponse({'status': 1, 'msg': f'{msg}', 'data': []})
 
+    # escape
+    user = MySQLdb.escape_string(user).decode('utf-8')
+    host = MySQLdb.escape_string(host).decode('utf-8')
+    password1 = MySQLdb.escape_string(password1).decode('utf-8')
+
     engine = get_engine(instance=instance)
     # 在一个事务内执行
     hosts = host.split("|")
@@ -155,6 +161,10 @@ def grant(request):
     priv_type = int(request.POST.get('priv_type'))
     privs = json.loads(request.POST.get('privs'))
     grant_sql = ''
+
+    # escape
+    user_host = MySQLdb.escape_string(user_host).decode('utf-8')
+
     # 全局权限
     if priv_type == 0:
         global_privs = privs['global_privs']
@@ -235,6 +245,10 @@ def reset_pwd(request):
     except Instance.DoesNotExist:
         return JsonResponse({'status': 1, 'msg': '你所在组未关联该实例', 'data': []})
 
+    # escape
+    user_host = MySQLdb.escape_string(user_host).decode('utf-8')
+    reset_pwd1 = MySQLdb.escape_string(reset_pwd1).decode('utf-8')
+
     # TODO 目前使用系统自带验证，后续实现验证器校验
     try:
         validate_password(reset_pwd1, user=None, password_validators=None)
@@ -269,6 +283,9 @@ def delete(request):
         instance = user_instances(request.user, db_type=['mysql']).get(id=instance_id)
     except Instance.DoesNotExist:
         return JsonResponse({'status': 1, 'msg': '你所在组未关联该实例', 'data': []})
+
+    # escape
+    user_host = MySQLdb.escape_string(user_host).decode('utf-8')
 
     engine = get_engine(instance=instance)
     exec_result = engine.execute(db_name='information_schema', sql=f"DROP USER {user_host};")

--- a/sql/instance_database.py
+++ b/sql/instance_database.py
@@ -5,6 +5,8 @@
 @file: instance_database.py
 @time: 2019/09/19
 """
+import MySQLdb
+
 import simplejson as json
 from django.contrib.auth.decorators import permission_required
 from django.http import JsonResponse, HttpResponse
@@ -101,6 +103,9 @@ def create(request):
         owner_display = Users.objects.get(username=owner).display
     except Users.DoesNotExist:
         return JsonResponse({'status': 1, 'msg': '负责人不存在', 'data': []})
+
+    # escape
+    db_name = MySQLdb.escape_string(db_name).decode('utf-8')
 
     engine = get_engine(instance=instance)
     exec_result = engine.execute(db_name='information_schema', sql=f"create database {db_name};")

--- a/sql/sql_optimize.py
+++ b/sql/sql_optimize.py
@@ -5,6 +5,7 @@
 @file: sql_optimize.py
 @time: 2019/03/04
 """
+import MySQLdb
 import re
 
 import simplejson as json
@@ -148,12 +149,14 @@ def optimize_sqltuning(request):
     sqltext = sqlparse.split(sqltext)[0]
     if re.match(r"^select|^show|^explain", sqltext, re.I) is None:
         result = {'status': 1, 'msg': '只支持查询SQL！', 'data': []}
-        return HttpResponse(json.dumps(result),content_type='application/json')
+        return HttpResponse(json.dumps(result), content_type='application/json')
     try:
         user_instances(request.user).get(instance_name=instance_name)
     except Instance.DoesNotExist:
         result = {'status': 1, 'msg': '你所在组未关联该实例！', 'data': []}
         return HttpResponse(json.dumps(result), content_type='application/json')
+    # escape
+    db_name = MySQLdb.escape_string(db_name).decode('utf-8')
 
     sql_tunning = SqlTuning(instance_name=instance_name, db_name=db_name, sqltext=sqltext)
     result = {'status': 0, 'msg': 'ok', 'data': {}}


### PR DESCRIPTION

目前采取对参数转义的方式进行处理，否则需要修改engine的方法接受SQL入参，改动略微有点大

参考文档：https://blog.csdn.net/weixin_42264360/article/details/96277424

实际的转义方法：https://github.com/mysql/mysql-server/blob/ee4455a33b10f1b1886044322e4893f587b319ed/mysys/charset.cc#L758


### sqlmap测试：
选取 data_dictionary 接口进行测试

测试命令：
```
./sqlmap.py -u "https://demo.archerydms.com/data_dictionary/table_info/?instance_name=archery&db_name=archery&tb_name=auth_group_permissions" --cookie="_ga=GA1.2.2110724810.1580562249; csrftoken=wd3y4yyGv43V8xIRayn2SzpxWfQqeFnR3SrXNRfHvH0CqQ9VsBc5IY6asPUPpYx8;  sessionid=ht8o3tnkd5a8ryh025fqyz8t4s8xvh12" --dbms mysql --tables  --dbs  -p tb_name
```

修改前
```bash
➜  sqlmapproject-sqlmap-12158af ./sqlmap.py -u "https://demo.archerydms.com/data_dictionary/table_info/?instance_name=archery&db_name=archery&tb_name=auth_group_permissions" --cookie="_ga=GA1.2.2110724810.1580562249; csrftoken=aA9eLTcSSZhjglDoq1HIz32QQsLmg0FNF2cdNFumaH7PcLl0NmLgmDhAOXXAlELF; sessionid=04p659wyc0zhq3219qrvfbig1k990ykr" --dbms mysql --dbs  -p tb_name

        ___
       __H__
 ___ ___[']_____ ___ ___  {1.4.12.10#dev}
|_ -| . [,]     | .'| . |
|___|_  [.]_|_|_|__,|  _|
      |_|V...       |_|   http://sqlmap.org

[!] legal disclaimer: Usage of sqlmap for attacking targets without prior mutual consent is illegal. It is the end user's responsibility to obey all applicable local, state and federal laws. Developers assume no liability and are not responsible for any misuse or damage caused by this program

[*] starting @ 14:31:02 /2020-12-05/

[14:31:02] [INFO] testing connection to the target URL
[14:31:03] [INFO] checking if the target is protected by some kind of WAF/IPS
[14:31:03] [INFO] testing if the target URL content is stable
[14:31:03] [INFO] target URL content is stable
[14:31:04] [WARNING] heuristic (basic) test shows that GET parameter 'tb_name' might not be injectable
[14:31:04] [INFO] testing for SQL injection on GET parameter 'tb_name'
[14:31:04] [INFO] testing 'AND boolean-based blind - WHERE or HAVING clause'
[14:31:06] [INFO] GET parameter 'tb_name' appears to be 'AND boolean-based blind - WHERE or HAVING clause' injectable
[14:31:06] [INFO] testing 'Generic inline queries'
[14:31:06] [INFO] testing 'MySQL >= 5.1 AND error-based - WHERE, HAVING, ORDER BY or GROUP BY clause (EXTRACTVALUE)'
[14:31:06] [INFO] testing 'MySQL >= 5.0.12 AND time-based blind (query SLEEP)'
[14:31:06] [WARNING] time-based comparison requires larger statistical model, please wait................. (done)
[14:31:41] [INFO] GET parameter 'tb_name' appears to be 'MySQL >= 5.0.12 AND time-based blind (query SLEEP)' injectable
for the remaining tests, do you want to include all tests for 'MySQL' extending provided level (1) and risk (1) values? [Y/n] y
[14:31:50] [INFO] testing 'Generic UNION query (NULL) - 1 to 20 columns'
[14:31:50] [INFO] automatically extending ranges for UNION query injection technique tests as there is at least one other (potential) technique found
[14:31:50] [INFO] 'ORDER BY' technique appears to be usable. This should reduce the time needed to find the right number of query columns. Automatically extending the range for current UNION query injection technique test
[14:31:52] [INFO] target URL appears to have 16 columns in query
[14:32:00] [INFO] GET parameter 'tb_name' is 'Generic UNION query (NULL) - 1 to 20 columns' injectable
GET parameter 'tb_name' is vulnerable. Do you want to keep testing the others (if any)? [y/N] y
sqlmap identified the following injection point(s) with a total of 73 HTTP(s) requests:
---
Parameter: tb_name (GET)
    Type: boolean-based blind
    Title: AND boolean-based blind - WHERE or HAVING clause
    Payload: instance_name=archery&db_name=archery&tb_name=auth_group_permissions' AND 4892=4892 AND 'tsaI'='tsaI

    Type: time-based blind
    Title: MySQL >= 5.0.12 AND time-based blind (query SLEEP)
    Payload: instance_name=archery&db_name=archery&tb_name=auth_group_permissions' AND (SELECT 2772 FROM (SELECT(SLEEP(5)))XlVn) AND 'VJWj'='VJWj

    Type: UNION query
    Title: Generic UNION query (NULL) - 16 columns
    Payload: instance_name=archery&db_name=archery&tb_name=-8381' UNION ALL SELECT NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,CONCAT(0x71626b6a71,0x6e7464656a614c53754b62734e684461725666517979746c65544b7878694f796c556b7043734856,0x716a6b7671),NULL-- -
---
[14:32:05] [INFO] the back-end DBMS is MySQL
web application technology: Nginx 1.16.1
back-end DBMS: MySQL >= 5.0.12
[14:32:06] [INFO] fetching database names
available databases [1]:
[*] information_schema

[*] ending @ 14:32:07 /2020-12-05/
```

修改后
```bash
➜  sqlmapproject-sqlmap-12158af ./sqlmap.py -u "https://demo.archerydms.com/data_dictionary/table_info/?instance_name=archery&db_name=archery&tb_name=auth_group_permissions" --cookie="_ga=GA1.2.2110724810.1580562249; csrftoken=aA9eLTcSSZhjglDoq1HIz32QQsLmg0FNF2cdNFumaH7PcLl0NmLgmDhAOXXAlELF; sessionid=04p659wyc0zhq3219qrvfbig1k990ykr" --dbms mysql --dbs  -p tb_name

        ___
       __H__
 ___ ___[']_____ ___ ___  {1.4.12.10#dev}
|_ -| . [,]     | .'| . |
|___|_  [(]_|_|_|__,|  _|
      |_|V...       |_|   http://sqlmap.org

[!] legal disclaimer: Usage of sqlmap for attacking targets without prior mutual consent is illegal. It is the end user's responsibility to obey all applicable local, state and federal laws. Developers assume no liability and are not responsible for any misuse or damage caused by this program

[*] starting @ 14:34:43 /2020-12-05/

[14:34:43] [INFO] testing connection to the target URL
[14:34:45] [INFO] checking if the target is protected by some kind of WAF/IPS
[14:34:46] [INFO] testing if the target URL content is stable
[14:34:47] [INFO] target URL content is stable
[14:34:48] [WARNING] heuristic (basic) test shows that GET parameter 'tb_name' might not be injectable
[14:34:49] [INFO] testing for SQL injection on GET parameter 'tb_name'
[14:34:49] [INFO] testing 'AND boolean-based blind - WHERE or HAVING clause'
[14:34:51] [INFO] testing 'Boolean-based blind - Parameter replace (original value)'
[14:34:51] [INFO] testing 'Generic inline queries'
[14:34:52] [INFO] testing 'MySQL >= 5.1 AND error-based - WHERE, HAVING, ORDER BY or GROUP BY clause (EXTRACTVALUE)'
[14:34:53] [INFO] testing 'MySQL >= 5.0.12 AND time-based blind (query SLEEP)'
[14:34:53] [WARNING] time-based comparison requires larger statistical model, please wait.......... (done)
it is recommended to perform only basic UNION tests if there is not at least one other (potential) technique found. Do you want to reduce the number of requests? [Y/n] y
[14:35:02] [INFO] testing 'Generic UNION query (NULL) - 1 to 10 columns'
[14:35:03] [WARNING] GET parameter 'tb_name' does not seem to be injectable
[14:35:03] [CRITICAL] all tested parameters do not appear to be injectable. Try to increase values for '--level'/'--risk' options if you wish to perform more tests. If you suspect that there is some kind of protection mechanism involved (e.g. WAF) maybe you could try to use option '--tamper' (e.g. '--tamper=space2comment') and/or switch '--random-agent'

[*] ending @ 14:35:03 /2020-12-05/
```



