### PR TITLE
add config for ban_self_audit

### DIFF
--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -264,6 +264,21 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="form-group">
+                                <label for="ban_self_audit"
+                                       class="col-sm-4 control-label">BAN_SELF_AUDIT</label>
+                                <div class="col-sm-8">
+                                    <div class="switch switch-small">
+                                        <label>
+                                            <input id="ban_self_audit"
+                                                   key="ban_self_audit"
+                                                   value="{{ config.ban_self_audit }}"
+                                                   type="checkbox">
+                                            是否允许工单审批人与提出人相同
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <h5 style="color: darkgrey"><b>SQL查询</b></h5>
                         <h6 style="color:red">注：开启脱敏功能必须要配置goInception信息，用于SQL语法解析</h6>

--- a/downloads/dictionary/test_instance_test_archery.html
+++ b/downloads/dictionary/test_instance_test_archery.html
@@ -1,0 +1,18 @@
+<html>
+    <meta charset="utf-8">
+    <title>数据库表结构说明文档</title>
+    <style>
+        body,td,th {font-family:"宋体"; font-size:12px;}
+        table,h1,p{width:960px;margin:0px auto;}
+        table{border-collapse:collapse;border:1px solid #CCC;background:#efefef;}
+        table caption{text-align:left; background-color:#fff; line-height:2em; font-size:14px; font-weight:bold; }
+        table th{text-align:left; font-weight:bold;height:26px; line-height:26px; font-size:12px; border:1px solid #CCC;padding-left:5px;}
+        table td{height:20px; font-size:12px; border:1px solid #CCC;background-color:#fff;padding-left:5px;}
+    </style>
+    
+    <body>
+    <h1 style="text-align:center;">test_archery 数据字典 (共 0 个表)</h1>
+    <p style="text-align:center;margin:20px auto;">生成时间：2023-01-31 14:41:33</p>
+    
+    </body>
+</html>

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -384,6 +384,27 @@ class Audit(object):
         )
         group_id = audit_info.group_id
         result = False
+
+        def get_workflow_applicant(workflow_id, workflow_type):
+            user = ""
+            if workflow_type == 1:
+                workflow = QueryPrivilegesApply.objects.get(apply_id=workflow_id)
+                user = workflow.user_name
+            elif workflow_type == 2:
+                workflow = SqlWorkflow.objects.get(id=workflow_id)
+                user = workflow.engineer
+            elif workflow_type == 3:
+                workflow = ArchiveConfig.objects.get(id=workflow_id)
+                user = workflow.user_name
+            return user
+
+        applicant = get_workflow_applicant(workflow_id, workflow_type)
+        if (
+            user.username == applicant
+            and not user.is_superuser
+            and SysConfig().get("ban_self_audit")
+        ):
+            return result
         # 只有待审核状态数据才可以审核
         if audit_info.current_status == WorkflowDict.workflow_status["audit_wait"]:
             try:


### PR DESCRIPTION
> https://github.com/hhyo/Archery/discussions/2039

Prevent the situation of `workflow auditor` being the same as `workflow creator`:
- superuser will not be limited
- introduced as a config option, default disabled