### PR TITLE
修复钉钉认证登录失败

### DIFF
--- a/common/auth.py
+++ b/common/auth.py
@@ -11,6 +11,7 @@ from django.contrib.auth.models import Group
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 
+from archery import settings
 from common.config import SysConfig
 from common.utils.ding_api import get_ding_user_id
 from sql.models import Users, ResourceGroup, TwoFactorAuthConfig
@@ -201,5 +202,11 @@ def sign_up(request):
 
 # 退出登录
 def sign_out(request):
+    user = request.user
     logout(request)
+    # 如果开启了钉钉认证，重定向到钉钉退出登录页面
+    if user.ding_user_id and settings.ENABLE_DINGDING:
+        return HttpResponseRedirect(
+            redirect_to="https://login.dingtalk.com/oauth2/logout"
+        )
     return HttpResponseRedirect(reverse("sql:login"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,5 +38,5 @@ django-environ==0.8.1
 alibabacloud_dysmsapi20170525==2.0.9
 tencentcloud-sdk-python==3.0.656
 mozilla-django-oidc==3.0.0
-django-auth-dingding==0.0.2
+django-auth-dingding==0.0.3
 cassandra-driver


### PR DESCRIPTION
1. 修复钉钉认证登录失败，原因调用钉钉接口缺少授权参数，导致登录无权限，已更新了django_dingding_auth版本到0.0.3修复
2. 添加了钉钉认证方式的退出登录逻辑，跳转到钉钉的logout页面，清除钉钉认证成功的浏览器相关cookie。