### PR TITLE
支持redis集群模式

### DIFF
--- a/common/static/dist/js/utils.js
+++ b/common/static/dist/js/utils.js
@@ -5,3 +5,21 @@ var onLoadErrorCallback = function (status, jqXHR) {
         alert("未知错误，请联系管理员处理！");
     }
 };
+
+// 实例配置页面根据db_type选择显示或隐藏mode字段，mode字段只适用于redis实例
+(function($) {
+    $(function() {
+        let db_type = $('#id_db_type');
+        let mode = $('#id_mode').parent().parent();
+
+        function toggleMode(value) {
+            value === 'redis' ? mode.show() : mode.hide();
+        }
+
+        toggleMode(db_type.val());
+
+        db_type.change(function() {
+            toggleMode($(this).val());
+        });
+    });
+})(django.jQuery);

--- a/sql/admin.py
+++ b/sql/admin.py
@@ -11,7 +11,7 @@ from .models import Users, Instance, SqlWorkflow, SqlWorkflowContent, QueryLog, 
     WorkflowAudit, WorkflowLog, ParamTemplate, ParamHistory, InstanceTag, \
     Tunnel, AuditEntry
 
-from sql.form import TunnelForm
+from sql.form import TunnelForm, InstanceForm
 
 
 # 用户管理
@@ -62,6 +62,7 @@ class InstanceTagAdmin(admin.ModelAdmin):
 # 实例管理
 @admin.register(Instance)
 class InstanceAdmin(admin.ModelAdmin):
+    form = InstanceForm
     list_display = ('id', 'instance_name', 'db_type', 'type', 'host', 'port', 'user', 'create_time')
     search_fields = ['instance_name', 'host', 'port', 'user']
     list_filter = ('db_type', 'type', 'instance_tag')

--- a/sql/engines/__init__.py
+++ b/sql/engines/__init__.py
@@ -17,6 +17,7 @@ class EngineBase:
             self.user = instance.user
             self.password = instance.password
             self.db_name = instance.db_name
+            self.mode = instance.mode
 
             # 判断如果配置了隧道则连接隧道，只测试了MySQL
             if self.instance.tunnel:

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -9,7 +9,8 @@
 import re
 import shlex
 
-import redis
+from redis import Redis
+from redis.cluster import RedisCluster
 import logging
 import traceback
 
@@ -25,8 +26,12 @@ logger = logging.getLogger('default')
 class RedisEngine(EngineBase):
     def get_connection(self, db_name=None):
         db_name = db_name or self.db_name
-        return redis.Redis(host=self.host, port=self.port, db=db_name, password=self.password,
-                           encoding_errors='ignore', decode_responses=True, socket_connect_timeout=10)
+        if self.mode == 'cluster':
+            return RedisCluster(host=self.host, port=self.port, password=self.password,
+                                encoding_errors='ignore', decode_responses=True, socket_connect_timeout=10)
+        else:
+            return Redis(host=self.host, port=self.port, db=db_name, password=self.password,
+                         encoding_errors='ignore', decode_responses=True, socket_connect_timeout=10)
 
     @property
     def name(self):

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -9,8 +9,7 @@
 import re
 import shlex
 
-from redis import Redis
-from redis.cluster import RedisCluster
+import redis
 import logging
 import traceback
 
@@ -27,10 +26,10 @@ class RedisEngine(EngineBase):
     def get_connection(self, db_name=None):
         db_name = db_name or self.db_name
         if self.mode == 'cluster':
