### PR TITLE
添加对AWS Secrets Manager支持及支持Redis SSL连接

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+.venv/
 *.swp
 *.lock
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ archery/settings.py.github
 archery/settings.py.dev
 archery/settings_dev.py
 sql/migrations/
+static/
+nohup.out
+supervisord.pid
 venv
 env
 sonar-project.properties

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ alibabacloud_dysmsapi20170525==2.0.9
 tencentcloud-sdk-python==3.0.656
 mozilla-django-oidc==3.0.0
 django-auth-dingding==0.0.2
+boto3==1.26.103

--- a/sql/engines/__init__.py
+++ b/sql/engines/__init__.py
@@ -73,6 +73,16 @@ class EngineBase:
             self.remote_port = instance.port
             self.remote_user = instance.user
             self.remote_password = instance.password
+            
+        if not instance.awsSecretId == None and instance.awsSecretId.strip():
+            client = boto3.client('secretsmanager')
+            response = client.get_secret_value(
+                SecretId=instance.awsSecretId
+            )
+            secret = json.loads(response['SecretString'])
+            self.remote_user = secret["username"]
+            self.remote_password = secret["password"]
+
         return (
             self.remote_host,
             self.remote_port,

--- a/sql/engines/__init__.py
+++ b/sql/engines/__init__.py
@@ -4,6 +4,7 @@ from sql.utils.ssh_tunnel import SSHConnection
 import boto3
 import simplejson as json
 
+
 class EngineBase:
     """enginebase 只定义了init函数和若干方法的名字, 具体实现用mysql.py pg.py等实现"""
 

--- a/sql/engines/__init__.py
+++ b/sql/engines/__init__.py
@@ -23,7 +23,7 @@ class EngineBase:
             self.mode = instance.mode
             self.awsSecretId = instance.awsSecretId
                     
-            if self.awsSecretId.strip():
+            if not self.awsSecretId == None and self.awsSecretId.strip():
                 client = boto3.client('secretsmanager')
                 response = client.get_secret_value(
                     SecretId=self.awsSecretId

--- a/sql/engines/__init__.py
+++ b/sql/engines/__init__.py
@@ -22,6 +22,7 @@ class EngineBase:
             self.db_name = instance.db_name
             self.mode = instance.mode
             self.awsSecretId = instance.awsSecretId
+            self.is_ssl = instance.is_ssl
                     
             if not self.awsSecretId == None and self.awsSecretId.strip():
                 client = boto3.client('secretsmanager')

--- a/sql/engines/__init__.py
+++ b/sql/engines/__init__.py
@@ -23,16 +23,14 @@ class EngineBase:
             self.mode = instance.mode
             self.awsSecretId = instance.awsSecretId
             self.is_ssl = instance.is_ssl
-                    
+
             if not self.awsSecretId == None and self.awsSecretId.strip():
-                client = boto3.client('secretsmanager')
-                response = client.get_secret_value(
-                    SecretId=self.awsSecretId
-                )
-                secret = json.loads(response['SecretString'])
+                client = boto3.client("secretsmanager")
+                response = client.get_secret_value(SecretId=instance.awsSecretId)
+                secret = json.loads(response["SecretString"])
                 self.user = secret["username"]
                 self.password = secret["password"]
-            
+
             # 判断如果配置了隧道则连接隧道，只测试了MySQL
             if self.instance.tunnel:
                 self.ssh = SSHConnection(
@@ -74,13 +72,11 @@ class EngineBase:
             self.remote_port = instance.port
             self.remote_user = instance.user
             self.remote_password = instance.password
-            
+
         if not instance.awsSecretId == None and instance.awsSecretId.strip():
-            client = boto3.client('secretsmanager')
-            response = client.get_secret_value(
-                SecretId=instance.awsSecretId
-            )
-            secret = json.loads(response['SecretString'])
+            client = boto3.client("secretsmanager")
+            response = client.get_secret_value(SecretId=instance.awsSecretId)
+            secret = json.loads(response["SecretString"])
             self.remote_user = secret["username"]
             self.remote_password = secret["password"]
 

--- a/sql/engines/goinception.py
+++ b/sql/engines/goinception.py
@@ -182,6 +182,7 @@ class GoInceptionEngine(EngineBase):
                           use `{db_name}`;
                           {sql.rstrip(';')};
                           inception_magic_commit;"""
+        logger.info(f"执行goInception语法树打印语句：{sql}")
         print_info = self.query(db_name=db_name, sql=sql).to_dict()[1]
         if print_info.get("errmsg"):
             raise RuntimeError(print_info.get("errmsg"))

--- a/sql/engines/goinception.py
+++ b/sql/engines/goinception.py
@@ -182,7 +182,6 @@ class GoInceptionEngine(EngineBase):
                           use `{db_name}`;
                           {sql.rstrip(';')};
                           inception_magic_commit;"""
-        logger.info(f"执行goInception语法树打印语句：{sql}")
         print_info = self.query(db_name=db_name, sql=sql).to_dict()[1]
         if print_info.get("errmsg"):
             raise RuntimeError(print_info.get("errmsg"))

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -33,6 +33,7 @@ class RedisEngine(EngineBase):
                 encoding_errors="ignore",
                 decode_responses=True,
                 socket_connect_timeout=10,
+                ssl=self.is_ssl,
             )
         else:
             return redis.Redis(
@@ -43,6 +44,7 @@ class RedisEngine(EngineBase):
                 encoding_errors="ignore",
                 decode_responses=True,
                 socket_connect_timeout=10,
+                ssl=self.is_ssl,
             )
 
     @property

--- a/sql/models.py
+++ b/sql/models.py
@@ -195,6 +195,7 @@ class Instance(models.Model):
     password = fields.EncryptedCharField(
         verbose_name="密码", max_length=300, default="", blank=True
     )
+    is_ssl = models.BooleanField("是否启用SSL", default=False)
     db_name = models.CharField("数据库", max_length=64, default="", blank=True)
     charset = models.CharField("字符集", max_length=20, default="", blank=True)
     service_name = models.CharField(

--- a/sql/models.py
+++ b/sql/models.py
@@ -202,7 +202,9 @@ class Instance(models.Model):
         "Oracle service name", max_length=50, null=True, blank=True
     )
     sid = models.CharField("Oracle sid", max_length=50, null=True, blank=True)
-    awsSecretId = models.CharField("AWS Secret Id", max_length=50, null=True, blank=True)
+    awsSecretId = models.CharField(
+        "AWS Secret Id", max_length=50, null=True, blank=True
+    )
     resource_group = models.ManyToManyField(
         ResourceGroup, verbose_name="资源组", blank=True
     )

--- a/sql/models.py
+++ b/sql/models.py
@@ -201,6 +201,7 @@ class Instance(models.Model):
         "Oracle service name", max_length=50, null=True, blank=True
     )
     sid = models.CharField("Oracle sid", max_length=50, null=True, blank=True)
+    awsSecretId = models.CharField("AWS Secret Id", max_length=50, null=True, blank=True)
     resource_group = models.ManyToManyField(
         ResourceGroup, verbose_name="资源组", blank=True
     )

--- a/src/init_sql/v1.9.3.sql
+++ b/src/init_sql/v1.9.3.sql
@@ -1,1 +1,2 @@
-ALTER TABLE sql_instance ADD awsSecretId varchar(100) NULL;
+ALTER TABLE sql_instance ADD awsSecretId varchar(100) DEFAULT '' COMMENT 'AWS SecretId';
+ALTER TABLE sql_instance ADD is_ssl tinyint(1) DEFAULT 0  COMMENT '是否启用SSL';

--- a/src/init_sql/v1.9.3.sql
+++ b/src/init_sql/v1.9.3.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sql_instance ADD awsSecretId varchar(100) NULL;


### PR DESCRIPTION
1. 支持从AWS Secrets Manager服务中获取username及password. 以支持RDB数据库的密码自动轮换机制。
    sql_instance表中添加awsSecretId字段以保存aws secret id. 如果有填写username及password以从AWS获取中为准。

2. 添加对Redis SSL连接支持。 
    sql_instance表中添加is_ssl字段，表明是否使用ssl进行连接。目前只支持redis
