### PR TITLE
增强用于匹配INSER语句的正则

### DIFF
--- a/sql/engines/clickhouse.py
+++ b/sql/engines/clickhouse.py
@@ -349,11 +349,11 @@ class ClickHouseEngine(EngineBase):
             # insert语句，explain无法正确判断，暂时只做表存在性检查与简单关键字匹配
             elif re.match(r"^insert", statement.lower()):
                 if re.match(
-                    r"^insert\s+into\s+(.+?)(\s+|\s*\(.+?)(values|format|select)(\s+|\()",
+                    r"^insert\s+into\s+([a-zA-Z_][0-9a-zA-Z_.]+)([\w\W]*?)(values|format|select)(\s+|\()",
                     statement.lower(),
                 ):
                     table_name = re.match(
-                        r"^insert\s+into\s+(.+?)(\s+|\s*\(.+?)(values|format|select)(\s+|\()",
+                        r"^insert\s+into\s+([a-zA-Z_][0-9a-zA-Z_.]+)([\w\W]*?)(values|format|select)(\s+|\()",
                         statement.lower(),
                         re.M,
                     ).group(1)


### PR DESCRIPTION
* 现有正则无法从下列语句获取正确的table_name(实际是无法匹配大部分格式化后的语句)
```sql
insert into
  db.newtable(
    account_id,
    application_id,
    customer_id,
    created_at
  )
select
  account_id,
  application_id,
  customer_id,
  created_at
from
  old_table;
```
* 更改后的正则更简单,高效并能保证table_name严格符合数据库表命名规则