### PR TITLE
修复Redis不支持集群模式的配置

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ qrcode==7.3.1
 django-environ==0.8.1
 alibabacloud_dysmsapi20170525==2.0.9
 tencentcloud-sdk-python==3.0.656
+redis-py-cluster==2.1.3

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -13,6 +13,7 @@ import redis
 import logging
 import traceback
 
+from rediscluster import RedisCluster
 from common.utils.timer import FuncTimer
 from . import EngineBase
 from .models import ResultSet, ReviewSet, ReviewResult
@@ -26,7 +27,7 @@ class RedisEngine(EngineBase):
     def get_connection(self, db_name=None):
         db_name = db_name or self.db_name
         if self.mode == "cluster":
-            return redis.cluster.RedisCluster(
+            return RedisCluster(
                 host=self.host,
                 port=self.port,
                 password=self.password,


### PR DESCRIPTION
修复Redis不支持集群模式的配置, 引入redis-py-cluster==2.1.3支持Redis操作