### PR TITLE
开启LDAP认证时，不显示其它认证按钮

### DIFF
--- a/common/templates/login.html
+++ b/common/templates/login.html
@@ -38,14 +38,13 @@
                     <a href="#" data-toggle="modal" data-target="#sign-up">注册用户</a>
                 </div>
             {% endif %}
-            {% if oidc_enabled %}
-                <div class="form-group">
-                    <a href="/oidc/authenticate/">以OIDC登录</a>
-                </div>
-            {% endif %}
             {% if dingding_enabled %}
                 <div class="form-group">
                     <a href="/dingding/authenticate/">以钉钉登录</a>
+                </div>
+            {% elif oidc_enabled %}
+                <div class="form-group">
+                    <a href="/oidc/authenticate/">以OIDC登录</a>
                 </div>
             {% endif %}
         </form>

--- a/sql/views.py
+++ b/sql/views.py
@@ -63,8 +63,10 @@ def login(request):
         "login.html",
         context={
             "sign_up_enabled": SysConfig().get("sign_up_enabled"),
-            "oidc_enabled": settings.ENABLE_OIDC,
-            "dingding_enabled": settings.ENABLE_DINGDING,
+            "oidc_enabled": settings.ENABLE_OIDC if not settings.ENABLE_LDAP else False,
+            "dingding_enabled": settings.ENABLE_DINGDING
+            if not settings.ENABLE_LDAP
+            else False,
         },
     )
 


### PR DESCRIPTION
确保开启LDAP认证时，不显示其它认证按钮，如果开启了LDAP，也开启了钉钉或OIDC认证，会显示其中一个认证按钮，此pr修复，麻烦帮忙merge一下