### PR TITLE
解决mysql密码包含!时my2sql认证报错问题

### DIFF
--- a/sql/binlog.py
+++ b/sql/binlog.py
@@ -138,10 +138,10 @@ def my2sql(request):
     my2sql = My2SQL()
 
     # 准备参数
-    instance_password = shlex.quote(f'"{str(instance.password)}"')
+    instance_password = shlex.quote(str(instance.password))
     args = {
         "conn_options": rf"-host {shlex.quote(str(instance.host))} -user {shlex.quote(str(instance.user))} \
-                -password '{instance_password}' -port {shlex.quote(str(instance.port))} ",
+                -password ''{instance_password}'' -port {shlex.quote(str(instance.port))} ",
         "work-type": work_type,
         "start-file": start_file,
         "start-pos": start_pos,


### PR DESCRIPTION
fix #1700
mysql密码包含感叹号，使用命令行登录时需要将密码用单引号括起来，之前一次修复(#1519)应该是漏了