### PR TITLE
feat(mysql): 添加ddl_dml不能同时提交的逻辑

### DIFF
--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -265,6 +265,21 @@
                                 </div>
                             </div>
                             <div class="form-group">
+                                <label for="ddl_dml_separation"
+                                       class="col-sm-4 control-label">DDL_DML_SEPARATION</label>
+                                <div class="col-sm-8">
+                                    <div class="switch switch-small">
+                                        <label>
+                                            <input id="ddl_dml_separation"
+                                                   key="ddl_dml_separation"
+                                                   value="{{ config.ddl_dml_separation }}"
+                                                   type="checkbox">
+                                            是否禁止DDL和DML在SQL上线同时提交(MySQL)
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="form-group">
                                 <label for="ban_self_audit"
                                        class="col-sm-4 control-label">BAN_SELF_AUDIT</label>
                                 <div class="col-sm-8">

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -464,7 +464,7 @@ class MysqlEngine(EngineBase):
         ddl_dml_separation = self.config.get("ddl_dml_separation", False)
         p = re.compile(critical_ddl_regex)
         # 获取语句类型：DDL或者DML
-        ddl_dml_flag = ''
+        ddl_dml_flag = ""
         for row in check_result.rows:
             statement = row.sql
             # 去除注释
@@ -484,7 +484,7 @@ class MysqlEngine(EngineBase):
                 row.errlevel = 2
                 row.errormessage = "禁止提交匹配" + critical_ddl_regex + "条件的语句！"
             elif ddl_dml_separation and syntax_type in ("DDL", "DML"):
-                if ddl_dml_flag == '':
+                if ddl_dml_flag == "":
                     ddl_dml_flag = syntax_type
                 elif ddl_dml_flag != syntax_type:
                     check_result.error_count += 1

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -461,11 +461,16 @@ class MysqlEngine(EngineBase):
 
         # 禁用/高危语句检查
         critical_ddl_regex = self.config.get("critical_ddl_regex", "")
+        ddl_dml_separation = self.config.get("ddl_dml_separation", False)
         p = re.compile(critical_ddl_regex)
+        # 获取语句类型：DDL或者DML
+        ddl_dml_flag = ''
         for row in check_result.rows:
             statement = row.sql
             # 去除注释
             statement = remove_comments(statement, db_type="mysql")
+            # 获取提交类型
+            syntax_type = get_syntax_type(statement, parser=False, db_type="mysql")
             # 禁用语句
             if re.match(r"^select", statement.lower()):
                 check_result.error_count += 1
@@ -478,6 +483,14 @@ class MysqlEngine(EngineBase):
                 row.stagestatus = "驳回高危SQL"
                 row.errlevel = 2
                 row.errormessage = "禁止提交匹配" + critical_ddl_regex + "条件的语句！"
+            elif ddl_dml_separation and syntax_type in ("DDL", "DML"):
+                if ddl_dml_flag == '':
+                    ddl_dml_flag = syntax_type
+                elif ddl_dml_flag != syntax_type:
+                    check_result.error_count += 1
+                    row.stagestatus = "驳回不支持语句"
+                    row.errlevel = 2
+                    row.errormessage = "DDL语句和DML语句不能同时执行！"
         return check_result
 
     def execute_workflow(self, workflow):


### PR DESCRIPTION

1. common/templates/config.html: 新增一个配置项ddl_dml_separation, 默认为False, 如果开启, 则不允许DDL语句和DML语句同时执行
2. sql/engines/mysql.py: 增加判断一个sql上线工单中,如果开启ddl_dml_separation, 并且同时存在ddl和dml,则error_count + 1

## 开启功能之后:
![image](https://user-images.githubusercontent.com/17695185/221153378-13b8fa25-f4d8-4e88-9cfe-394586c1882f.png)

![image](https://user-images.githubusercontent.com/17695185/221152344-70238d1d-3297-43bb-8af9-3c8fe3e3793c.png)

![image](https://user-images.githubusercontent.com/17695185/221152649-cf22c354-8a5f-4211-b935-7f592f93c453.png)

![image](https://user-images.githubusercontent.com/17695185/221152726-3e24cd75-7f9e-4ad2-9c09-d7d4242012b5.png)

![image](https://user-images.githubusercontent.com/17695185/221152810-3ff383c3-b856-42ea-99b2-7c7d7b852002.png)

## 关闭功能之后:
![image](https://user-images.githubusercontent.com/17695185/221152993-be91afa2-18fd-41ed-8314-861256f70b04.png)

![image](https://user-images.githubusercontent.com/17695185/221153245-95315974-104b-460a-9366-370e3c1e45eb.png)
