### PR TITLE
add pycryptodome to requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-  - "3.6.5"
   - "3.7"
   - "3.8"
+  - "3.9"
 before_install:
   - sudo apt-get install unixodbc unixodbc-dev
 services:

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ sshtunnel==0.1.5
 uvloop==0.14.0
 httptools==0.1.1
 uvicorn==0.12.2
+pycryptodome==3.10.1


### PR DESCRIPTION
django 貌似不带这些玩意儿了

另外 3.6.5 不支持算了 ,CI 挂了, 反正我们的base 是 3.8