### PR TITLE
fix #2252

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -864,7 +864,7 @@ class OracleEngine(EngineBase):
                                 else:
                                     object_name_list.add(object_name)
                                     if (
-                                        result_set["rows"] is not None
+                                        result_set["rows"]
                                         and result_set["rows"] > 1000
                                     ):
                                         result = ReviewResult(
@@ -896,7 +896,7 @@ class OracleEngine(EngineBase):
                                         )
                             else:
                                 if (
-                                    result_set["rows"] is not None
+                                    result_set["rows"]
                                     and result_set["rows"] > 1000
                                 ):
                                     result = ReviewResult(

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -864,7 +864,7 @@ class OracleEngine(EngineBase):
                                 else:
                                     object_name_list.add(object_name)
                                     if (
-                                        result_set.get("rows",None)
+                                        result_set.get("rows", None)
                                         and result_set["rows"] > 1000
                                     ):
                                         result = ReviewResult(
@@ -896,7 +896,7 @@ class OracleEngine(EngineBase):
                                         )
                             else:
                                 if (
-                                    result_set.get("rows",None)
+                                    result_set.get("rows", None)
                                     and result_set["rows"] > 1000
                                 ):
                                     result = ReviewResult(

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -590,7 +590,7 @@ class OracleEngine(EngineBase):
             conn = self.get_connection()
             cursor = conn.cursor()
             if db_name:
-                conn.current_schema=db_name
+                conn.current_schema = db_name
             if re.match(r"^explain", sql, re.I):
                 sql = sql
             else:
@@ -666,7 +666,7 @@ class OracleEngine(EngineBase):
             conn = self.get_connection()
             cursor = conn.cursor()
             if db_name:
-                conn.current_schema=db_name
+                conn.current_schema = db_name
             sql = sql.rstrip(";")
             # 支持oralce查询SQL执行计划语句
             if re.match(r"^explain", sql, re.I):

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -1089,6 +1089,7 @@ class OracleEngine(EngineBase):
         try:
             conn = self.get_connection()
             cursor = conn.cursor()
+            conn.current_schema =  workflow.db_name
             # 获取执行工单时间，用于备份SQL的日志挖掘起始时间
             cursor.execute(f"alter session set nls_date_format='yyyy-mm-dd hh24:mi:ss'")
             cursor.execute(f"select sysdate from dual")

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -590,10 +590,7 @@ class OracleEngine(EngineBase):
             conn = self.get_connection()
             cursor = conn.cursor()
             if db_name:
-                cursor.execute(
-                    f" ALTER SESSION SET CURRENT_SCHEMA = :db_name ",
-                    {"db_name": db_name},
-                )
+                conn.conn.current_schema=db_name
             if re.match(r"^explain", sql, re.I):
                 sql = sql
             else:
@@ -669,10 +666,7 @@ class OracleEngine(EngineBase):
             conn = self.get_connection()
             cursor = conn.cursor()
             if db_name:
-                cursor.execute(
-                    f" ALTER SESSION SET CURRENT_SCHEMA = :db_name ",
-                    {"db_name": db_name},
-                )
+                conn.current_schema=db_name
             sql = sql.rstrip(";")
             # 支持oralce查询SQL执行计划语句
             if re.match(r"^explain", sql, re.I):

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -590,7 +590,7 @@ class OracleEngine(EngineBase):
             conn = self.get_connection()
             cursor = conn.cursor()
             if db_name:
-                conn.conn.current_schema=db_name
+                conn.current_schema=db_name
             if re.match(r"^explain", sql, re.I):
                 sql = sql
             else:

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -1095,7 +1095,7 @@ class OracleEngine(EngineBase):
         try:
             conn = self.get_connection()
             cursor = conn.cursor()
-            conn.current_schema =  workflow.db_name
+            conn.current_schema = workflow.db_name
             # 获取执行工单时间，用于备份SQL的日志挖掘起始时间
             cursor.execute(f"alter session set nls_date_format='yyyy-mm-dd hh24:mi:ss'")
             cursor.execute(f"select sysdate from dual")

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -864,7 +864,7 @@ class OracleEngine(EngineBase):
                                 else:
                                     object_name_list.add(object_name)
                                     if (
-                                        result_set["rows"]
+                                        result_set.get("rows",None)
                                         and result_set["rows"] > 1000
                                     ):
                                         result = ReviewResult(
@@ -896,7 +896,7 @@ class OracleEngine(EngineBase):
                                         )
                             else:
                                 if (
-                                    result_set["rows"]
+                                    result_set.get("rows",None)
                                     and result_set["rows"] > 1000
                                 ):
                                     result = ReviewResult(

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -863,7 +863,10 @@ class OracleEngine(EngineBase):
                                     )
                                 else:
                                     object_name_list.add(object_name)
-                                    if result_set["rows"] is not None and result_set["rows"] > 1000:
+                                    if (
+                                        result_set["rows"] is not None
+                                        and result_set["rows"] > 1000
+                                    ):
                                         result = ReviewResult(
                                             id=line,
                                             errlevel=1,
@@ -892,7 +895,10 @@ class OracleEngine(EngineBase):
                                             execute_time=0,
                                         )
                             else:
-                                if result_set["rows"] is not None and result_set["rows"] > 1000:
+                                if (
+                                    result_set["rows"] is not None
+                                    and result_set["rows"] > 1000
+                                ):
                                     result = ReviewResult(
                                         id=line,
                                         errlevel=1,

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -863,7 +863,7 @@ class OracleEngine(EngineBase):
                                     )
                                 else:
                                     object_name_list.add(object_name)
-                                    if result_set["rows"] > 1000:
+                                    if result_set["rows"] is not None and result_set["rows"] > 1000:
                                         result = ReviewResult(
                                             id=line,
                                             errlevel=1,
@@ -892,7 +892,7 @@ class OracleEngine(EngineBase):
                                             execute_time=0,
                                         )
                             else:
-                                if result_set["rows"] > 1000:
+                                if result_set["rows"] is not None and result_set["rows"] > 1000:
                                     result = ReviewResult(
                                         id=line,
                                         errlevel=1,

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -368,6 +368,7 @@ def get_exec_sqlitem_list(reviewResult, db_name):
     :return:
     """
     list = []
+
     
     for item in reviewResult:
         list.append(

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -368,7 +368,6 @@ def get_exec_sqlitem_list(reviewResult, db_name):
     :return:
     """
     list = []
-
     
     for item in reviewResult:
         list.append(

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -368,8 +368,7 @@ def get_exec_sqlitem_list(reviewResult, db_name):
     :return:
     """
     list = []
-    list.append(SqlItem(statement=f' ALTER SESSION SET CURRENT_SCHEMA = "{db_name}" '))
-
+    
     for item in reviewResult:
         list.append(
             SqlItem(

--- a/sql/utils/sql_utils.py
+++ b/sql/utils/sql_utils.py
@@ -368,7 +368,7 @@ def get_exec_sqlitem_list(reviewResult, db_name):
     :return:
     """
     list = []
-    
+
     for item in reviewResult:
         list.append(
             SqlItem(


### PR DESCRIPTION
fix #2252 使用conn.current_schema=db_name 替换ALTER SESSION SET CURRENT_SCHEMA = :db_name 。
fix #2262 由于sql检测中可能存在影响行数位none的情况，针对性修复