### PR TITLE
兼容AWS DocumentDB

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -591,10 +591,10 @@ class MongoEngine(EngineBase):
             for d in db[collection_name].find().limit(2):
                 documents_sample.append(d)
         else:
-            for d in db[collection_name].find().sort([("$natural", 1)]).limit(1):
+            for d in db[collection_name].find().sort([("_id", 1)]).limit(1):
                 documents_sample.append(d)
 
-            for d in db[collection_name].find().sort([("$natural", -1)]).limit(1):
+            for d in db[collection_name].find().sort([("_id", -1)]).limit(1):
                 documents_sample.append(d)
         columns = []
         # _merge_property_names


### PR DESCRIPTION
fix #1258  fix #1646
mongo engine获取字段列表的逻辑是使用$natural排序取首尾两条记录的字段并集，而AWS DocumentDB部分版本并不支持$natural修饰符，所以修改为按_id排序