### PR TITLE
允许管理员重置用户登录失败次数

### DIFF
--- a/sql/admin.py
+++ b/sql/admin.py
@@ -80,7 +80,7 @@ class UsersAdmin(UserAdmin):
             },
         ),
         ("资源组", {"fields": ("resource_group",)}),
-        ("其他信息", {"fields": ("date_joined",)}),
+        ("其他信息", {"fields": ("date_joined", "failed_login_count")}),
     )
     # 添加页显示内容
     add_fieldsets = (


### PR DESCRIPTION
当用户登录失败次数达到LOCK_CNT_THRESHOLD时将被锁定一段时间，允许管理员对用户登录失败次数清零来进行手动解锁