### PR TITLE
实例列表排序(支持汉字排序) #1290

### DIFF
--- a/common/utils/convert.py
+++ b/common/utils/convert.py
@@ -1,0 +1,17 @@
+from django.db.models import Func
+
+
+class Convert(Func):
+    """
+    Description: 支持mysql的convert(field using gbk)语法，从而支持汉字排序
+    Usage:       queryset.order_by(Convert('name', 'gbk').asc())
+    Reference:   https://stackoverflow.com/questions/38517743/django-how-to-make-a-query-with-order-by-convert-name-using-gbk-asc
+    """
+
+    def __init__(self, expression, transcoding_name, **extra):
+        super(Convert, self).__init__(expression=expression, transcoding_name=transcoding_name, **extra)
+
+    def as_mysql(self, compiler, connection):
+        self.function = 'CONVERT'
+        self.template = '%(function)s(%(expression)s USING  %(transcoding_name)s)'
+        return super(Convert, self).as_sql(compiler, connection)

--- a/sql/resource_group.py
+++ b/sql/resource_group.py
@@ -9,6 +9,7 @@ from django.db.models import F, Value, IntegerField
 from django.http import HttpResponse
 from common.utils.extend_json_encoder import ExtendJSONEncoder
 from common.utils.permission import superuser_required
+from common.utils.convert import Convert
 from sql.models import ResourceGroup, Users, Instance
 from sql.utils.resource_group import user_instances
 from sql.utils.workflow_audit import Audit
@@ -137,7 +138,8 @@ def instances(request):
     if tag_code:
         filter_dict['instance_tag__tag_code'] = tag_code
         filter_dict['instance_tag__active'] = True
-    ins = ins.filter(**filter_dict).values('id', 'type', 'db_type', 'instance_name')
+    ins = ins.filter(**filter_dict).order_by(Convert('instance_name', 'gbk').asc()).values(
+        'id', 'type', 'db_type', 'instance_name')
     rows = [row for row in ins]
     result = {'status': 0, 'msg': 'ok', "data": rows}
     return HttpResponse(json.dumps(result), content_type='application/json')
@@ -149,7 +151,8 @@ def user_all_instances(request):
     type = request.GET.get('type')
     db_type = request.GET.getlist('db_type[]')
     tag_codes = request.GET.getlist('tag_codes[]')
-    instances = user_instances(user, type, db_type, tag_codes).values('id', 'type', 'db_type', 'instance_name')
+    instances = user_instances(user, type, db_type, tag_codes).order_by(
+        Convert('instance_name', 'gbk').asc()).values('id', 'type', 'db_type', 'instance_name')
     rows = [row for row in instances]
     result = {'status': 0, 'msg': 'ok', "data": rows}
     return HttpResponse(json.dumps(result), content_type='application/json')

--- a/sql/templates/instance.html
+++ b/sql/templates/instance.html
@@ -91,6 +91,7 @@
                 pagination: true,                   //是否显示分页（*）
                 sortable: true,                     //是否启用排序
                 sortOrder: "asc",                   //排序方式
+                sortName: 'id',                   //排序字段
                 sidePagination: "server",           //分页方式：client客户端分页，server服务端分页（*）
                 pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
                 pageSize: 14,                     //每页的记录行数（*）
@@ -122,15 +123,19 @@
                             type: $("#type").val(),
                             db_type: $("#db_type").val(),
                             tags: $("#tags").val(),
+                            sortName: params.sort,
+                            sortOrder: params.order
                         }
                     },
                 columns: [
                     {
                         title: 'ID',
-                        field: 'id'
+                        field: 'id',
+                        sortable: true
                     }, {
                         title: '实例名称',
                         field: 'instance_name',
+                        sortable: true,
                         formatter: function (value, row, index) {
                             return "<a target=\"_blank\" href=\"/admin/sql/instance/" + row.id + "/change/\">" + value + "</a>"
                         }
@@ -139,10 +144,12 @@
                         field: 'type'
                     }, {
                         title: '数据库类型',
-                        field: 'db_type'
+                        field: 'db_type',
+                        sortable: true
                     }, {
                         title: 'HOST',
-                        field: 'host'
+                        field: 'host',
+                        sortable: true
                     }, {
                         title: 'PORT',
                         field: 'port'

--- a/sql/views.py
+++ b/sql/views.py
@@ -16,6 +16,7 @@ from archery import settings
 from common.config import SysConfig
 from sql.engines import get_engine
 from common.utils.permission import superuser_required
+from common.utils.convert import Convert
 from sql.engines.models import ReviewResult, ReviewSet
 from sql.utils.tasks import task_info
 
@@ -68,7 +69,7 @@ def sqlworkflow(request):
     else:
         filter_dict['engineer'] = user.username
     instance_id = SqlWorkflow.objects.filter(**filter_dict).values('instance_id').distinct()
-    instance = Instance.objects.filter(pk__in=instance_id)
+    instance = Instance.objects.filter(pk__in=instance_id).order_by(Convert('instance_name', 'gbk').asc())
     resource_group_id = SqlWorkflow.objects.filter(**filter_dict).values('group_id').distinct()
     resource_group = ResourceGroup.objects.filter(group_id__in=resource_group_id)
 
@@ -342,7 +343,7 @@ def archive(request):
     """归档列表页面"""
     # 获取资源组
     group_list = user_groups(request.user)
-    ins_list = user_instances(request.user, db_type=['mysql'])
+    ins_list = user_instances(request.user, db_type=['mysql']).order_by(Convert('instance_name', 'gbk').asc())
     return render(request, 'archive.html', {'group_list': group_list, 'ins_list': ins_list})
 
 


### PR DESCRIPTION
相关issue：#1290
1. 系统各功能筛选获取的实例列表按名称排序(兼容汉字，按gbk排序)
2. 实例管理--实例列表增加排序字段


排序前：
![image](https://user-images.githubusercontent.com/33473924/148899605-8dfb661b-3b03-4d80-aca3-32a5850a69b1.png)

排序后：
![image](https://user-images.githubusercontent.com/33473924/148899689-dbe801f0-6104-4759-bf2a-fecc7ec09473.png)
