### PR TITLE
修复mongo会话管理报错

### DIFF
--- a/common/utils/extend_json_encoder.py
+++ b/common/utils/extend_json_encoder.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from bson.objectid import ObjectId
 from bson.timestamp import Timestamp
 from bson.decimal128 import Decimal128
+from bson.regex import Regex
 
 
 @singledispatch
@@ -73,6 +74,11 @@ def _(o):
 
 
 @convert.register(Decimal128)
+def _(o):
+    return str(o)
+
+
+@convert.register(Regex)
 def _(o):
     return str(o)
 

--- a/common/utils/extend_json_encoder.py
+++ b/common/utils/extend_json_encoder.py
@@ -9,6 +9,7 @@ from ipaddress import IPv4Address, IPv6Address
 from uuid import UUID
 from bson.objectid import ObjectId
 from bson.timestamp import Timestamp
+from bson.decimal128 import Decimal128
 
 
 @singledispatch
@@ -67,6 +68,11 @@ def _(o):
 
 
 @convert.register(Timestamp)
+def _(o):
+    return str(o)
+
+
+@convert.register(Decimal128)
 def _(o):
     return str(o)
 


### PR DESCRIPTION
对Decimal128和Regex类型做json序列化处理
```
TypeError: Object of type Decimal128 is not JSON serializable
TypeError: Object of type Regex is not JSON serializable
```