### PR TITLE
fix: 手动更新 redis 依赖至 4.1.0

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN cd /opt \
     && yum -y install nginx \
     && source /opt/venv4archery/bin/activate \
     && pip3 install -r /opt/archery/requirements.txt \
-    && pip3 install redis==4.1.0 \
+    && pip3 install "redis>=4.1.0" \
     && cp -f /opt/archery/src/docker/nginx.conf /etc/nginx/ \
     && cp -f /opt/archery/src/docker/supervisord.conf /etc/ \
     && mv /opt/sqladvisor /opt/archery/src/plugins/ \

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN cd /opt \
     && yum -y install nginx \
     && source /opt/venv4archery/bin/activate \
     && pip3 install -r /opt/archery/requirements.txt \
+    && pip3 install redis==4.1.0 \
     && cp -f /opt/archery/src/docker/nginx.conf /etc/nginx/ \
     && cp -f /opt/archery/src/docker/supervisord.conf /etc/ \
     && mv /opt/sqladvisor /opt/archery/src/plugins/ \


### PR DESCRIPTION
dockerFile 文件手动更新redis依赖, 解决安装依赖时冲突,可解决 redis 集群连接出现无法连接实例, module 'redis' has no attribute 'cluster'
fix #1997 