### PR TITLE
修复点击未收藏显示所有数据的bug

### DIFF
--- a/sql/query.py
+++ b/sql/query.py
@@ -199,9 +199,10 @@ def querylog(request):
 
     # 组合筛选项
     filter_dict = dict()
-    # 是否收藏
-    if star:
-        filter_dict['favorite'] = star
+
+    # 确定favorite字段的值,是否收藏
+    filter_dict['favorite'] = star
+
     # 语句别名
     if query_log_id:
         filter_dict['id'] = query_log_id


### PR DESCRIPTION
现象：
SQL查询界面上的在线查询功能，选择未收藏的选项，返回的结果包含了未收藏和已收藏的所有数据

原因：
filter_dict['favorite'] 做了多余判断，导致前端选择未收藏时，filter_dict['favorite'] 为空