### PR TITLE
问题:mongodb表名带-和.符号无法申请上线，原因:\w只匹配[a-zA-Z0-9_]，修正:(\w*) -> ([\w\.-]+)

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -412,7 +412,7 @@ class MongoEngine(EngineBase):
                                            "remove", "replaceOne", "renameCollection", "update", "updateOne",
                                            "updateMany", "renameCollection"]
                 pattern = re.compile(
-                    r'''^db\.createCollection\(([\s\S]*)\)$|^db\.(\w+)\.(?:[A-Za-z]+)(?:\([\s\S]*\)$)|^db\.getCollection\((?:\s*)(?:'|")([\w-]*)('|")(\s*)\)\.([A-Za-z]+)(\([\s\S]*\)$)''')
+                    r'''^db\.createCollection\(([\s\S]*)\)$|^db\.([\w\.-]+)\.(?:[A-Za-z]+)(?:\([\s\S]*\)$)|^db\.getCollection\((?:\s*)(?:'|")([\w-]*)('|")(\s*)\)\.([A-Za-z]+)(\([\s\S]*\)$)''')
                 m = pattern.match(check_sql)
                 if m is not None and (re.search(re.compile(r'}(?:\s*){'), check_sql) is None) and check_sql.count(
                         '{') == check_sql.count('}') and check_sql.count('(') == check_sql.count(')'):


### PR DESCRIPTION
[问题:mongodb表名带-和.符号无法申请上线，原因:\w只匹配[a-zA-Z0-9_]，修正:(\w*) -> ([\w\.-]+)]