### PR TITLE
修复mongo执行sql语句超过4000工单失败的问题

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -360,6 +360,7 @@ class MongoEngine(EngineBase):
                     _re_msg.append(_line)
 
                 msg = "\n".join(_re_msg)
+                msg = msg.replace("true\n","")
             except Exception as e:
                 logger.warning(f"mongo语句执行报错，语句：{sql}，{e}错误信息{traceback.format_exc()}")
             finally:

--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -360,7 +360,7 @@ class MongoEngine(EngineBase):
                     _re_msg.append(_line)
 
                 msg = "\n".join(_re_msg)
-                msg = msg.replace("true\n","")
+                msg = msg.replace("true\n", "")
             except Exception as e:
                 logger.warning(f"mongo语句执行报错，语句：{sql}，{e}错误信息{traceback.format_exc()}")
             finally:


### PR DESCRIPTION
sql语句超过4000时，使用load 方式执行语句，末尾返回true 导致json 格式化失败，工单执行成功，但是工单执行状态返回失败，