### PR TITLE
修复非Chrome浏览器登录配置2FA未保存问题

### DIFF
--- a/common/templates/2fa.html
+++ b/common/templates/2fa.html
@@ -228,6 +228,7 @@
                 key: $("#qrcode-img").attr('key'),
                 phone: $("#phone").val()
             },
+            async: false,
             complete: function () {
             },
             success: function (data) {


### PR DESCRIPTION
fix #1963
非chrome浏览器登录跳转时，保存2fa配置的ajax异步请求会被强制打断，导致登录成功但2fa配置未保存
ajax请求修改为同步模式