### PR TITLE
修复mongo正则匹配与method取值问题

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -533,7 +533,7 @@ class MongoEngine(EngineBase):
                     "renameCollection",
                 ]
                 pattern = re.compile(
-                    r"""^db\.createCollection\(([\s\S]*)\)$|^db\.([\w\.-]+)\.(?:[A-Za-z]+)(?:\([\s\S]*\)$)|^db\.getCollection\((?:\s*)(?:'|")([\w-]*)('|")(\s*)\)\.([A-Za-z]+)(\([\s\S]*\)$)"""
+                    r"""^db\.createCollection\(([\s\S]*)\)$|^db\.([\w\.-]+)\.(?:[A-Za-z]+)(?:\([\s\S]*\)$)|^db\.getCollection\((?:\s*)(?:'|")([\w\.-]+)('|")(\s*)\)\.([A-Za-z]+)(\([\s\S]*\)$)"""
                 )
                 m = pattern.match(check_sql)
                 if (
@@ -571,10 +571,8 @@ class MongoEngine(EngineBase):
                                 check_result.rows += [result]
                                 continue
                         else:
-                            # method = sql_str.split('.')[2]
-                            # methodStr = method.split('(')[0].strip()
                             methodStr = (
-                                sql_str.split("(")[0].split(".")[-1].strip()
+                                sql_str.split(".")[-1].split("(")[0].strip()
                             )  # 最后一个.和括号(之间的字符串作为方法
                         if methodStr in is_exist_premise_method and not is_in:
                             check_result.error = "文档不存在"


### PR DESCRIPTION
处理两个遗留问题：
1. pr #1372 这里对集合名包含特殊符号做了兼容，但是db.getCollection的正则当时没有更新到
![01](https://user-images.githubusercontent.com/33473924/202987784-8ecf29ba-7c71-46ee-bedb-619524836969.jpg)

2. pr #1381 取method注释描述是对的，但是split顺序反了，导致诸如db.getCollection("abc").remove({})、db.abc.find({}).remove()的语句都无法提交
![02](https://user-images.githubusercontent.com/33473924/202988308-81effeda-8858-450d-8ddf-673a2577b0d2.jpg)