-            return RedisCluster(host=self.host, port=self.port, password=self.password,
+            return redis.cluster.RedisCluster(host=self.host, port=self.port, password=self.password,
                                 encoding_errors='ignore', decode_responses=True, socket_connect_timeout=10)
         else:
-            return Redis(host=self.host, port=self.port, db=db_name, password=self.password,
+            return redis.Redis(host=self.host, port=self.port, db=db_name, password=self.password,
                          encoding_errors='ignore', decode_responses=True, socket_connect_timeout=10)
 
     @property

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -549,40 +549,40 @@ class TestRedis(TestCase):
         SqlWorkflow.objects.all().delete()
         SqlWorkflowContent.objects.all().delete()
 
-    @patch('Redis')
+    @patch('redis.Redis')
     def test_engine_base_info(self, _conn):
         new_engine = RedisEngine(instance=self.ins)
         self.assertEqual(new_engine.name, 'Redis')
         self.assertEqual(new_engine.info, 'Redis engine')
 
-    @patch('Redis')
+    @patch('redis.Redis')
     def test_get_connection(self, _conn):
         new_engine = RedisEngine(instance=self.ins)
         new_engine.get_connection()
         _conn.assert_called_once()
 
-    @patch('Redis.execute_command', return_value=[1, 2, 3])
+    @patch('redis.Redis.execute_command', return_value=[1, 2, 3])
     def test_query_return_list(self, _execute_command):
         new_engine = RedisEngine(instance=self.ins)
         query_result = new_engine.query(db_name=0, sql='keys *', limit_num=100)
         self.assertIsInstance(query_result, ResultSet)
         self.assertTupleEqual(query_result.rows, ([1], [2], [3]))
 
-    @patch('Redis.execute_command', return_value='text')
+    @patch('redis.Redis.execute_command', return_value='text')
     def test_query_return_str(self, _execute_command):
         new_engine = RedisEngine(instance=self.ins)
         query_result = new_engine.query(db_name=0, sql='keys *', limit_num=100)
         self.assertIsInstance(query_result, ResultSet)
         self.assertTupleEqual(query_result.rows, (['text'],))
 
-    @patch('Redis.execute_command', return_value='text')
+    @patch('redis.Redis.execute_command', return_value='text')
     def test_query_execute(self, _execute_command):
         new_engine = RedisEngine(instance=self.ins)
         query_result = new_engine.query(db_name=0, sql='keys *', limit_num=100)
         self.assertIsInstance(query_result, ResultSet)
         self.assertTupleEqual(query_result.rows, (['text'],))
 
-    @patch('Redis.config_get', return_value={"databases": 4})
+    @patch('redis.Redis.config_get', return_value={"databases": 4})
     def test_get_all_databases(self, _config_get):
         new_engine = RedisEngine(instance=self.ins)
         dbs = new_engine.get_all_databases()
@@ -628,7 +628,7 @@ class TestRedis(TestCase):
         self.assertIsInstance(check_result, ReviewSet)
         self.assertEqual(check_result.rows[0].__dict__, row.__dict__)
 
-    @patch('Redis.execute_command', return_value='text')
+    @patch('redis.Redis.execute_command', return_value='text')
     def test_execute_workflow_success(self, _execute_command):
         sql = 'set 1 1'
         row = ReviewResult(id=1,

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -539,8 +539,8 @@ class TestMysql(TestCase):
 class TestRedis(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ins = Instance(instance_name='some_ins', type='slave', db_type='redis', host='some_host',
-                           port=1366, user='ins_user', password='some_str')
+        cls.ins = Instance(instance_name='some_ins', type='slave', db_type='redis', mode='standalone',
+                           host='some_host', port=1366, user='ins_user', password='some_str')
         cls.ins.save()
 
     @classmethod
@@ -549,40 +549,40 @@ class TestRedis(TestCase):
         SqlWorkflow.objects.all().delete()
         SqlWorkflowContent.objects.all().delete()
 
-    @patch('redis.Redis')
+    @patch('Redis')
     def test_engine_base_info(self, _conn):
         new_engine = RedisEngine(instance=self.ins)
         self.assertEqual(new_engine.name, 'Redis')
         self.assertEqual(new_engine.info, 'Redis engine')
 
-    @patch('redis.Redis')
+    @patch('Redis')
     def test_get_connection(self, _conn):
         new_engine = RedisEngine(instance=self.ins)
         new_engine.get_connection()
         _conn.assert_called_once()
 
-    @patch('redis.Redis.execute_command', return_value=[1, 2, 3])
+    @patch('Redis.execute_command', return_value=[1, 2, 3])
     def test_query_return_list(self, _execute_command):
         new_engine = RedisEngine(instance=self.ins)
         query_result = new_engine.query(db_name=0, sql='keys *', limit_num=100)
         self.assertIsInstance(query_result, ResultSet)
         self.assertTupleEqual(query_result.rows, ([1], [2], [3]))
 
-    @patch('redis.Redis.execute_command', return_value='text')
+    @patch('Redis.execute_command', return_value='text')
     def test_query_return_str(self, _execute_command):
         new_engine = RedisEngine(instance=self.ins)
         query_result = new_engine.query(db_name=0, sql='keys *', limit_num=100)
         self.assertIsInstance(query_result, ResultSet)
         self.assertTupleEqual(query_result.rows, (['text'],))
 
-    @patch('redis.Redis.execute_command', return_value='text')
+    @patch('Redis.execute_command', return_value='text')
     def test_query_execute(self, _execute_command):
         new_engine = RedisEngine(instance=self.ins)
         query_result = new_engine.query(db_name=0, sql='keys *', limit_num=100)
         self.assertIsInstance(query_result, ResultSet)
         self.assertTupleEqual(query_result.rows, (['text'],))
 
-    @patch('redis.Redis.config_get', return_value={"databases": 4})
+    @patch('Redis.config_get', return_value={"databases": 4})
     def test_get_all_databases(self, _config_get):
         new_engine = RedisEngine(instance=self.ins)
         dbs = new_engine.get_all_databases()
@@ -628,7 +628,7 @@ class TestRedis(TestCase):
         self.assertIsInstance(check_result, ReviewSet)
         self.assertEqual(check_result.rows[0].__dict__, row.__dict__)
 
-    @patch('redis.Redis.execute_command', return_value='text')
+    @patch('Redis.execute_command', return_value='text')
     def test_execute_workflow_success(self, _execute_command):
         sql = 'set 1 1'
         row = ReviewResult(id=1,

--- a/sql/form.py
+++ b/sql/form.py
@@ -9,7 +9,7 @@
 ---------------------------------------------------------
 """
 from django.forms import ModelForm, Textarea
-from sql.models import Tunnel
+from sql.models import Tunnel, Instance
 from django.core.exceptions import ValidationError
 
 
@@ -30,3 +30,9 @@ class TunnelForm(ModelForm):
                     cleaned_data['pkey'] = str(pkey_path, 'utf-8').replace(r'\r', '').replace(r'\n', '')
             except IOError:
                 raise ValidationError("秘钥文件不存在， 请勾选秘钥路径的清除选项再进行保存")
+
+
+class InstanceForm(ModelForm):
+    class Media:
+        model = Instance
+        js = ('jquery/jquery.min.js', 'dist/js/utils.js', )

--- a/sql/models.py
+++ b/sql/models.py
@@ -129,6 +129,7 @@ class Instance(models.Model):
     instance_name = models.CharField('实例名称', max_length=50, unique=True)
     type = models.CharField('实例类型', max_length=6, choices=(('master', '主库'), ('slave', '从库')))
     db_type = models.CharField('数据库类型', max_length=20, choices=DB_TYPE_CHOICES)
+    mode = models.CharField('运行模式', max_length=10, default='', choices=(('standalone', '单机'), ('cluster', '集群')))
     host = models.CharField('实例连接', max_length=200)
     port = models.IntegerField('端口', default=0)
     user = fields.EncryptedCharField(verbose_name='用户名', max_length=200, default='', blank=True)

--- a/sql/models.py
+++ b/sql/models.py
@@ -129,7 +129,7 @@ class Instance(models.Model):
     instance_name = models.CharField('实例名称', max_length=50, unique=True)
     type = models.CharField('实例类型', max_length=6, choices=(('master', '主库'), ('slave', '从库')))
     db_type = models.CharField('数据库类型', max_length=20, choices=DB_TYPE_CHOICES)
-    mode = models.CharField('运行模式', max_length=10, default='', choices=(('standalone', '单机'), ('cluster', '集群')))
+    mode = models.CharField('运行模式', max_length=10, default='', blank=True, choices=(('standalone', '单机'), ('cluster', '集群')))
     host = models.CharField('实例连接', max_length=200)
     port = models.IntegerField('端口', default=0)
     user = fields.EncryptedCharField(verbose_name='用户名', max_length=200, default='', blank=True)

--- a/src/init_sql/v1.8.3.sql
+++ b/src/init_sql/v1.8.3.sql
@@ -29,3 +29,6 @@ insert IGNORE INTO auth_permission (name, content_type_id, codename) VALUES
 set @content_type_id=(select id from django_content_type where app_label='sql' and model='permission');
 insert IGNORE INTO auth_permission (name, content_type_id, codename) VALUES
 ('在线查询下载权限', @content_type_id, 'query_download');
+
+-- 实例配置表新增mode字段，用于redis实例
+alter table sql_instance add column `mode` varchar(10) DEFAULT '' after `db_type`;

--- a/src/init_sql/v1.8.3.sql
+++ b/src/init_sql/v1.8.3.sql
@@ -30,5 +30,6 @@ set @content_type_id=(select id from django_content_type where app_label='sql' a
 insert IGNORE INTO auth_permission (name, content_type_id, codename) VALUES
 ('在线查询下载权限', @content_type_id, 'query_download');
 
--- 实例配置表新增mode字段，用于redis实例
+-- 实例配置表新增mode字段，用于redis实例；为历史数据设置默认值
 alter table sql_instance add column `mode` varchar(10) DEFAULT '' after `db_type`;
+update sql_instance set mode='standalone' where db_type='redis';


### PR DESCRIPTION
相关issues：#720 #895 #1238 #1243

redis生产环境上了规模的基本都是使用cluster模式，当前版本只支持standalone

修改：
1.实例配置表新增运行模式字段mode，可选standalone或cluster，只有db_type选择redis时可配置，其他时候隐藏
2.redis引擎引入redis.cluster.RedisCluster作为集群连接器