### PR TITLE
修复clickhouse上线审核版本兼容性问题

### DIFF
--- a/sql/engines/clickhouse.py
+++ b/sql/engines/clickhouse.py
@@ -195,8 +195,8 @@ class ClickHouseEngine(EngineBase):
                               sql=statement,
                               affected_rows=0,
                               execute_time=0, )
-        # clickhouse版本>=20.6.3才使用explain检查
-        if self.server_version >= (20, 6, 3):
+        # clickhouse版本>=21.1.2 explain ast才支持非select语句检查
+        if self.server_version >= (21, 1, 2):
             explain_result = self.query(db_name=db_name, sql=f"explain ast {statement}")
             if explain_result.error:
                 check_result.is_critical = True


### PR DESCRIPTION
fix #1426
clickhouse上线前语法检查使用explain ast，从v21.1.2.15版本起才支持检查非select语句，将explain_check的版本门槛提高到21.1.2