### PR TITLE
解决平台报错：'NoneType' object is not subscriptable

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -604,7 +604,7 @@ class OracleEngine(EngineBase):
             sql = sql.rstrip(";")
             cursor.execute(sql)
             # 获取影响行数
-            cursor.execute(f"select CARDINALITY from SYS.PLAN_TABLE$ where id = 0")
+            cursor.execute(f"select CARDINALITY from (select CARDINALITY from PLAN_TABLE t where id = 0 order by t.timestamp desc) where rownum = 1")
             rows = cursor.fetchone()
             conn.rollback()
             if not rows:

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -604,7 +604,9 @@ class OracleEngine(EngineBase):
             sql = sql.rstrip(";")
             cursor.execute(sql)
             # 获取影响行数
-            cursor.execute(f"select CARDINALITY from (select CARDINALITY from PLAN_TABLE t where id = 0 order by t.timestamp desc) where rownum = 1")
+            cursor.execute(
+                f"select CARDINALITY from (select CARDINALITY from PLAN_TABLE t where id = 0 order by t.timestamp desc) where rownum = 1"
+            )
             rows = cursor.fetchone()
             conn.rollback()
             if not rows:

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -605,7 +605,7 @@ class OracleEngine(EngineBase):
             cursor.execute(sql)
             # 获取影响行数
             cursor.execute(
-                f"select CARDINALITY from (select CARDINALITY from PLAN_TABLE t where id = 0 order by t.timestamp desc) where rownum = 1"
+                "select CARDINALITY from (select CARDINALITY from PLAN_TABLE t where id = 0 order by t.timestamp desc) where rownum = 1"
             )
             rows = cursor.fetchone()
             conn.rollback()


### PR DESCRIPTION
fix：解决从SQL执行计划中获取影响行数，原代码直接从Oracle系统全局临时表SYS.PLAN_TABLE$获取数据在特定情况下（登录的Oracle用户生成了自己的PLAN_TABLE表）可能为空，从而导致Archery平台报错：'NoneType' object is not subscriptable的问题。