### PR TITLE
docker安装默认映射出goinception的4000端口

### DIFF
--- a/src/docker-compose/docker-compose.yml
+++ b/src/docker-compose/docker-compose.yml
@@ -35,8 +35,8 @@ services:
     image: hanchuanchuan/goinception
     container_name: goinception
     restart: always
-    expose:
-      - "4000"
+    ports:
+      - "4000:4000"
     volumes:
       - "./inception/config.toml:/etc/config.toml"
 


### PR DESCRIPTION
docker安装默认映射出goinception的4000端口，方便后续自定义审核级别。