### PR TITLE
:sparkles: 增加OIDC登入功能

### DIFF
--- a/archery/settings.py
+++ b/archery/settings.py
@@ -61,7 +61,6 @@ INSTALLED_APPS = (
     "rest_framework",
     "django_filters",
     "drf_spectacular",
-    "mozilla_django_oidc",
 )
 
 MIDDLEWARE = (
@@ -235,11 +234,12 @@ SIMPLE_JWT = {
 ENABLE_OIDC = env("ENABLE_OIDC", False)
 if ENABLE_OIDC:
 
+    INSTALLED_APPS += ("mozilla_django_oidc",)
+    MIDDLEWARE += ("mozilla_django_oidc.middleware.SessionRefresh",)
     AUTHENTICATION_BACKENDS = (
         "oidc.auth.OIDCAuthenticationBackend",
         "django.contrib.auth.backends.ModelBackend",
     )
-    MIDDLEWARE += ("mozilla_django_oidc.middleware.SessionRefresh",)
 
     OIDC_RP_WELLKNOWN_URL = env(
         "OIDC_RP_WELLKNOWN_URL"

--- a/archery/settings.py
+++ b/archery/settings.py
@@ -246,6 +246,7 @@ if ENABLE_OIDC:
     OIDC_RP_CLIENT_SECRET = env("OIDC_RP_CLIENT_SECRET")
 
     response = requests.get(OIDC_RP_WELLKNOWN_URL)
+    response.raise_for_status()
     config = response.json()
     OIDC_OP_AUTHORIZATION_ENDPOINT = config["authorization_endpoint"]
     OIDC_OP_TOKEN_ENDPOINT = config["token_endpoint"]

--- a/archery/settings.py
+++ b/archery/settings.py
@@ -6,6 +6,7 @@ import os
 from typing import List
 from datetime import timedelta
 import environ
+import requests
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -240,16 +241,19 @@ if ENABLE_OIDC:
         "django.contrib.auth.backends.ModelBackend",
     )
 
-    OIDC_RP_ISSUER_URL = env("OIDC_RP_ISSUER_URL", default="https://keycloak.example.com/realms/<your realm>")
+    OIDC_RP_WELLKNOWN_URL = env("OIDC_RP_WELLKNOWN_URL", default="https://keycloak.example.com/realms/<your realm>/.well-known/openid-configuration")
     OIDC_RP_CLIENT_ID = env("OIDC_RP_CLIENT_ID", default="<your client id>")
     OIDC_RP_CLIENT_SECRET = env("OIDC_RP_CLIENT_SECRET", default="<your client secret>")
 
-    # the following settings are good for keycloak
-    OIDC_OP_AUTHORIZATION_ENDPOINT = env("OIDC_OP_AUTHORIZATION_ENDPOINT", default=OIDC_RP_ISSUER_URL + "/protocol/openid-connect/auth")
-    OIDC_OP_TOKEN_ENDPOINT = env("OIDC_OP_TOKEN_ENDPOINT", default=OIDC_RP_ISSUER_URL + "/protocol/openid-connect/token")
-    OIDC_OP_USER_ENDPOINT = env("OIDC_OP_USER_ENDPOINT", default=OIDC_RP_ISSUER_URL + "/protocol/openid-connect/userinfo")
-    OIDC_OP_JWKS_ENDPOINT = env("OIDC_OP_JWKS_ENDPOINT", default=OIDC_RP_ISSUER_URL + "/protocol/openid-connect/certs")
-    OIDC_OP_LOGOUT_ENDPOINT = env("OIDC_OP_LOGOUT_ENDPOINT", default=OIDC_RP_ISSUER_URL + "/protocol/openid-connect/logout")
+    response = requests.get(OIDC_RP_WELLKNOWN_URL)
+    config = response.json()
+    OIDC_OP_AUTHORIZATION_ENDPOINT = config["authorization_endpoint"]
+    OIDC_OP_TOKEN_ENDPOINT = config["token_endpoint"]
+    OIDC_OP_USER_ENDPOINT = config["userinfo_endpoint"]
+    OIDC_OP_JWKS_ENDPOINT = config["jwks_uri"]
+    OIDC_OP_LOGOUT_ENDPOINT = config["end_session_endpoint"]
+
+    OIDC_RP_SCOPES = env("OIDC_RP_SCOPES", default="openid profile email")
     OIDC_RP_SIGN_ALGO = env("OIDC_RP_SIGN_ALGO", default="RS256")
 
     LOGIN_REDIRECT_URL = "/"

--- a/archery/settings.py
+++ b/archery/settings.py
@@ -241,7 +241,9 @@ if ENABLE_OIDC:
         "django.contrib.auth.backends.ModelBackend",
     )
 
-    OIDC_RP_WELLKNOWN_URL = env("OIDC_RP_WELLKNOWN_URL") # 例如 https://keycloak.example.com/realms/<your realm>/.well-known/openid-configuration
+    OIDC_RP_WELLKNOWN_URL = env(
+        "OIDC_RP_WELLKNOWN_URL"
+    )  # 例如 https://keycloak.example.com/realms/<your realm>/.well-known/openid-configuration
     OIDC_RP_CLIENT_ID = env("OIDC_RP_CLIENT_ID")
     OIDC_RP_CLIENT_SECRET = env("OIDC_RP_CLIENT_SECRET")
 

--- a/archery/settings.py
+++ b/archery/settings.py
@@ -75,7 +75,6 @@ MIDDLEWARE = (
     "django.middleware.gzip.GZipMiddleware",
     "common.middleware.check_login_middleware.CheckLoginMiddleware",
     "common.middleware.exception_logging_middleware.ExceptionLoggingMiddleware",
-    "mozilla_django_oidc.middleware.SessionRefresh",
 )
 
 ROOT_URLCONF = "archery.urls"
@@ -240,6 +239,7 @@ if ENABLE_OIDC:
         "oidc.auth.OIDCAuthenticationBackend",
         "django.contrib.auth.backends.ModelBackend",
     )
