### PR TITLE
停止支持python3.6

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
   
     # https://github.com/actions/example-services/tree/master/.github/workflows
     services:

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,11 +29,10 @@ pycryptodome==3.10.1
 pandas==1.1.5
 pyodps==0.10.7.1
 clickhouse-driver==0.2.3
-djangorestframework==3.12.4
-djangorestframework-simplejwt==4.3.0
+djangorestframework==3.13.1
+djangorestframework-simplejwt==5.0.0
 django-filter==21.1
 drf-spectacular==0.22.0
-pyjwt==1.7.1
 pyotp==2.6.0
-pillow==8.4.0
+pillow==9.0.1
 qrcode==7.3.1


### PR DESCRIPTION
archery部分依赖库已停止支持python3.6，使用旧版本存在安全隐患