### PR TITLE
mongo 上线语句collection名称支持"."符号

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -439,7 +439,7 @@ class MongoEngine(EngineBase):
                                 check_result.rows += [result]
                                 continue
                         else:
-                            if re.search(".", table_name) is not None:
+                            if re.search("\.", table_name) is not None:
                                 method = sql_str.split(".")[3]
                             else:
                                 method = sql_str.split('.')[2]

--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -281,7 +281,7 @@ class MongoEngine(EngineBase):
                         # 第一行可能是WARNING语句，因此跳过
                         continue
                     _re_msg.append(_line)
-                
+
                 msg = '\n'.join(_re_msg)
 
             except Exception as e:
@@ -412,7 +412,7 @@ class MongoEngine(EngineBase):
                                            "remove", "replaceOne", "renameCollection", "update", "updateOne",
                                            "updateMany", "renameCollection"]
                 pattern = re.compile(
-                    r'''^db\.createCollection\(([\s\S]*)\)$|^db\.(\w+)\.(?:[A-Za-z]+)(?:\([\s\S]*\)$)|^db\.getCollection\((?:\s*)(?:'|")([\w-]*)('|")(\s*)\)\.([A-Za-z]+)(\([\s\S]*\)$)''')
+                    r'''^db\.createCollection\(([\s\S]*)\)$|^db\.(\w+)\.(?:[A-Za-z]+)(?:\([\s\S]*\)$)|^db\.getCollection\((?:\s*)(?:'|")([\w-]*\.{0,1}[\w-]*)('|")(\s*)\)\.([A-Za-z]+)(\([\s\S]*\)$)''')
                 m = pattern.match(check_sql)
                 if m is not None and (re.search(re.compile(r'}(?:\s*){'), check_sql) is None) and check_sql.count(
                         '{') == check_sql.count('}') and check_sql.count('(') == check_sql.count(')'):
@@ -439,7 +439,10 @@ class MongoEngine(EngineBase):
                                 check_result.rows += [result]
                                 continue
                         else:
-                            method = sql_str.split('.')[2]
+                            if re.search(".", table_name) is not None:
+                                method = sql_str.split(".")[3]
+                            else:
+                                method = sql_str.split('.')[2]
                             methodStr = method.split('(')[0].strip()
                         if methodStr in is_exist_premise_method and not is_in:
                             check_result.error = "文档不存在"


### PR DESCRIPTION
修改了正则匹配，如果mongo上线语句的collection名称带“.”符号的话，无法校验通过。如：`db.getCollection("amss.rule").remove({'rule_id' :'R_RCV_000058'})`
我修改的正则匹配只是db.getCollection()方式，db.{collection}不修改，而且仅仅支持xxx.xxx格式，其它的格式也不支持了，感觉这个正则不好写。