### PR TITLE
fix: 支持使用create or replace创建函数、存储过程、视图以及包等语句

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -437,82 +437,14 @@ class OracleEngine(EngineBase):
     def get_sql_first_object_name(sql=""):
         """获取sql文本中的object_name"""
         object_name = ""
-        if re.match(r"^create\s+table\s", sql, re.M | re.IGNORECASE):
+        if re.match(r"^(create|alter)\s+(table|index|unique\sindex|sequence)\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+table\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+index\s", sql, re.M | re.IGNORECASE):
+                r"^(create|alter)\s+(table|index|unique\sindex|sequence)\s+(.+?)(\s|\()", sql, re.M | re.IGNORECASE
+            ).group(3)
+        elif re.match(r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+index\s(.+?)\s", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+unique\s+index\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+unique\s+index\s(.+?)\s", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+sequence\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+sequence\s(.+?)(\s|$)", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^alter\s+table\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^alter\s+table\s(.+?)\s", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+function\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+function\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+view\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+view\s(.+?)\s", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+procedure\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+procedure\s(.+?)\s", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+package\s+body", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+package\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+package\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+package\s(.+?)\s", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+type\s+body", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+type\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
-            ).group(1)
-		elif re.match(r"^create\s+type\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+type\s(.+?)\s", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+or\s+replace\s+function\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+or\s+replace\s+function\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+or\s+replace\s+view\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+or\s+replace\s+view\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+or\s+replace\s+procedure\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+or\s+replace\s+procedure\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+or\s+replace\s+package\s+body", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+or\s+replace\s+package\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+or\s+replace\s+package\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+or\s+replace\s+package\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
-            ).group(1)	
-        elif re.match(r"^create\s+or\s+replace\s+type\s+body", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+or\s+replace\s+type\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
-            ).group(1)
-        elif re.match(r"^create\s+or\s+replace\s+type\s", sql, re.M | re.IGNORECASE):
-            object_name = re.match(
-                r"^create\s+or\s+replace\s+type\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
-            ).group(1)
+                r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s+(.+?)(\s|\()", sql, re.M | re.IGNORECASE
+            ).group(3)
         else:
             return object_name.strip()
         return object_name.strip()

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -469,7 +469,7 @@ class OracleEngine(EngineBase):
             )
             return object_name
         return object_name
