### PR TITLE
修复sql查询界面，收藏显示异常问题

### DIFF
--- a/sql/query.py
+++ b/sql/query.py
@@ -200,7 +200,7 @@ def querylog(request):
     # 组合筛选项
     filter_dict = dict()
 
-    # 确定favorite字段的值,是否收藏
+    # 确定favorite字段的值
     filter_dict['favorite'] = star
 
     # 语句别名

--- a/sql/query.py
+++ b/sql/query.py
@@ -199,9 +199,10 @@ def querylog(request):
 
     # 组合筛选项
     filter_dict = dict()
-    # 是否收藏
-    if star:
-        filter_dict['favorite'] = star
+
+    # 确定favorite字段的值,是否收藏
+    filter_dict['favorite'] = star
+
     # 语句别名
     if query_log_id:
         filter_dict['id'] = query_log_id


### PR DESCRIPTION
现象： 选择未收藏的sql会显示全部的sql查询，包括已收藏的
原因：star未对空值做判断，如果是false，filter_dict['favorite']则为空，导致查询结果异常