### PR TITLE
支持配置自动审核数据库类型

### DIFF
--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -209,6 +209,24 @@
                                     </div>
                                 </div>
                                 <div class="form-group">
+                                    <label for="auto_review_db_type"
+                                           class="col-sm-4 control-label">AUTO_REVIEW_DB_TYPE</label>
+                                    <div class="col-sm-5">
+                                        <select id="auto_review_db_type" key="auto_review_db_type"
+                                                class="form-control selectpicker" data-live-search="true"
+                                                multiple data-selected-text-format="count > 5"
+                                                data-none-selected-text="自动审批的数据库类型">
+                                            {% for type in db_type %}
+                                                {% if type|is_in:config.auto_review_db_type %}
+                                                    <option value="{{ type }}" selected>{{ type }}</option>
+                                                {% else %}
+                                                    <option value="{{ type }}">{{ type }}</option>
+                                                {% endif %}
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="form-group">
                                     <label for="auto_review_regex"
                                            class="col-sm-4 control-label">AUTO_REVIEW_REGEX</label>
                                     <div class="col-sm-5">

--- a/sql/utils/sql_review.py
+++ b/sql/utils/sql_review.py
@@ -19,8 +19,9 @@ def is_auto_review(workflow_id):
 
     workflow = SqlWorkflow.objects.get(id=workflow_id)
     auto_review_tags = SysConfig().get('auto_review_tag', '').split(',')
+    auto_review_db_type = SysConfig().get('auto_review_db_type', '').split(',')
     # TODO 这里也可以放到engine中实现，但是配置项可能会相对复杂
-    if workflow.instance.db_type == 'mysql' and workflow.instance.instance_tag.filter(
+    if workflow.instance.db_type in auto_review_db_type and workflow.instance.instance_tag.filter(
             tag_code__in=auto_review_tags).exists():
         # 获取正则表达式
         auto_review_regex = SysConfig().get(

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -183,6 +183,7 @@ class TestSQLReview(TestCase):
         """
         # 开启自动审批设置
         self.sys_config.set('auto_review', 'true')
+        self.sys_config.set('auto_review_db_type', 'mysql')
         self.sys_config.set('auto_review_regex', '^drop')  # drop语句需要审批
         self.sys_config.set('auto_review_max_update_rows', '50')  # update影响行数大于50需要审批
         self.sys_config.get_all_config()
@@ -201,6 +202,7 @@ class TestSQLReview(TestCase):
         """
         # 开启自动审批设置
         self.sys_config.set('auto_review', 'true')
+        self.sys_config.set('auto_review_db_type', 'mysql')
         self.sys_config.set('auto_review_regex', '^drop')  # drop语句需要审批
         self.sys_config.set('auto_review_max_update_rows', '2')  # update影响行数大于2需要审批
         self.sys_config.get_all_config()
@@ -248,6 +250,37 @@ class TestSQLReview(TestCase):
         self.wf1.instance.instance_tag.add(tag)
         r = is_auto_review(self.wfc1.workflow_id)
         self.assertTrue(r)
+
+    @patch('sql.engines.get_engine')
+    def test_auto_review_false(self, _get_engine):
+        """
+        测试自动审批通过的判定条件，
+        :return:
+        """
+        # 开启自动审批设置
+        self.sys_config.set('auto_review', 'true')
+        self.sys_config.set('auto_review_db_type', '')  #未配置auto_review_db_type需要审批
+        self.sys_config.set('auto_review_regex', '^drop')  # drop语句需要审批
+        self.sys_config.set('auto_review_max_update_rows', '2')  # update影响行数大于2需要审批
+        self.sys_config.set('auto_review_tag', 'GA')  # 仅GA开启自动审批
+        self.sys_config.get_all_config()
+        # 修改工单为update，mock返回值，update影响行数=3
+        self.wfc1.sql_content = "update table users set email='';"
+        self.wfc1.review_content = json.dumps([
+            {"id": 1, "stage": "CHECKED", "errlevel": 0, "stagestatus": "Audit completed", "errormessage": "None",
+             "sql": "use archer_test", "affected_rows": 0, "sequence": "'0_0_0'", "backup_dbname": "None",
+             "execute_time": "0", "sqlsha1": "", "actual_affected_rows": 'null'},
+            {"id": 2, "stage": "CHECKED", "errlevel": 0, "stagestatus": "Audit completed", "errormessage": "None",
+             "sql": "update table users set email=''", "affected_rows": 1, "sequence": "'0_0_1'",
+             "backup_dbname": "mysql_3306_archer_test", "execute_time": "0", "sqlsha1": "",
+             "actual_affected_rows": 'null'}])
+        self.wfc1.save(update_fields=('sql_content', 'review_content'))
+        # 修改工单实例标签
+        tag, is_created = InstanceTag.objects.get_or_create(tag_code='GA',
+                                                            defaults={'tag_name': '生产环境', 'active': True})
+        self.wf1.instance.instance_tag.add(tag)
+        r = is_auto_review(self.wfc1.workflow_id)
+        self.assertFalse(r)
 
     def test_can_execute_for_resource_group(self, ):
         """

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -227,6 +227,7 @@ class TestSQLReview(TestCase):
         """
         # 开启自动审批设置
         self.sys_config.set('auto_review', 'true')
+        self.sys_config.set('auto_review_db_type', 'mysql')
         self.sys_config.set('auto_review_regex', '^drop')  # drop语句需要审批
         self.sys_config.set('auto_review_max_update_rows', '2')  # update影响行数大于2需要审批
         self.sys_config.set('auto_review_tag', 'GA')  # 仅GA开启自动审批

--- a/sql/views.py
+++ b/sql/views.py
@@ -385,6 +385,8 @@ def config(request):
     auth_group_list = Group.objects.all()
     # 获取所有实例标签
     instance_tags = InstanceTag.objects.all()
+    # 支持自动审核的数据库类型
+    db_type = ['mysql', 'oracle', 'mongo', 'clickhouse']
     # 获取所有配置项
     all_config = Config.objects.all().values('item', 'value')
     sys_config = {}
@@ -392,7 +394,7 @@ def config(request):
         sys_config[items['item']] = items['value']
 
     context = {'group_list': group_list, 'auth_group_list': auth_group_list, 'instance_tags': instance_tags,
-               'config': sys_config, 'WorkflowDict': WorkflowDict}
+               'db_type': db_type, 'config': sys_config, 'WorkflowDict': WorkflowDict}
     return render(request, 'config.html', context)
 
 


### PR DESCRIPTION
相关issue：#1446
当前工单自动审核写死了只支持mysql实例，修改为可配置
新增配置项AUTO_REVIEW_DB_TYPE