### PR TITLE
解决SQL工单提交人信息缺失的问题 fix #1881

### DIFF
--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -312,12 +312,23 @@ class WorkflowSerializer(serializers.ModelSerializer):
             data["run_date_end"] = None
         return super().to_internal_value(data)
 
-    def validate_group_id(self, group_id):
+    @staticmethod
+    def validate_group_id(group_id):
         try:
             ResourceGroup.objects.get(pk=group_id)
         except ResourceGroup.DoesNotExist:
             raise serializers.ValidationError({"errors": f"不存在该资源组：{group_id}"})
         return group_id
+
+    def validate_engineer(self, engineer):
+        """仅管理员做engineer校验"""
+        user = self.context["request"].user
+        if user.is_superuser:
+            try:
+                Users.objects.get(username=engineer)
+            except Users.DoesNotExist:
+                raise serializers.ValidationError({"errors": f"不存在用户：{engineer}"})
+        return engineer
 
     class Meta:
         model = SqlWorkflow
@@ -330,11 +341,11 @@ class WorkflowSerializer(serializers.ModelSerializer):
             "group_name",
             "finish_time",
             "is_manual",
-            "engineer",
         ]
         extra_kwargs = {
             "demand_url": {"required": False},
             "is_backup": {"required": False},
+            "engineer": {"required": False},
         }
 
 
@@ -346,10 +357,17 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
         workflow_data = validated_data.pop("workflow")
         instance = workflow_data["instance"]
         sql_content = validated_data["sql_content"].strip()
-        user = self.context["request"].user  # 只能提交自己负责的资源
         group = ResourceGroup.objects.get(pk=workflow_data["group_id"])
+        engineer = workflow_data.get("engineer")
 
-        # 验证组权限（用户是否在该组、该组是否有指定实例）
+        # 管理员可以指定提交人信息
+        if self.context["request"].user.is_superuser:
+            user = Users.objects.get(username=engineer)
+        # 提交人只能是自己
+        else:
+            user = self.context["request"].user
+
+        # 验证提交用户的组权限（用户是否在该组、该组是否有指定实例）
         try:
             user_instances(user, tag_codes=["can_write"]).get(id=instance.id)
         except instance.DoesNotExist:

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -387,6 +387,7 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
             is_backup=is_backup,
             is_manual=0,
             syntax_type=check_result.syntax_type,
+            engineer=user.username,
             engineer_display=user.display,
             group_name=group.group_name,
             audit_auth_groups=Audit.settings(

--- a/sql_api/tests.py
+++ b/sql_api/tests.py
@@ -549,7 +549,6 @@ class TestWorkflow(APITestCase):
                 "demand_url": "test",
                 "group_id": 1,
                 "db_name": "test_db",
-                "engineer": self.user.username,
                 "instance": self.ins.id,
             },
             "sql_content": "alter table abc add column note varchar(64);",
@@ -559,6 +558,31 @@ class TestWorkflow(APITestCase):
         self.assertEqual(r.json()["workflow"]["workflow_name"], "上线工单1")
         self.assertEqual(r.json()["workflow"]["engineer"], self.user.username)
         self.assertEqual(r.json()["workflow"]["engineer_display"], self.user.display)
+
+    def test_submit_workflow_super(self):
+        """测试管理员提交SQL上线工单，可以指定用户"""
+        User.objects.filter(id=self.user.id).update(is_superuser=1)
+        user2 = User.objects.create(
+            username="test_user2", display="测试用户2", is_active=True
+        )
+        user2.groups.add(self.group.id)
+        user2.resource_group.add(self.res_group.group_id)
+        json_data = {
+            "workflow": {
+                "workflow_name": "上线工单1",
+                "demand_url": "test",
+                "group_id": 1,
+                "db_name": "test_db",
+                "engineer": "test_user2",
+                "instance": self.ins.id,
+            },
+            "sql_content": "alter table abc add column note varchar(64);",
+        }
+        r = self.client.post("/api/v1/workflow/", json_data, format="json")
+        self.assertEqual(r.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(r.json()["workflow"]["workflow_name"], "上线工单1")
+        self.assertEqual(r.json()["workflow"]["engineer"], user2.username)
+        self.assertEqual(r.json()["workflow"]["engineer_display"], user2.display)
 
     def test_submit_param_is_None(self):
         """测试SQL提交，参数内容为空"""

--- a/sql_api/tests.py
+++ b/sql_api/tests.py
@@ -557,6 +557,8 @@ class TestWorkflow(APITestCase):
         r = self.client.post("/api/v1/workflow/", json_data, format="json")
         self.assertEqual(r.status_code, status.HTTP_201_CREATED)
         self.assertEqual(r.json()["workflow"]["workflow_name"], "上线工单1")
+        self.assertEqual(r.json()["workflow"]["engineer"], self.user.username)
+        self.assertEqual(r.json()["workflow"]["engineer_display"], self.user.display)
 
     def test_submit_param_is_None(self):
         """测试SQL提交，参数内容为空"""


### PR DESCRIPTION
SQL工单缺失提交人信息，会导致权限校验异常，已经提交的工单需要人工修正数据，更新sql_workflow表中的engineer字段为提交人username

#1668 这里实际上存在一个不兼容的修改：通过API提交工单时，指定提交人已经失效，会全部标记为当前认证用户 @nick2wang 可以看下是否需要将api版本调整为v2，还是保持现状
