### PR TITLE
自动识别Oracle SQL上线文本中的PLSQL程序块

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -691,6 +691,7 @@ class OracleEngine(EngineBase):
         critical_ddl_regex = config.get("critical_ddl_regex", "")
         p = re.compile(critical_ddl_regex)
         check_result.syntax_type = 2  # TODO 工单类型 0、其他 1、DDL，2、DML
+        sqlitem = None
         try:
             sqlitemList = get_full_sqlitem_list(sql, db_name)
             for sqlitem in sqlitemList:

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1738,7 +1738,7 @@ end;"""
         check_result = new_engine.execute_check(db_name="TRADE", sql=sql)
         self.assertIsInstance(check_result, ReviewSet)
         self.assertEqual(check_result.rows[0].__dict__, row.__dict__)
-        
+
     @patch("cx_Oracle.connect.cursor.execute")
     @patch("cx_Oracle.connect.cursor")
     @patch("cx_Oracle.connect")

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1670,13 +1670,14 @@ class TestOracle(TestCase):
 name IN VARCHAR2)    
 is    
 begin    
-    insert into user1 values(id,name);    
-end;""" 
+    insert into user1 values(id,name);
+end;"""
         object_name = new_engine.get_sql_first_object_name(sql)
         self.assertEqual(object_name, "INSERTUSER")
 
     @patch(
-        "sql.engines.oracle.OracleEngine.get_sql_first_object_name", return_value="INSERTUSER"
+        "sql.engines.oracle.OracleEngine.get_sql_first_object_name",
+        return_value="INSERTUSER",
     )
     @patch("sql.engines.oracle.OracleEngine.object_name_check", return_value=True)
     def test_execute_check_replace_exist_plsql_object(
@@ -1710,7 +1711,8 @@ end;"""
         self.assertEqual(check_result.rows[0].__dict__, row.__dict__)
 
     @patch(
-        "sql.engines.oracle.OracleEngine.get_sql_first_object_name", return_value="INSERTUSER"
+        "sql.engines.oracle.OracleEngine.get_sql_first_object_name",
+        return_value="INSERTUSER",
     )
     @patch("sql.engines.oracle.OracleEngine.object_name_check", return_value=True)
     def test_execute_check_exist_plsql_object(

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -351,7 +351,7 @@ def get_full_sqlitem_list(full_sql, db_name):
             delimiter_flag = 0
         else:
             # 表示当前为以;结尾的正常sql
-			# 去除剩余SQL文本中可能多添加$$符号（创建表、视图、序列运行结尾加“/”符号，但不作为PLSQL块处理）
+	    # 去除剩余SQL文本中可能多添加$$符号（创建表、视图、序列运行结尾加“/”符号，但不作为PLSQL块处理）
             sql_area = sql_area.replace('/\n$$','')
             tmp_list = get_base_sqlitem_list(sql)
             list.extend(tmp_list)

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -148,74 +148,74 @@ def get_base_sqlitem_list(full_sql):
 
 
 def get_full_sqlitem_list(full_sql, db_name):
-    """预处SQL理文本：
-	对PLSQL语句块自动添加delimiter $$作为开始间隔符，$$作为结束间隔符
-    """
-
-    full_sql = full_sql + '\n' + '--SQL END'
-    pattern_dict = {r'(;[\s]*\/[^\*])':';\n/\n$$', 
-                    r'(create[\s]*?or[\s]*?replace[\s]*?procedure)':'create or replace procedure', 
-                    r'(create[\s]*?or[\s]*?replace[\s]*?function)':'create or replace function',
-                    r'(create[\s]*?or[\s]*?replace[\s]*?trigger)':'create or replace trigger',
-                    r'(create[\s]*?or[\s]*?replace[\s]*?package)':'create or replace package', 
-                    r'(create[\s]*?or[\s]*?replace[\s]*?type)':'create or replace type',
-                    r'(create[\s]*?procedure)':'create procedure', 
-                    r'(create[\s]*?function)':'create function', 
-                    r'(create[\s]*?trigger)':'create trigger', 
-                    r'(create[\s]*?package)':'create package',
-                    r'(create[\s]*?type)':'create type'}
-    for pattern in pattern_dict:
-        full_sql = re.sub(pattern, pattern_dict[pattern], full_sql, flags=re.I)
-    pre_sql_list = full_sql.split('\n')
-    full_sql_new = ''
-    is_inside_plsqlblock = 0
-    for line in pre_sql_list:
-        if re.match(r"^declare", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-        elif re.match(r"^begin", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-        elif re.match(r"^create or replace procedure\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-        elif re.match(r"^create or replace function\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-        elif re.match(r"^create or replace trigger\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-        elif re.match(r"^create or replace package\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-        elif re.match(r"^create or replace type\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-        elif re.match(r"^create procedure\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-        elif re.match(r"^create function\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-        elif re.match(r"^create trigger\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-        elif re.match(r"^create package\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-        elif re.match(r"^create type\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
-            line = 'delimiter $$' + '\n' + line
-            is_inside_plsqlblock = 1
-
-        if line.strip() == "$$":
-            is_inside_plsqlblock = 0
-        full_sql_new = full_sql_new + line + '\n'
-    
     """获取Sql对应的SqlItem列表, 包括PLSQL部分
-        PLSQL语句块由delimiter $$作为开始间隔符，以$$作为结束间隔符
     :param full_sql: 全部sql内容
     :return: SqlItem 列表
     """
+
+    """预处理SQL文本，第一步：自动添加PLSQL块结尾标识符
+    根据PLSQL书写语法，识别结尾符号，在PLSQL语句结尾添加$$符号（单独一行），作为该平台处理PLSQL块结尾标识符
+    同时需要过滤掉PLSQL块中间可能存在的注释 /* 注释内容 */ 干扰
+    """
+    pattern = r"(;(\s)*\n(/$|/\s))"
+    full_sql = re.sub(pattern, ";\n/\n$$", full_sql, flags=re.I)
+
+    """预处理SQL文本，第二步：自动添加PLSQL块开始标识符
+    根据PLSQL书写语法，识别开始符号，在PLSQL语句开始前添加delimiter $$符号（单独一行），作为该平台处理PLSQL块开始标识符
+    PLSQL块包括：以declare开始的匿名块、以begin开始的匿名块、存储过程、函数、触发器、包以及包体、对象类型以及对象类型体
+    """
+
+    """1、调整PLSQL开始部分语句，对于开始部分（如：create or replace procedure）中间可能存在换行的调整为一行，
+    保证下一步处理中，使用换行分割时，PLSQL开始标识完整的落在一行内
+    """
+    pattern_dict = {
+        r"(create\s+or\s+replace\s+procedure)": "create or replace procedure",
+        r"(create\s+or\s+replace\s+function)": "create or replace function",
+        r"(create\s+or\s+replace\s+trigger)": "create or replace trigger",
+        r"(create\s+or\s+replace\s+package)": "create or replace package",
+        r"(create\s+or\s+replace\s+type)": "create or replace type",
+        r"(create\s+procedure)": "create procedure",
+        r"(create\s+function)": "create function",
+        r"(create\s+trigger)": "create trigger",
+        r"(create\s+package)": "create package",
+        r"(create\s+type)": "create type",
+    }
+
+    for pattern in pattern_dict:
+        full_sql = re.sub(pattern, pattern_dict[pattern], full_sql, flags=re.I)
+
+    """2、使用换行符分割SQL文本，逐行处理SQL文本：
+    识别PLSQL开始语法标识符，在开始标识符前加delimiter $$（独立一行），作为该平台识别PLSQL开始位置的标识符，
+    同时通过引入is_inside_plsqlblock参数，排除掉那些可能存在于PLSQL程序块内部的开始标识符（declare，begin,create [or replace] xx等）
+    """
+    pre_sql_list = full_sql.split("\n")
+    full_sql_new = ""
+    is_inside_plsqlblock = 0
+
+    # 逐行处理SQL文本
+    for line in pre_sql_list:
+        # 匹配到declare和begin开始的行，同时该行SQL不是处于PLSQL程序块内部的，前面添加delimiter $$标识符（独立一行）
+        pattern = r"^(declare|begin)"
+        groups = re.match(pattern, line, re.IGNORECASE)
+        if groups and is_inside_plsqlblock == 0:
+            line = "delimiter $$" + "\n" + line
+            # 修改is_inside_plsqlblock参数为1，标识文本进入PLSQL块内部
+            is_inside_plsqlblock = 1
+
+        # 匹配到create [or replace] function|procedure|trigger|package|type开始的行，同时该行SQL不是处于PLSQL程序块内部的，
+        # 前面添加delimiter $$标识符（独立一行）
+        pattern = r"^create\s+(or\s+replace\s+)?(function|procedure|trigger|package|type)\s"
+        groups = re.match(pattern, line, re.IGNORECASE)
+        if groups and is_inside_plsqlblock == 0:
+            line = "delimiter $$" + "\n" + line
+            # 修改is_inside_plsqlblock参数为1，标识文本进入PLSQL块内部
+            is_inside_plsqlblock = 1
+
+        # 匹配到内容为$$的行，修改is_inside_plsqlblock参数为0，标识文本跳出PLSQL块
+        if line.strip() == "$$":
+            is_inside_plsqlblock = 0
+        full_sql_new = full_sql_new + line + '\n'
+
     list = []
 
     # 定义开始分隔符，两端用括号，是为了re.split()返回列表包含分隔符
@@ -335,9 +335,9 @@ def get_full_sqlitem_list(full_sql, db_name):
 
                 if length > pos + 2:
                     # 处理$$之后的那些语句, 默认为单条可执行SQL的集合
-                    sql_area = sql[pos + 2 :].strip()
-                    # 去除剩余SQL文本中可能多添加$$符号（创建表、视图、序列运行结尾加“/”符号，但不作为PLSQL块处理）
-                    sql_area = sql_area.replace('/\n$$','')
+                    # 创建视图、序列、表，语句作为SQL处理最后如果加了 / ，预处理中会在 / 后一行加$$，
+                    # 这里需要将SQL文本中 /\n$$ 去除后再传给get_base_sqlitem_list函数
+                    sql_area = sql[pos + 2:].replace("/\n$$","").strip()
                     if len(sql_area) > 0:
                         tmp_list = get_base_sqlitem_list(sql_area)
                         list.extend(tmp_list)
@@ -351,9 +351,9 @@ def get_full_sqlitem_list(full_sql, db_name):
             delimiter_flag = 0
         else:
             # 表示当前为以;结尾的正常sql
-	    # 去除剩余SQL文本中可能多添加$$符号（创建表、视图、序列运行结尾加“/”符号，但不作为PLSQL块处理）
-            sql_area = sql_area.replace('/\n$$','')
-            tmp_list = get_base_sqlitem_list(sql)
+            # 创建视图、序列、表，语句作为SQL处理最后如果加了 / ，预处理中会在 / 后一行加$$，
+            # 这里需要将SQL文本中 /\n$$ 去除后再传给get_base_sqlitem_list函数
+            sql = sql.replace("/\n$$","")
             list.extend(tmp_list)
     return list
 

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -244,7 +244,8 @@ def get_full_sqlitem_list(full_sql, db_name):
         if re.match(regex_delimiter, sql):
             delimiter_flag = 1
             continue
-
+            
+        tmp_list = []
         if delimiter_flag == 1:
             # 表示SQL块为delimiter $$标记之后的内容
 

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -196,7 +196,7 @@ def get_full_sqlitem_list(full_sql, db_name):
     for line in pre_sql_list:
         # 匹配到declare和begin开始的行，同时该行SQL不是处于PLSQL程序块内部的，前面添加delimiter $$标识符（独立一行）
         pattern = r"^(declare|begin)"
-        groups = re.match(pattern, line, re.IGNORECASE)
+        groups = re.match(pattern, line.lstrip(), re.IGNORECASE)
         if groups and is_inside_plsqlblock == 0:
             line = "delimiter $$" + "\n" + line
             # 修改is_inside_plsqlblock参数为1，标识文本进入PLSQL块内部
@@ -207,7 +207,7 @@ def get_full_sqlitem_list(full_sql, db_name):
         pattern = (
             r"^create\s+(or\s+replace\s+)?(function|procedure|trigger|package|type)\s"
         )
-        groups = re.match(pattern, line, re.IGNORECASE)
+        groups = re.match(pattern, line.lstrip(), re.IGNORECASE)
         if groups and is_inside_plsqlblock == 0:
             line = "delimiter $$" + "\n" + line
             # 修改is_inside_plsqlblock参数为1，标识文本进入PLSQL块内部

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -204,7 +204,9 @@ def get_full_sqlitem_list(full_sql, db_name):
 
         # 匹配到create [or replace] function|procedure|trigger|package|type开始的行，同时该行SQL不是处于PLSQL程序块内部的，
         # 前面添加delimiter $$标识符（独立一行）
-        pattern = r"^create\s+(or\s+replace\s+)?(function|procedure|trigger|package|type)\s"
+        pattern = (
+            r"^create\s+(or\s+replace\s+)?(function|procedure|trigger|package|type)\s"
+        )
         groups = re.match(pattern, line, re.IGNORECASE)
         if groups and is_inside_plsqlblock == 0:
             line = "delimiter $$" + "\n" + line
@@ -214,7 +216,7 @@ def get_full_sqlitem_list(full_sql, db_name):
         # 匹配到内容为$$的行，修改is_inside_plsqlblock参数为0，标识文本跳出PLSQL块
         if line.strip() == "$$":
             is_inside_plsqlblock = 0
-        full_sql_new = full_sql_new + line + '\n'
+        full_sql_new = full_sql_new + line + "\n"
 
     list = []
 
@@ -337,7 +339,7 @@ def get_full_sqlitem_list(full_sql, db_name):
                     # 处理$$之后的那些语句, 默认为单条可执行SQL的集合
                     # 创建视图、序列、表，语句作为SQL处理最后如果加了 / ，预处理中会在 / 后一行加$$，
                     # 这里需要将SQL文本中 /\n$$ 去除后再传给get_base_sqlitem_list函数
-                    sql_area = sql[pos + 2:].replace("/\n$$","").strip()
+                    sql_area = sql[pos + 2 :].replace("/\n$$", "").strip()
                     if len(sql_area) > 0:
                         tmp_list = get_base_sqlitem_list(sql_area)
                         list.extend(tmp_list)
@@ -353,7 +355,7 @@ def get_full_sqlitem_list(full_sql, db_name):
             # 表示当前为以;结尾的正常sql
             # 创建视图、序列、表，语句作为SQL处理最后如果加了 / ，预处理中会在 / 后一行加$$，
             # 这里需要将SQL文本中 /\n$$ 去除后再传给get_base_sqlitem_list函数
-            sql = sql.replace("/\n$$","")
+            sql = sql.replace("/\n$$", "")
             tmp_list = get_base_sqlitem_list(sql)
             list.extend(tmp_list)
     return list

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -148,6 +148,69 @@ def get_base_sqlitem_list(full_sql):
 
 
 def get_full_sqlitem_list(full_sql, db_name):
+    """预处SQL理文本：
+	对PLSQL语句块自动添加delimiter $$作为开始间隔符，$$作为结束间隔符
+    """
+
+    full_sql = full_sql + '\n' + '--SQL END'
+    pattern_dict = {r'(;[\s]*\/[^\*])':';\n/\n$$', 
+                    r'(create[\s]*?or[\s]*?replace[\s]*?procedure)':'create or replace procedure', 
+                    r'(create[\s]*?or[\s]*?replace[\s]*?function)':'create or replace function',
+                    r'(create[\s]*?or[\s]*?replace[\s]*?trigger)':'create or replace trigger',
+                    r'(create[\s]*?or[\s]*?replace[\s]*?package)':'create or replace package', 
+                    r'(create[\s]*?or[\s]*?replace[\s]*?type)':'create or replace type',
+                    r'(create[\s]*?procedure)':'create procedure', 
+                    r'(create[\s]*?function)':'create function', 
+                    r'(create[\s]*?trigger)':'create trigger', 
+                    r'(create[\s]*?package)':'create package',
+                    r'(create[\s]*?type)':'create type'}
+    for pattern in pattern_dict:
+        full_sql = re.sub(pattern, pattern_dict[pattern], full_sql, flags=re.I)
+    pre_sql_list = full_sql.split('\n')
+    full_sql_new = ''
+    is_inside_plsqlblock = 0
+    for line in pre_sql_list:
+        if re.match(r"^declare", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+        elif re.match(r"^begin", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+        elif re.match(r"^create or replace procedure\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+        elif re.match(r"^create or replace function\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+        elif re.match(r"^create or replace trigger\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+        elif re.match(r"^create or replace package\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+        elif re.match(r"^create or replace type\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+        elif re.match(r"^create procedure\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+        elif re.match(r"^create function\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+        elif re.match(r"^create trigger\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+        elif re.match(r"^create package\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+        elif re.match(r"^create type\s", line.lower().lstrip()) and is_inside_plsqlblock == 0:
+            line = 'delimiter $$' + '\n' + line
+            is_inside_plsqlblock = 1
+
+        if line.strip() == "$$":
+            is_inside_plsqlblock = 0
+        full_sql_new = full_sql_new + line + '\n'
+    
     """获取Sql对应的SqlItem列表, 包括PLSQL部分
         PLSQL语句块由delimiter $$作为开始间隔符，以$$作为结束间隔符
     :param full_sql: 全部sql内容
@@ -158,11 +221,11 @@ def get_full_sqlitem_list(full_sql, db_name):
     # 定义开始分隔符，两端用括号，是为了re.split()返回列表包含分隔符
     regex_delimiter = r"(delimiter\s*\$\$)"
     # 注意：必须把package body置于package之前，否则将永远匹配不上package body
-    regex_objdefine = r'create\s+or\s+replace\s+(function|procedure|trigger|package\s+body|package|view)\s+("?\w+"?\.)?"?\w+"?[\s+|\(]'
+    regex_objdefine = r'create\s+or\s+replace\s+(function|procedure|trigger|package\s+body|package|type\s+body|type)\s+("?\w+"?\.)?"?\w+"?[\s+|\(]'
     # 对象命名，两端有双引号
     regex_objname = r'^".+"$'
 
-    sql_list = re.split(pattern=regex_delimiter, string=full_sql, flags=re.I)
+    sql_list = re.split(pattern=regex_delimiter, string=full_sql_new, flags=re.I)
 
     # delimiter_flag => 分隔符标记, 0:不是, 1:是
     # 遇到分隔符标记为1, 则本块SQL要去判断是否有PLSQL内容
@@ -273,6 +336,8 @@ def get_full_sqlitem_list(full_sql, db_name):
                 if length > pos + 2:
                     # 处理$$之后的那些语句, 默认为单条可执行SQL的集合
                     sql_area = sql[pos + 2 :].strip()
+                    # 去除剩余SQL文本中可能多添加$$符号（创建表、视图、序列运行结尾加“/”符号，但不作为PLSQL块处理）
+                    sql_area = sql_area.replace('/\n$$','')
                     if len(sql_area) > 0:
                         tmp_list = get_base_sqlitem_list(sql_area)
                         list.extend(tmp_list)
@@ -286,6 +351,8 @@ def get_full_sqlitem_list(full_sql, db_name):
             delimiter_flag = 0
         else:
             # 表示当前为以;结尾的正常sql
+			# 去除剩余SQL文本中可能多添加$$符号（创建表、视图、序列运行结尾加“/”符号，但不作为PLSQL块处理）
+            sql_area = sql_area.replace('/\n$$','')
             tmp_list = get_base_sqlitem_list(sql)
             list.extend(tmp_list)
     return list

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -244,8 +244,7 @@ def get_full_sqlitem_list(full_sql, db_name):
         if re.match(regex_delimiter, sql):
             delimiter_flag = 1
             continue
-            
-        tmp_list = []
+
         if delimiter_flag == 1:
             # 表示SQL块为delimiter $$标记之后的内容
 
@@ -355,6 +354,7 @@ def get_full_sqlitem_list(full_sql, db_name):
             # 创建视图、序列、表，语句作为SQL处理最后如果加了 / ，预处理中会在 / 后一行加$$，
             # 这里需要将SQL文本中 /\n$$ 去除后再传给get_base_sqlitem_list函数
             sql = sql.replace("/\n$$","")
+            tmp_list = get_base_sqlitem_list(sql)
             list.extend(tmp_list)
     return list
 

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -193,7 +193,7 @@ END;
 """
         lists = get_full_sqlitem_list(text, "db")
         rows = [
-		    SqlItem(
+	    SqlItem(
                 id=0,
                 statement="""declare
     v_rowcount integer;
@@ -333,7 +333,7 @@ create table user(
                 object_owner="",
                 object_type="",
                 object_name="",
-			),
+	    ),
             SqlItem(
                 id=0,
                 statement=sqlparse.format(
@@ -343,8 +343,8 @@ create table user(
                 object_owner="",
                 object_type="",
                 object_name="",
-			)
-		]
+	    )
+	]
         self.assertIsInstance(lists[1], SqlItem)
         self.assertIsInstance(lists[2], SqlItem)
         self.assertEqual(lists[1].__dict__, rows[0].__dict__)
@@ -391,7 +391,7 @@ create table user(
                 object_type="",
                 object_name="",
             )
-		]
+	]
         self.assertIsInstance(lists[0], SqlItem)
         self.assertIsInstance(lists[1], SqlItem)
         self.assertEqual(lists[0].__dict__, rows[0].__dict__)

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -343,7 +343,7 @@ create table user(
                 object_owner="",
                 object_type="",
                 object_name="",
-            )
+            ),
         ]
         self.assertIsInstance(lists[1], SqlItem)
         self.assertIsInstance(lists[2], SqlItem)
@@ -390,7 +390,7 @@ create table user(
                 object_owner="",
                 object_type="",
                 object_name="",
-            )
+            ),
         ]
         self.assertIsInstance(lists[0], SqlItem)
         self.assertIsInstance(lists[1], SqlItem)

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -193,7 +193,7 @@ END;
 """
         lists = get_full_sqlitem_list(text, "db")
         rows = [
-	    SqlItem(
+            SqlItem(
                 id=0,
                 statement="""declare
     v_rowcount integer;
@@ -333,7 +333,7 @@ create table user(
                 object_owner="",
                 object_type="",
                 object_name="",
-	    ),
+            ),
             SqlItem(
                 id=0,
                 statement=sqlparse.format(
@@ -343,8 +343,8 @@ create table user(
                 object_owner="",
                 object_type="",
                 object_name="",
-	    )
-	]
+            )
+        ]
         self.assertIsInstance(lists[1], SqlItem)
         self.assertIsInstance(lists[2], SqlItem)
         self.assertEqual(lists[1].__dict__, rows[0].__dict__)
@@ -391,7 +391,7 @@ create table user(
                 object_type="",
                 object_name="",
             )
-	]
+        ]
         self.assertIsInstance(lists[0], SqlItem)
         self.assertIsInstance(lists[1], SqlItem)
         self.assertEqual(lists[0].__dict__, rows[0].__dict__)

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -22,7 +22,7 @@ from django_q.models import Schedule
 
 from common.config import SysConfig
 from common.utils.const import WorkflowDict
-from sql.engines.models import ReviewResult, ReviewSet
+from sql.engines.models import ReviewResult, ReviewSet, SqlItem
 from sql.models import (
     Users,
     SqlWorkflow,
@@ -158,6 +158,232 @@ class TestSQLUtils(TestCase):
                 }
             ],
         )
+
+    def test_get_full_sqlitem_list_anonymous_plsql(self):
+        """
+        测试SQL文本中plsql可执行块（匿名块）自动分割
+        :return:
+        """
+        text = """
+declare
+    v_rowcount integer;
+begin
+    select count(1) into v_rowcount  from user_tables
+      where table_name = upper('test2'); --账户特定关系人信息历史表
+    if v_rowcount = 0 then
+        execute IMMEDIATE '
+        create table test2
+        (
+        vc_bfcyid           int,           --受益人信息唯一标志ID
+        vc_specperid        VARCHAR2(100)  --特定关系人信息唯一标志ID
+        )
+        ';
+        execute IMMEDIATE '
+        CREATE index Idx_test2_1 ON test2(VC_BFCYID)
+        ';
+    end if;
+end;
+/
+
+BEGIN
+    insert into test2 values(1,'qq1');
+    commit;
+END;
+/
+"""
+        lists = get_full_sqlitem_list(text, "db")
+        rows = [SqlItem(
+            id=0,
+            statement="""declare
+    v_rowcount integer;
+begin
+    select count(1) into v_rowcount  from user_tables
+      where table_name = upper('test2'); --账户特定关系人信息历史表
+    if v_rowcount = 0 then
+        execute IMMEDIATE '
+        create table test2
+        (
+        vc_bfcyid           int,           --受益人信息唯一标志ID
+        vc_specperid        VARCHAR2(100)  --特定关系人信息唯一标志ID
+        )
+        ';
+        execute IMMEDIATE '
+        CREATE index Idx_test2_1 ON test2(VC_BFCYID)
+        ';
+    end if;
+end;""",
+            stmt_type="PLSQL",
+            object_owner="db",
+            object_type="ANONYMOUS",
+            object_name="ANONYMOUS",
+        ),SqlItem(
+            id=0,
+            statement="""BEGIN
+    insert into test2 values(1,'qq1');
+    commit;
+END;""",
+            stmt_type="PLSQL",
+            object_owner="db",
+            object_type="ANONYMOUS",
+            object_name="ANONYMOUS",
+        )]
+        self.assertIsInstance(lists[0], SqlItem)
+        self.assertIsInstance(lists[1], SqlItem)
+        self.assertEqual(lists[0].__dict__, rows[0].__dict__)
+        self.assertEqual(lists[1].__dict__, rows[1].__dict__)
+
+    def test_get_full_sqlitem_list_plsql(self):
+        """
+        测试SQL文本中plsql对象定义语句（存储过程、函数等）自动分割
+        :return:
+        """
+        text = """
+create or replace procedure INSERTUSER
+(id IN NUMBER,
+name IN VARCHAR2)
+is
+begin
+    insert into user1 values(id,name);
+end;
+/
+
+create or replace function annual_income(name1 varchar2)
+return number is
+annual_salary number(7,2);
+begin
+    select sal*12+nvl(comm,0) into annual_salary from emp where lower(ename)=lower(name1);
+return annual_salary;
+end;
+/
+"""
+        lists = get_full_sqlitem_list(text, "db")
+        rows = [SqlItem(
+            id=0,
+            statement="""create or replace procedure INSERTUSER
+(id IN NUMBER,
+name IN VARCHAR2)
+is
+begin
+    insert into user1 values(id,name);
+end;""",
+            stmt_type="PLSQL",
+            object_owner="db",
+            object_type="PROCEDURE",
+            object_name="INSERTUSER",
+        ),SqlItem(
+            id=0,
+            statement="""create or replace function annual_income(name1 varchar2)
+return number is
+annual_salary number(7,2);
+begin
+    select sal*12+nvl(comm,0) into annual_salary from emp where lower(ename)=lower(name1);
+return annual_salary;
+end;""",
+            stmt_type="PLSQL",
+            object_owner="db",
+            object_type="FUNCTION",
+            object_name="ANNUAL_INCOME",
+        )]
+        self.assertIsInstance(lists[0], SqlItem)
+        self.assertIsInstance(lists[1], SqlItem)
+        self.assertEqual(lists[0].__dict__, rows[0].__dict__)
+        self.assertEqual(lists[1].__dict__, rows[1].__dict__)
+
+    def test_get_full_sqlitem_list_sql_after_plsql(self):
+        """
+        测试SQL文本中plsql后面普通SQL语句以;自动分割
+        :return:
+        """
+        text = """
+create or replace procedure INSERTUSER
+(id IN NUMBER,
+name IN VARCHAR2)
+is
+begin
+    insert into user1 values(id,name);
+end;
+/
+update user_account set created=sysdate where account_no=1; 
+create table user(
+    id int,
+    uname varchar(100),
+    age int
+);
+"""
+        sql1 = "update user_account set created=sysdate where account_no=1;"
+        sql2 = """create table user(
+    id int,
+    uname varchar(100),
+    age int
+);"""
+        lists = get_full_sqlitem_list(text, "db")
+        rows = [SqlItem(
+            id=0,
+            statement=sqlparse.format(
+                sql1, strip_comments=True, reindent=True, keyword_case="lower"
+            ),
+            stmt_type="SQL",
+            object_owner="",
+            object_type="",
+            object_name="",
+        ),SqlItem(
+            id=0,
+            statement=sqlparse.format(
+                sql2, strip_comments=True, reindent=True, keyword_case="lower"
+            ),
+            stmt_type="SQL",
+            object_owner="",
+            object_type="",
+            object_name="",
+        )]
+        self.assertIsInstance(lists[1], SqlItem)
+        self.assertIsInstance(lists[2], SqlItem)
+        self.assertEqual(lists[1].__dict__, rows[0].__dict__)
+        self.assertEqual(lists[2].__dict__, rows[1].__dict__)
+
+    def test_get_full_sqlitem_list_sql(self):
+        """
+        测试普通SQL（不包含plsql执行块和plsql对象定义块）文本，以;符号进行SQL语句分割
+        :return:
+        """
+        text = """
+update user_account set created=sysdate where account_no=1; 
+create table user(
+    id int,
+    uname varchar(100),
+    age int
+);
+"""
+        sql1 = "update user_account set created=sysdate where account_no=1;"
+        sql2 = """create table user(
+    id int,
+    uname varchar(100),
+    age int
+);"""
+        lists = get_full_sqlitem_list(text, "db")
+        rows = [SqlItem(
+            id=0,
+            statement=sqlparse.format(
+                sql1, strip_comments=True, reindent=True, keyword_case="lower"
+            ),
+            stmt_type="SQL",
+            object_owner="",
+            object_type="",
+            object_name="",
+        ),SqlItem(
+            id=0,
+            statement=sqlparse.format(
+                sql2, strip_comments=True, reindent=True, keyword_case="lower"
+            ),
+            stmt_type="SQL",
+            object_owner="",
+            object_type="",
+            object_name="",
+        )]
+        self.assertIsInstance(lists[0], SqlItem)
+        self.assertIsInstance(lists[1], SqlItem)
+        self.assertEqual(lists[0].__dict__, rows[0].__dict__)
+        self.assertEqual(lists[1].__dict__, rows[1].__dict__)
 
 
 class TestSQLReview(TestCase):

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -192,9 +192,10 @@ END;
 /
 """
         lists = get_full_sqlitem_list(text, "db")
-        rows = [SqlItem(
-            id=0,
-            statement="""declare
+        rows = [
+		    SqlItem(
+                id=0,
+                statement="""declare
     v_rowcount integer;
 begin
     select count(1) into v_rowcount  from user_tables
@@ -212,21 +213,23 @@ begin
         ';
     end if;
 end;""",
-            stmt_type="PLSQL",
-            object_owner="db",
-            object_type="ANONYMOUS",
-            object_name="ANONYMOUS",
-        ),SqlItem(
-            id=0,
-            statement="""BEGIN
+                stmt_type="PLSQL",
+                object_owner="db",
+                object_type="ANONYMOUS",
+                object_name="ANONYMOUS",
+            ),
+            SqlItem(
+                id=0,
+                statement="""BEGIN
     insert into test2 values(1,'qq1');
     commit;
 END;""",
-            stmt_type="PLSQL",
-            object_owner="db",
-            object_type="ANONYMOUS",
-            object_name="ANONYMOUS",
-        )]
+                stmt_type="PLSQL",
+                object_owner="db",
+                object_type="ANONYMOUS",
+                object_name="ANONYMOUS",
+            ),
+        ]
         self.assertIsInstance(lists[0], SqlItem)
         self.assertIsInstance(lists[1], SqlItem)
         self.assertEqual(lists[0].__dict__, rows[0].__dict__)
@@ -257,33 +260,36 @@ end;
 /
 """
         lists = get_full_sqlitem_list(text, "db")
-        rows = [SqlItem(
-            id=0,
-            statement="""create or replace procedure INSERTUSER
+        rows = [
+            SqlItem(
+                id=0,
+                statement="""create or replace procedure INSERTUSER
 (id IN NUMBER,
 name IN VARCHAR2)
 is
 begin
     insert into user1 values(id,name);
 end;""",
-            stmt_type="PLSQL",
-            object_owner="db",
-            object_type="PROCEDURE",
-            object_name="INSERTUSER",
-        ),SqlItem(
-            id=0,
-            statement="""create or replace function annual_income(name1 varchar2)
+                stmt_type="PLSQL",
+                object_owner="db",
+                object_type="PROCEDURE",
+                object_name="INSERTUSER",
+            ),
+            SqlItem(
+                id=0,
+                statement="""create or replace function annual_income(name1 varchar2)
 return number is
 annual_salary number(7,2);
 begin
     select sal*12+nvl(comm,0) into annual_salary from emp where lower(ename)=lower(name1);
 return annual_salary;
 end;""",
-            stmt_type="PLSQL",
-            object_owner="db",
-            object_type="FUNCTION",
-            object_name="ANNUAL_INCOME",
-        )]
+                stmt_type="PLSQL",
+                object_owner="db",
+                object_type="FUNCTION",
+                object_name="ANNUAL_INCOME",
+            ),
+        ]
         self.assertIsInstance(lists[0], SqlItem)
         self.assertIsInstance(lists[1], SqlItem)
         self.assertEqual(lists[0].__dict__, rows[0].__dict__)
@@ -317,25 +323,28 @@ create table user(
     age int
 );"""
         lists = get_full_sqlitem_list(text, "db")
-        rows = [SqlItem(
-            id=0,
-            statement=sqlparse.format(
-                sql1, strip_comments=True, reindent=True, keyword_case="lower"
-            ),
-            stmt_type="SQL",
-            object_owner="",
-            object_type="",
-            object_name="",
-        ),SqlItem(
-            id=0,
-            statement=sqlparse.format(
-                sql2, strip_comments=True, reindent=True, keyword_case="lower"
-            ),
-            stmt_type="SQL",
-            object_owner="",
-            object_type="",
-            object_name="",
-        )]
+        rows = [
+            SqlItem(
+                id=0,
+                statement=sqlparse.format(
+                    sql1, strip_comments=True, reindent=True, keyword_case="lower"
+                ),
+                stmt_type="SQL",
+                object_owner="",
+                object_type="",
+                object_name="",
+			),
+            SqlItem(
+                id=0,
+                statement=sqlparse.format(
+                    sql2, strip_comments=True, reindent=True, keyword_case="lower"
+                ),
+                stmt_type="SQL",
+                object_owner="",
+                object_type="",
+                object_name="",
+			)
+		]
         self.assertIsInstance(lists[1], SqlItem)
         self.assertIsInstance(lists[2], SqlItem)
         self.assertEqual(lists[1].__dict__, rows[0].__dict__)
@@ -361,25 +370,28 @@ create table user(
     age int
 );"""
         lists = get_full_sqlitem_list(text, "db")
-        rows = [SqlItem(
-            id=0,
-            statement=sqlparse.format(
-                sql1, strip_comments=True, reindent=True, keyword_case="lower"
+        rows = [
+            SqlItem(
+                id=0,
+                statement=sqlparse.format(
+                    sql1, strip_comments=True, reindent=True, keyword_case="lower"
+                ),
+                stmt_type="SQL",
+                object_owner="",
+                object_type="",
+                object_name="",
             ),
-            stmt_type="SQL",
-            object_owner="",
-            object_type="",
-            object_name="",
-        ),SqlItem(
-            id=0,
-            statement=sqlparse.format(
-                sql2, strip_comments=True, reindent=True, keyword_case="lower"
-            ),
-            stmt_type="SQL",
-            object_owner="",
-            object_type="",
-            object_name="",
-        )]
+            SqlItem(
+                id=0,
+                statement=sqlparse.format(
+                    sql2, strip_comments=True, reindent=True, keyword_case="lower"
+                ),
+                stmt_type="SQL",
+                object_owner="",
+                object_type="",
+                object_name="",
+            )
+		]
         self.assertIsInstance(lists[0], SqlItem)
         self.assertIsInstance(lists[1], SqlItem)
         self.assertEqual(lists[0].__dict__, rows[0].__dict__)


### PR DESCRIPTION
自动识别Oracle SQL上线文本中的PLSQL程序块，原代码逻辑要求在PLSQL块开始和结尾处手动添加指定符号，很难满足产线实际上线要求，新功能在原来基础上实现自动识别和分割PLSQL代码块。