### PR TITLE
修复oracle的sql上线，单条回退sql超过4000长度被强制截断成多条的问题

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -981,10 +981,14 @@ class OracleEngine(EngineBase):
                                         endtime=>to_date('{end_time}','yyyy/mm/dd hh24:mi:ss'),
                                         options=>dbms_logmnr.dict_from_online_catalog + dbms_logmnr.continuous_mine);
                                     end;'''
-            undo_sql = f'''select sql_redo,sql_undo from v$logmnr_contents
-                                  where  SEG_OWNER not in ('SYS','SYSTEM')
-                                         and session# = (select sid from v$mystat where rownum = 1)
-                                         and serial# = (select serial# from v$session s where s.sid = (select sid from v$mystat where rownum = 1 )) order by scn desc'''
+            undo_sql = f'''select 
+                           xmlagg(xmlparse(content sql_redo)  order by  scn,rs_id,ssn,rownum).getclobval() ,
+                           xmlagg(xmlparse(content sql_undo)  order by  scn,rs_id,ssn,rownum).getclobval() 
+                           from v$logmnr_contents
+                           where  SEG_OWNER not in ('SYS')
+                           and session# = (select sid from v$mystat where rownum = 1)
+                           and serial# = (select serial# from v$session s where s.sid = (select sid from v$mystat where rownum = 1 ))  
+                           group by  scn,rs_id,ssn  order by scn desc'''
             logmnr_end_sql = f'''begin
                                     dbms_logmnr.end_logmnr;
                                  end;'''


### PR DESCRIPTION
修复oracle的sql上线，单条回退sql超过4000长度被强制截断成多条的问题。

fix https://github.com/hhyo/Archery/issues/1467