### PR TITLE
insert语句匹配正则适配更多语句

### DIFF
--- a/sql/engines/clickhouse.py
+++ b/sql/engines/clickhouse.py
@@ -346,14 +346,15 @@ class ClickHouseEngine(EngineBase):
                         errormessage=f"表 {table_name} 不存在！",
                         sql=statement,
                     )
-            # insert语句，explain无法正确判断，暂时只做表存在性检查与简单关键字匹配
+            # 
+            语句，explain无法正确判断，暂时只做表存在性检查与简单关键字匹配
             elif re.match(r"^insert", statement.lower()):
                 if re.match(
-                    r"^insert\s+into\s+([a-zA-Z_][0-9a-zA-Z_.]+?)(?:\s+|\(.+?\))",
+                    r"^insert\s+into\s+([a-zA-Z_][0-9a-zA-Z_.]+?)(\s+|\s*\(.+?\s*)(values|format|select)(\s+|\()",
                     statement.lower(),
                 ):
                     table_name = re.match(
-                        r"^insert\s+into\s+([a-zA-Z_][0-9a-zA-Z_.]+?)(?:\s+|\(.+?\))",
+                        r"^insert\s+into\s+([a-zA-Z_][0-9a-zA-Z_.]+?)(\s+|\s*\(.+?\s*)(values|format|select)(\s+|\()",
                         statement.lower(),
                         re.M,
                     ).group(1)

--- a/sql/engines/clickhouse.py
+++ b/sql/engines/clickhouse.py
@@ -349,11 +349,11 @@ class ClickHouseEngine(EngineBase):
             # insert语句，explain无法正确判断，暂时只做表存在性检查与简单关键字匹配
             elif re.match(r"^insert", statement.lower()):
                 if re.match(
-                    r"^insert\s+into\s+(.+?)(\s+|\s*\(.+?)(values|format|select)(\s+|\()",
+                    r"^insert\s+into\s+([a-zA-Z_][0-9a-zA-Z_.]+?)(?:\s+|\(.+?\))",
                     statement.lower(),
                 ):
                     table_name = re.match(
-                        r"^insert\s+into\s+(.+?)(\s+|\s*\(.+?)(values|format|select)(\s+|\()",
+                        r"^insert\s+into\s+([a-zA-Z_][0-9a-zA-Z_.]+?)(?:\s+|\(.+?\))",
                         statement.lower(),
                         re.M,
                     ).group(1)


### PR DESCRIPTION
* 现有正则无法从下列语句获取正确的table_name insert into db.newtable(account_id, application_id,customer_id, created_at) select  account_id,
        application_id,
        customer_id,
        created_at
from old_table; 
* 更改后的正则更简单,高效并能捕获符合数据库表命名规则的table_name