### PR TITLE
解决会话管理表格可能加载错误的问题

### DIFF
--- a/sql/templates/dbdiagnostic.html
+++ b/sql/templates/dbdiagnostic.html
@@ -95,9 +95,9 @@
     <script src="{% static 'bootstrap-table/js/tableExport.min.js' %}"></script>
     <script>
 
-        var processListColumns  = NaN;
-        var tablespaceListColumns = NaN;
-        var lockListColumns = NaN;
+        var processListColumns  = [];
+        var tablespaceListColumns = [];
+        var lockListColumns = [];
         var processListDetailFormatCallback = NaN;
         var lockListDetailFormatCallback = NaN;
 


### PR DESCRIPTION
 如果直接选择不支持表管理的数据库实例，比如mongo，由于没有定义列信息，表格会渲染异常
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/8842982/230120524-d560a349-e4d9-412c-bcea-28e51b94db83.png">