+    MIDDLEWARE += ("mozilla_django_oidc.middleware.SessionRefresh",)
 
     OIDC_RP_WELLKNOWN_URL = env(
         "OIDC_RP_WELLKNOWN_URL"

--- a/archery/settings.py
+++ b/archery/settings.py
@@ -241,9 +241,9 @@ if ENABLE_OIDC:
         "django.contrib.auth.backends.ModelBackend",
     )
 
-    OIDC_RP_WELLKNOWN_URL = env("OIDC_RP_WELLKNOWN_URL", default="https://keycloak.example.com/realms/<your realm>/.well-known/openid-configuration")
-    OIDC_RP_CLIENT_ID = env("OIDC_RP_CLIENT_ID", default="<your client id>")
-    OIDC_RP_CLIENT_SECRET = env("OIDC_RP_CLIENT_SECRET", default="<your client secret>")
+    OIDC_RP_WELLKNOWN_URL = env("OIDC_RP_WELLKNOWN_URL") # 例如 https://keycloak.example.com/realms/<your realm>/.well-known/openid-configuration
+    OIDC_RP_CLIENT_ID = env("OIDC_RP_CLIENT_ID")
+    OIDC_RP_CLIENT_SECRET = env("OIDC_RP_CLIENT_SECRET")
 
     response = requests.get(OIDC_RP_WELLKNOWN_URL)
     config = response.json()

--- a/archery/urls.py
+++ b/archery/urls.py
@@ -5,6 +5,7 @@ from common import views
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include(("sql_api.urls", "sql_api"), namespace="sql_api")),
+    path("oidc/", include("mozilla_django_oidc.urls")),
     path("", include(("sql.urls", "sql"), namespace="sql")),
 ]
 

--- a/common/middleware/check_login_middleware.py
+++ b/common/middleware/check_login_middleware.py
@@ -3,7 +3,16 @@ import re
 from django.http import HttpResponseRedirect
 from django.utils.deprecation import MiddlewareMixin
 
-IGNORE_URL = ["/login/", "/login/2fa/", "/authenticate/", "/signup/", "/api/info", "/oidc/callback/", "/oidc/authenticate/", "/oidc/logout/"]
+IGNORE_URL = [
+    "/login/",
+    "/login/2fa/",
+    "/authenticate/",
+    "/signup/",
+    "/api/info",
+    "/oidc/callback/",
+    "/oidc/authenticate/",
+    "/oidc/logout/",
+]
 
 IGNORE_URL_RE = r"/api/(v1|auth)/\w+"
 

