### PR TITLE
问题: mongodb表名带多个.的情况下, 无法正确截取methodStr. 原因是 默认截取第二个 "." 到"(" 之间的字符串作为method

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -439,8 +439,9 @@ class MongoEngine(EngineBase):
                                 check_result.rows += [result]
                                 continue
                         else:
-                            method = sql_str.split('.')[2]
-                            methodStr = method.split('(')[0].strip()
+                            # method = sql_str.split('.')[2]
+                            # methodStr = method.split('(')[0].strip()
+                            methodStr = sql_str.split('(')[0].split('.')[-1].strip()    # 最后一个.和括号(之间的字符串作为方法
                         if methodStr in is_exist_premise_method and not is_in:
                             check_result.error = "文档不存在"
                             check_result.error_count += 1

--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -412,7 +412,7 @@ class MongoEngine(EngineBase):
                                            "remove", "replaceOne", "renameCollection", "update", "updateOne",
                                            "updateMany", "renameCollection"]
                 pattern = re.compile(
-                    r'''^db\.createCollection\(([\s\S]*)\)$|^db\.(\w+)\.(?:[A-Za-z]+)(?:\([\s\S]*\)$)|^db\.getCollection\((?:\s*)(?:'|")([\w-]*)('|")(\s*)\)\.([A-Za-z]+)(\([\s\S]*\)$)''')
+                    r'''^db\.createCollection\(([\s\S]*)\)$|^db\.([\w\.-]+)\.(?:[A-Za-z]+)(?:\([\s\S]*\)$)|^db\.getCollection\((?:\s*)(?:'|")([\w-]*)('|")(\s*)\)\.([A-Za-z]+)(\([\s\S]*\)$)''')
                 m = pattern.match(check_sql)
                 if m is not None and (re.search(re.compile(r'}(?:\s*){'), check_sql) is None) and check_sql.count(
                         '{') == check_sql.count('}') and check_sql.count('(') == check_sql.count(')'):


### PR DESCRIPTION
问题:  mongodb表名带多个.的情况下, 无法正确截取methodStr. 
原因:  默认截取第二个 "." 到"(" 之间的字符串作为method
修改:  修改为截取最后一个"."到"(" 之间的字符串作为method