### PR TITLE
mysql查询支持将Binary格式转换为HEX展示 

### DIFF
--- a/sql/engines/models.py
+++ b/sql/engines/models.py
@@ -130,6 +130,7 @@ class ResultSet:
         status=None,
         affected_rows=0,
         column_list=None,
+        column_type=None,
         **kwargs
     ):
         self.full_sql = full_sql
@@ -145,6 +146,7 @@ class ResultSet:
         # rows 为普通列表
         self.rows = rows or []
         self.column_list = column_list if column_list else []
+        self.column_type = column_type if column_type else []
         self.status = status
         self.affected_rows = affected_rows
 

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -152,7 +152,7 @@ class MysqlEngine(EngineBase):
             row[0]
             for row in result.rows
             if row[0]
-               not in ("information_schema", "performance_schema", "mysql", "test", "sys")
+            not in ("information_schema", "performance_schema", "mysql", "test", "sys")
         ]
         result.rows = db_list
         return result
@@ -314,7 +314,7 @@ class MysqlEngine(EngineBase):
         """处理ResultSet，将binary处理成hex"""
         new_rows, hex_column_index = [], []
         for idx, _type in enumerate(result_set.column_type):
-            if _type in ['TINY_BLOB', 'MEDIUM_BLOB', 'LONG_BLOB', 'BLOB']:
+            if _type in ["TINY_BLOB", "MEDIUM_BLOB", "LONG_BLOB", "BLOB"]:
                 hex_column_index.append(idx)
         if hex_column_index:
             for row in result_set.rows:
@@ -346,10 +346,12 @@ class MysqlEngine(EngineBase):
             fields = cursor.description
 
             result_set.column_list = [i[0] for i in fields] if fields else []
-            result_set.column_type = [column_types_map.get(i[1], '') for i in fields] if fields else []
+            result_set.column_type = (
+                [column_types_map.get(i[1], "") for i in fields] if fields else []
+            )
             result_set.rows = rows
             result_set.affected_rows = effect_row
-            if kwargs.get('binary_as_hex'):
+            if kwargs.get("binary_as_hex"):
                 result_set = self.result_set_binary_as_hex(result_set)
         except Exception as e:
             logger.warning(f"MySQL语句执行报错，语句：{sql}，错误信息{traceback.format_exc()}")
@@ -384,13 +386,13 @@ class MysqlEngine(EngineBase):
                 result["msg"] = explain_result.error
         # 不应该查看mysql.user表
         if re.match(
-                ".*(\\s)+(mysql|`mysql`)(\\s)*\\.(\\s)*(user|`user`)((\\s)*|;).*",
-                sql.lower().replace("\n", ""),
+            ".*(\\s)+(mysql|`mysql`)(\\s)*\\.(\\s)*(user|`user`)((\\s)*|;).*",
+            sql.lower().replace("\n", ""),
         ) or (
-                db_name == "mysql"
-                and re.match(
-            ".*(\\s)+(user|`user`)((\\s)*|;).*", sql.lower().replace("\n", "")
-        )
+            db_name == "mysql"
+            and re.match(
+                ".*(\\s)+(user|`user`)((\\s)*|;).*", sql.lower().replace("\n", "")
+            )
         ):
             result["bad_query"] = True
             result["msg"] = "您无权查看该表"


### PR DESCRIPTION
关联issue: #1766 #1772

查询时可以指定传入参数：binary_as_hex，会将binary数据转换成16进制文本

并没有在数据查询中默认开启，因为有些文本的二进制数据在转换前是可以直接输出文本内容，强制转换后会全部都变成16进制，建议按需自己调整

参考：

- https://peps.python.org/pep-0249/#description
- https://github.com/mysql/mysql-connector-python/blob/master/lib/mysql/connector/constants.py#L168
- https://docs.python.org/3/library/stdtypes.html#bytes.hex