-		
+
     @staticmethod
     def check_create_index_table(sql="", object_name_list=None, db_name=""):
         schema_name = '"' + db_name + '"'

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -457,25 +457,25 @@ class OracleEngine(EngineBase):
             object_name = re.match(
                 r"^alter\s+table\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+function\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+[or\s]+[replace\s]+function\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+function\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
+                r"^create\s+[or\s]+[replace\s]+function\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+view\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+[or\s]+[replace\s]+view\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+view\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+[or\s]+[replace\s]+view\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+procedure\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+[or\s]+[replace\s]+procedure\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+procedure\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+[or\s]+[replace\s]+procedure\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+package\s+body", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+[or\s]+[replace\s]+package\s+body", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+package\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+[or\s]+[replace\s]+package\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+package\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+[or\s]+[replace\s]+package\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+package\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+[or\s]+[replace\s]+package\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
         else:
             return object_name.strip()

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -437,17 +437,25 @@ class OracleEngine(EngineBase):
     def get_sql_first_object_name(sql=""):
         """获取sql文本中的object_name"""
         object_name = ""
-        if re.match(r"^(create|alter)\s+(table|index|unique\sindex|sequence)\s", sql, re.M | re.IGNORECASE):
+        # 匹配表、索引、序列
+        pattern=r"^(create|alter)\s+(table|index|unique\sindex|sequence)\s"
+        groups = re.match(pattern, sql, re.M |  re.IGNORECASE)
+
+        if groups:
             object_name = re.match(
                 r"^(create|alter)\s+(table|index|unique\sindex|sequence)\s+(.+?)(\s|\()", sql, re.M | re.IGNORECASE
-            ).group(3)
-        elif re.match(r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s", sql, re.M | re.IGNORECASE):
+            ).group(3).strip()
+            return object_name
+
+        # 匹配创建或者替换SQL块
+        pattern=r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s"
+        groups = re.match(pattern, sql, re.M |  re.IGNORECASE)
+
+        if groups:
             object_name = re.match(
                 r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s+(.+?)(\s|\()", sql, re.M | re.IGNORECASE
-            ).group(3)
-        else:
-            return object_name.strip()
-        return object_name.strip()
+            ).group(3).strip()
+            return object_name
 
     @staticmethod
     def check_create_index_table(sql="", object_name_list=None, db_name=""):

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -453,10 +453,11 @@ class OracleEngine(EngineBase):
 
         if groups:
             object_name = re.match(
-                r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s+(.+?)(\s|\()", sql, re.M | re.IGNORECASE
+                r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s+(.+?)(\s|\()",
+                sql, re.M | re.IGNORECASE
             ).group(3).strip()
             return object_name
-
+        return object_name
     @staticmethod
     def check_create_index_table(sql="", object_name_list=None, db_name=""):
         schema_name = '"' + db_name + '"'

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -438,26 +438,38 @@ class OracleEngine(EngineBase):
         """获取sql文本中的object_name"""
         object_name = ""
         # 匹配表、索引、序列
-        pattern=r"^(create|alter)\s+(table|index|unique\sindex|sequence)\s"
-        groups = re.match(pattern, sql, re.M |  re.IGNORECASE)
+        pattern = r"^(create|alter)\s+(table|index|unique\sindex|sequence)\s"
+        groups = re.match(pattern, sql, re.M | re.IGNORECASE)
 
         if groups:
-            object_name = re.match(
-                r"^(create|alter)\s+(table|index|unique\sindex|sequence)\s+(.+?)(\s|\()", sql, re.M | re.IGNORECASE
-            ).group(3).strip()
+            object_name = (
+                re.match(
+                    r"^(create|alter)\s+(table|index|unique\sindex|sequence)\s+(.+?)(\s|\()",
+                    sql,
+                    re.M | re.IGNORECASE,
+                )
+                .group(3)
+                .strip()
+            )
             return object_name
 
         # 匹配创建或者替换SQL块
-        pattern=r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s"
-        groups = re.match(pattern, sql, re.M |  re.IGNORECASE)
+        pattern = r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s"
+        groups = re.match(pattern, sql, re.M | re.IGNORECASE)
 
         if groups:
-            object_name = re.match(
-                r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s+(.+?)(\s|\()",
-                sql, re.M | re.IGNORECASE
-            ).group(3).strip()
+            object_name = (
+                re.match(
+                    r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s+(.+?)(\s|\()",
+                    sql,
+                    re.M | re.IGNORECASE,
+                )
+                .group(3)
+                .strip()
+            )
             return object_name
         return object_name
+		
     @staticmethod
     def check_create_index_table(sql="", object_name_list=None, db_name=""):
         schema_name = '"' + db_name + '"'
@@ -943,18 +955,25 @@ class OracleEngine(EngineBase):
                                 object_name = object_name.upper()
 
                         object_name = f"""{schema_name}.{object_name}"""
-                        if re.match(r"^create\sor\sreplace", sql_lower) and (self.object_name_check(db_name=db_name,
-                                                  object_name=object_name) or object_name in object_name_list):
-                            result = ReviewResult(id=line, errlevel=1,
-                                                  stagestatus=f"""{object_name}对象已经存在，请确认是否替换！""",
-                                                  errormessage=f"""{object_name}对象已经存在，请确认是否替换！""",
-                                                  sql=sqlitem.statement,
-                                                  stmt_type=sqlitem.stmt_type,
-                                                  object_owner=sqlitem.object_owner,
-                                                  object_type=sqlitem.object_type,
-                                                  object_name=sqlitem.object_name,
-                                                  affected_rows=0,
-                                                  execute_time=0, )
+                        if re.match(r"^create\sor\sreplace", sql_lower) and (
+                            self.object_name_check(
+                                db_name=db_name, object_name=object_name
+                            )
+                            or object_name in object_name_list
+                        ):
+                            result = ReviewResult(
+                                id=line,
+                                errlevel=1,
+                                stagestatus=f"""{object_name}对象已经存在，请确认是否替换！""",
+                                errormessage=f"""{object_name}对象已经存在，请确认是否替换！""",
+                                sql=sqlitem.statement,
+                                stmt_type=sqlitem.stmt_type,
+                                object_owner=sqlitem.object_owner,
+                                object_type=sqlitem.object_type,
+                                object_name=sqlitem.object_name,
+                                affected_rows=0,
+                                execute_time=0,
+                            )
                         elif (
                             self.object_name_check(
                                 db_name=db_name, object_name=object_name

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -457,25 +457,61 @@ class OracleEngine(EngineBase):
             object_name = re.match(
                 r"^alter\s+table\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+[or\s]+[replace\s]+function\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+function\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+[or\s]+[replace\s]+function\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
+                r"^create\s+function\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+[or\s]+[replace\s]+view\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+view\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+[or\s]+[replace\s]+view\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+view\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+[or\s]+[replace\s]+procedure\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+procedure\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+[or\s]+[replace\s]+procedure\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+procedure\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+[or\s]+[replace\s]+package\s+body", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+package\s+body", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+[or\s]+[replace\s]+package\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+package\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
             ).group(1)
-        elif re.match(r"^create\s+[or\s]+[replace\s]+package\s", sql, re.M | re.IGNORECASE):
+        elif re.match(r"^create\s+package\s", sql, re.M | re.IGNORECASE):
             object_name = re.match(
-                r"^create\s+[or\s]+[replace\s]+package\s(.+?)\s", sql, re.M | re.IGNORECASE
+                r"^create\s+package\s(.+?)\s", sql, re.M | re.IGNORECASE
+            ).group(1)
+        elif re.match(r"^create\s+type\s+body", sql, re.M | re.IGNORECASE):
+            object_name = re.match(
+                r"^create\s+type\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
+            ).group(1)
+		elif re.match(r"^create\s+type\s", sql, re.M | re.IGNORECASE):
+            object_name = re.match(
+                r"^create\s+type\s(.+?)\s", sql, re.M | re.IGNORECASE
+            ).group(1)
+        elif re.match(r"^create\s+or\s+replace\s+function\s", sql, re.M | re.IGNORECASE):
+            object_name = re.match(
+                r"^create\s+or\s+replace\s+function\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
+            ).group(1)
+        elif re.match(r"^create\s+or\s+replace\s+view\s", sql, re.M | re.IGNORECASE):
+            object_name = re.match(
+                r"^create\s+or\s+replace\s+view\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
+            ).group(1)
+        elif re.match(r"^create\s+or\s+replace\s+procedure\s", sql, re.M | re.IGNORECASE):
+            object_name = re.match(
+                r"^create\s+or\s+replace\s+procedure\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
+            ).group(1)
+        elif re.match(r"^create\s+or\s+replace\s+package\s+body", sql, re.M | re.IGNORECASE):
+            object_name = re.match(
+                r"^create\s+or\s+replace\s+package\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
+            ).group(1)
+        elif re.match(r"^create\s+or\s+replace\s+package\s", sql, re.M | re.IGNORECASE):
+            object_name = re.match(
+                r"^create\s+or\s+replace\s+package\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
+            ).group(1)	
+        elif re.match(r"^create\s+or\s+replace\s+type\s+body", sql, re.M | re.IGNORECASE):
+            object_name = re.match(
+                r"^create\s+or\s+replace\s+type\s+body\s(.+?)\s", sql, re.M | re.IGNORECASE
+            ).group(1)
+        elif re.match(r"^create\s+or\s+replace\s+type\s", sql, re.M | re.IGNORECASE):
+            object_name = re.match(
+                r"^create\s+or\s+replace\s+type\s(.+?)(\s|\()", sql, re.M | re.IGNORECASE
             ).group(1)
         else:
             return object_name.strip()
@@ -966,7 +1002,19 @@ class OracleEngine(EngineBase):
                                 object_name = object_name.upper()
 
                         object_name = f"""{schema_name}.{object_name}"""
-                        if (
+                        if re.match(r"^create\sor\sreplace", sql_lower) and (self.object_name_check(db_name=db_name,
+                                                  object_name=object_name) or object_name in object_name_list):
+                            result = ReviewResult(id=line, errlevel=1,
+                                                  stagestatus=f"""{object_name}对象已经存在，请确认是否替换！""",
+                                                  errormessage=f"""{object_name}对象已经存在，请确认是否替换！""",
+                                                  sql=sqlitem.statement,
+                                                  stmt_type=sqlitem.stmt_type,
+                                                  object_owner=sqlitem.object_owner,
+                                                  object_type=sqlitem.object_type,
+                                                  object_name=sqlitem.object_name,
+                                                  affected_rows=0,
+                                                  execute_time=0, )
+                        elif (
                             self.object_name_check(
                                 db_name=db_name, object_name=object_name
                             )

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -442,14 +442,15 @@ class OracleEngine(EngineBase):
         groups = re.match(pattern, sql, re.M | re.IGNORECASE)
 
         if groups:
-            object_name = 
+            object_name = (
                 re.match(
                     r"^(create|alter)\s+(table|index|unique\sindex|sequence)\s+(.+?)(\s|\()",
                     sql,
                     re.M | re.IGNORECASE,
-                ).group(3).strip()
-            return object_name
-        else:
+                )
+                .group(3)
+                .strip()
+            )
             return object_name
 
         # 匹配创建或者替换SQL块
@@ -457,15 +458,17 @@ class OracleEngine(EngineBase):
         groups = re.match(pattern, sql, re.M | re.IGNORECASE)
 
         if groups:
-            object_name = 
+            object_name = (
                 re.match(
                     r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s+(.+?)(\s|\()",
                     sql,
                     re.M | re.IGNORECASE,
-                ).group(3).strip()
+                )
+                .group(3)
+                .strip()
+            )
             return object_name
-        else:
-            return object_name
+        return object_name
 
     @staticmethod
     def check_create_index_table(sql="", object_name_list=None, db_name=""):

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -442,15 +442,14 @@ class OracleEngine(EngineBase):
         groups = re.match(pattern, sql, re.M | re.IGNORECASE)
 
         if groups:
-            object_name = (
+            object_name = 
                 re.match(
                     r"^(create|alter)\s+(table|index|unique\sindex|sequence)\s+(.+?)(\s|\()",
                     sql,
                     re.M | re.IGNORECASE,
-                )
-                .group(3)
-                .strip()
-            )
+                ).group(3).strip()
+            return object_name
+        else:
             return object_name
 
         # 匹配创建或者替换SQL块
@@ -458,17 +457,15 @@ class OracleEngine(EngineBase):
         groups = re.match(pattern, sql, re.M | re.IGNORECASE)
 
         if groups:
-            object_name = (
+            object_name = 
                 re.match(
                     r"^create\s+(or\s+replace\s+)?(function|view|procedure|trigger|package\sbody|package|type\sbody|type)\s+(.+?)(\s|\()",
                     sql,
                     re.M | re.IGNORECASE,
-                )
-                .group(3)
-                .strip()
-            )
+                ).group(3).strip()
             return object_name
-        return object_name
+        else:
+            return object_name
 
     @staticmethod
     def check_create_index_table(sql="", object_name_list=None, db_name=""):


### PR DESCRIPTION
原来代码只支持使用create创建函数、存储过程、视图以及包，使用create or replace创建时获取不到对象名导致报错，实际运维中上线SQL大多使用create or replace方式，修改后同时支持使用create 和 create or replace两个方式。