### PR TITLE
DDL语句不支持Bind variables

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -590,10 +590,11 @@ class OracleEngine(EngineBase):
             conn = self.get_connection()
             cursor = conn.cursor()
             if db_name:
-                cursor.execute(
-                    f" ALTER SESSION SET CURRENT_SCHEMA = :db_name ",
-                    {"db_name": db_name},
-                )
+                cursor.execute(f' ALTER SESSION SET CURRENT_SCHEMA = "{db_name}" ')
+                # cursor.execute(
+                #     f" ALTER SESSION SET CURRENT_SCHEMA = :db_name ",
+                #     {"db_name": db_name},
+                # )
             if re.match(r"^explain", sql, re.I):
                 sql = sql
             else:
@@ -669,10 +670,11 @@ class OracleEngine(EngineBase):
             conn = self.get_connection()
             cursor = conn.cursor()
             if db_name:
-                cursor.execute(
-                    f" ALTER SESSION SET CURRENT_SCHEMA = :db_name ",
-                    {"db_name": db_name},
-                )
+                cursor.execute(f' ALTER SESSION SET CURRENT_SCHEMA = "{db_name}" ')
+                # cursor.execute(
+                #     f" ALTER SESSION SET CURRENT_SCHEMA = :db_name ",
+                #     {"db_name": db_name},
+                # )
             sql = sql.rstrip(";")
             # 支持oralce查询SQL执行计划语句
             if re.match(r"^explain", sql, re.I):


### PR DESCRIPTION
cx_Oracle官方说明：Bind variables also cannot be used in DDL statements, such as CREATE TABLE or ALTER statements.
恢复至1.9.1的写法
fix #2252