--- a/common/middleware/check_login_middleware.py
+++ b/common/middleware/check_login_middleware.py
@@ -3,7 +3,7 @@ import re
 from django.http import HttpResponseRedirect
 from django.utils.deprecation import MiddlewareMixin
 
-IGNORE_URL = ["/login/", "/login/2fa/", "/authenticate/", "/signup/", "/api/info"]
+IGNORE_URL = ["/login/", "/login/2fa/", "/authenticate/", "/signup/", "/api/info", "/oidc/callback/", "/oidc/authenticate/", "/oidc/logout/"]
 
 IGNORE_URL_RE = r"/api/(v1|auth)/\w+"
 

--- a/common/templates/login.html
+++ b/common/templates/login.html
@@ -38,6 +38,11 @@
                     <a href="#" data-toggle="modal" data-target="#sign-up">注册用户</a>
                 </div>
             {% endif %}
+            {% if oidc_enabled %}
+                <div class="form-group">
+                    <a href="/oidc/authenticate/">以OIDC登录</a>
+                </div>
+            {% endif %}
         </form>
     </div>
 </div>

--- a/oidc/auth.py
+++ b/oidc/auth.py
@@ -1,0 +1,14 @@
+from mozilla_django_oidc import auth
+from django.core.exceptions import SuspiciousOperation
+
+class OIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
+    def create_user(self, claims):
+        """Return object for a newly created user account."""
+        email = claims.get("email")
+        username = claims.get("preferred_username")
+        display = claims.get("name")
+        if not email or not username or not display:
+            raise SuspiciousOperation("email and name and preferred_username should not be empty")
+        if username == "admin":
+            raise SuspiciousOperation("admin never get access from oidc")
+        return self.UserModel.objects.create_user(username, email=email, display=display)

--- a/oidc/auth.py
+++ b/oidc/auth.py
@@ -19,6 +19,10 @@ class OIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
         init_user(user)
         return user
 
+    def describe_user_by_claims(self, claims):
+        username = claims.get("preferred_username")
+        return "username {}".format(username)
+
     def filter_users_by_claims(self, claims):
         """Return all users matching the username."""
         username = claims.get("preferred_username")

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ qrcode==7.3.1
 django-environ==0.8.1
 alibabacloud_dysmsapi20170525==2.0.9
 tencentcloud-sdk-python==3.0.656
+mozilla-django-oidc==3.0.0

--- a/sql/views.py
+++ b/sql/views.py
@@ -65,7 +65,7 @@ def login(request):
         "login.html",
         context={
             "sign_up_enabled": SysConfig().get("sign_up_enabled"),
-            "oidc_enabled": os.getenv("ENABLE_OIDC")
+            "oidc_enabled": os.getenv("ENABLE_OIDC"),
         },
     )
 

--- a/sql/views.py
+++ b/sql/views.py
@@ -63,7 +63,10 @@ def login(request):
     return render(
         request,
         "login.html",
-        context={"sign_up_enabled": SysConfig().get("sign_up_enabled"), "oidc_enabled": os.getenv("ENABLE_OIDC")},
+        context={
+            "sign_up_enabled": SysConfig().get("sign_up_enabled"),
+            "oidc_enabled": os.getenv("ENABLE_OIDC")
+        },
     )
 
 

--- a/sql/views.py
+++ b/sql/views.py
@@ -63,7 +63,7 @@ def login(request):
     return render(
         request,
         "login.html",
-        context={"sign_up_enabled": SysConfig().get("sign_up_enabled")},
+        context={"sign_up_enabled": SysConfig().get("sign_up_enabled"), "oidc_enabled": os.getenv("ENABLE_OIDC")},
     )
 
 


### PR DESCRIPTION
这个pull request 增加了keycloak / oidc 登入选项, 基本上打开以下参数就可连结keycloak

ENABLE_OIDC="True"
OIDC_RP_ISSUER_URL="https://keycloak.example.com/realms/<your realm>"
OIDC_RP_CLIENT_ID="<your client id>"
OIDC_RP_CLIENT_SECRET="<your client secret>"

