### PR TITLE
修复实例check返回连接状态错误bug fix #1179

### DIFF
--- a/common/check.py
+++ b/common/check.py
@@ -129,7 +129,10 @@ def instance(request):
     try:
         engine = get_engine(instance=instance)
         engine.get_connection()
-        engine.get_all_databases()
+        dbs = engine.get_all_databases()
+        if dbs.error:
+            result['status'] = 1
+            result['msg'] = '无法连接实例,\n{}'.format(dbs.error)
     except Exception as e:
         result['status'] = 1
         result['msg'] = '无法连接实例,\n{}'.format(str(e))

--- a/common/tests.py
+++ b/common/tests.py
@@ -316,12 +316,13 @@ class CheckTest(TestCase):
     def testInstanceCheck(self, _get_engine, _conn):
         _get_engine.return_value.get_connection = _conn
         _get_engine.return_value.get_all_databases.return_value.rows.return_value = ResultSet(
-            rows=(('test1',), ('test2',)))
+            rows=((),),
+            error='Wrong password')
         c = Client()
         c.force_login(self.superuser1)
         r = c.post('/check/instance/', data={'instance_id': self.slave1.id})
         r_json = r.json()
-        self.assertEqual(r_json['status'], 0)
+        self.assertEqual(r_json['status'], 1)
 
     @patch('MySQLdb.connect')
     def test_inception_check(self, _conn):

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -52,6 +52,7 @@ class RedisEngine(EngineBase):
         except Exception as e:
             logger.warning(f"Redis CONFIG GET databases 执行报错，异常信息：{e}")
             rows = 16
+            result.error = str(e)
 
         db_list = [str(x) for x in range(int(rows))]
         result.rows = db_list


### PR DESCRIPTION
fix #1179
redis和clickhouse engine使用的连接器在实例信息配置错误的情况下不会抛出异常，导致实例配置无论正确与否都会返回连接成功