### PR TITLE
base镜像中mysql client版本升级至5.7

### DIFF
--- a/src/docker/Dockerfile-base
+++ b/src/docker/Dockerfile-base
@@ -44,6 +44,7 @@ RUN yum -y install libffi-devel wget gcc make zlib-devel openssl openssl-devel n
     && yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm \
     && yum -y install Percona-Server-devel-57 Percona-Server-shared-57  Percona-Server-client-57 \
     && yum -y install percona-toolkit \
+    && ln -fs /usr/lib64/mysql/libmysqlclient.so.18 /usr/lib64/libperconaserverclient_r.so \
     && cd /opt \
     && git clone https://github.com/hhyo/SQLAdvisor.git --depth 3 \
     && cd /opt/SQLAdvisor/ \

--- a/src/docker/Dockerfile-base
+++ b/src/docker/Dockerfile-base
@@ -42,7 +42,7 @@ RUN yum -y install libffi-devel wget gcc make zlib-devel openssl openssl-devel n
     && yum -y install epel-release \
     && yum -y install cmake bison gcc-c++ git mysql-devel libaio-devel  glib2 glib2-devel \
     && yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm \
-    && yum -y install Percona-Server-devel-56 Percona-Server-shared-56  Percona-Server-client-56 \
+    && yum -y install Percona-Server-devel-57 Percona-Server-shared-57  Percona-Server-client-57 \
     && yum -y install percona-toolkit \
     && cd /opt \
     && git clone https://github.com/hhyo/SQLAdvisor.git --depth 3 \


### PR DESCRIPTION
fix #1659
为兼容mysql 8.0默认的caching_sha_password认证方式，需要将docker base中的mysql client升级至5.7版本

不升级的临时处理方法：
```
-- 将mysql 8.0的实例配置账号认证方式修改为mysql_native_password
alter user archery_user@'xxx' identified with mysql_native_password by 'archery_password';
```