### PR TITLE
调整instance_account唯一索引

### DIFF
--- a/sql/models.py
+++ b/sql/models.py
@@ -616,7 +616,7 @@ class InstanceAccount(models.Model):
     class Meta:
         managed = True
         db_table = "instance_account"
-        unique_together = ("instance", "user", "host")
+        unique_together = ("instance", "user", "host", "db_name")
         verbose_name = "实例账号列表"
         verbose_name_plural = "实例账号列表"
 

--- a/src/init_sql/v1.9.2.sql
+++ b/src/init_sql/v1.9.2.sql
@@ -1,3 +1,10 @@
 -- https://github.com/hhyo/Archery/pull/2108
 alter table instance_account
     add db_name varchar(128) default '' not null comment '数据库名（mongodb）' after host;
+
+-- instance_account表调整唯一索引
+set @drop_sql=(select concat('alter table instance_account drop index ', constraint_name) from information_schema.table_constraints where table_schema=database() and table_name='instance_account' and constraint_type='UNIQUE');
+prepare stmt from @drop_sql;
+execute stmt;
+drop prepare stmt;
+alter table instance_account add unique index uidx_instanceid_user_host_dbname(`instance_id`, `user`, `host`, `db_name`);


### PR DESCRIPTION
#2108 新增的mongo账号管理添加的db_name字段没有加入唯一索引，导致同一mongo实例不同数据库录入相同名称账号时报错失败
```
MySQLdb._exceptions.IntegrityError: (1062, "Duplicate entry '11-hzpTW5c0st1JwqCNx3BFAA==-' for key 'instance_account_instance_id_user_host_514c1ac6_uniq'")
```