### PR TITLE
添加审批流按权限组独自发送钉钉通知的功能

### DIFF
--- a/sql/admin.py
+++ b/sql/admin.py
@@ -29,6 +29,7 @@ from .models import (
     Tunnel,
     AuditEntry,
     TwoFactorAuthConfig,
+    GroupNotification,
 )
 
 from sql.form import TunnelForm, InstanceForm
@@ -528,3 +529,10 @@ class AuditEntryAdmin(admin.ModelAdmin):
         "action_time",
     )
     list_filter = ("user_id", "user_name", "user_display", "action", "extra_info")
+
+
+# 权限组通知
+@admin.register(GroupNotification)
+class GroupNotificationAdmin(admin.ModelAdmin):
+    list_display = ("group_id", "ding_webhook")
+    search_fields = ["authgroup__name", "ding_webhook"]

--- a/sql/models.py
+++ b/sql/models.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import AbstractUser
 from mirage import fields
 from django.utils.translation import gettext as _
 from mirage.crypto import Crypto
+from django.contrib.auth.models import Group
 
 
 class ResourceGroup(models.Model):
@@ -1203,3 +1204,17 @@ class AuditEntry(models.Model):
         return "{0} - {1} - {2} - {3} - {4}".format(
             self.user_id, self.user_name, self.extra_info, self.action, self.action_time
         )
+
+class GroupNotification(models.Model):
+    """
+    权限组通知
+    """
+    id = models.AutoField("ID", primary_key=True)
+    group = models.ForeignKey(Group, unique=True, on_delete=models.CASCADE)
+    ding_webhook = models.CharField("钉钉webhook地址", max_length=255, blank=True)
+
+    class Meta:
+        managed = True
+        db_table = "auth_group_notification"
+        verbose_name = u"权限组通知"
+        verbose_name_plural = u"权限组通知"

--- a/sql/models.py
+++ b/sql/models.py
@@ -1208,10 +1208,12 @@ class AuditEntry(models.Model):
             self.user_id, self.user_name, self.extra_info, self.action, self.action_time
         )
 
+
 class GroupNotification(models.Model):
     """
     权限组通知
     """
+
     id = models.AutoField("ID", primary_key=True)
     group = models.ForeignKey(Group, unique=True, on_delete=models.CASCADE)
     ding_webhook = models.CharField("钉钉webhook地址", max_length=255, blank=True)
@@ -1219,5 +1221,5 @@ class GroupNotification(models.Model):
     class Meta:
         managed = True
         db_table = "auth_group_notification"
-        verbose_name = u"权限组通知"
-        verbose_name_plural = u"权限组通知"
+        verbose_name = "权限组通知"
+        verbose_name_plural = "权限组通知"

--- a/sql/notify.py
+++ b/sql/notify.py
@@ -136,8 +136,13 @@ def notify_for_audit(audit_id, **kwargs):
         group_id=audit_detail.group_id
     ).qywx_webhook
     # 获取当前审批和审批流程
-    workflow_auditors, current_workflow_auditors, group_webhook = Audit.review_info_with_notification(
-        audit_detail.workflow_id, audit_detail.workflow_type)
+    (
+        workflow_auditors,
+        current_workflow_auditors,
+        group_webhook,
+    ) = Audit.review_info_with_notification(
+        audit_detail.workflow_id, audit_detail.workflow_type
+    )
 
     # 准备消息内容
     if workflow_type == WorkflowDict.workflow_type["query"]:

--- a/sql/notify.py
+++ b/sql/notify.py
@@ -63,6 +63,7 @@ def __send(msg_title, msg_content, msg_to, msg_cc=None, **kwargs):
     dingding_webhook = kwargs.get("dingding_webhook")
     feishu_webhook = kwargs.get("feishu_webhook")
     qywx_webhook = kwargs.get("qywx_webhook")
+    group_webhook = kwargs.get("group_webhook")
     msg_to_email = [user.email for user in msg_to if user.email]
     msg_cc_email = [user.email for user in msg_cc if user.email]
     msg_to_ding_user = [
@@ -95,6 +96,8 @@ def __send(msg_title, msg_content, msg_to, msg_cc=None, **kwargs):
         msg_sender.send_feishu_user(msg_title, msg_content, open_id, user_mail)
     if sys_config.get("qywx_webhook") and qywx_webhook:
         msg_sender.send_qywx_webhook(qywx_webhook, msg_title + "\n" + msg_content)
+    if group_webhook:
+        msg_sender.send_ding(group_webhook, msg_title + "\n" + msg_content)
 
 
 def notify_for_audit(audit_id, **kwargs):
@@ -133,9 +136,8 @@ def notify_for_audit(audit_id, **kwargs):
         group_id=audit_detail.group_id
     ).qywx_webhook
     # 获取当前审批和审批流程
-    workflow_auditors, current_workflow_auditors = Audit.review_info(
-        audit_detail.workflow_id, audit_detail.workflow_type
-    )
+    workflow_auditors, current_workflow_auditors, group_webhook = Audit.review_info_with_notification(
+        audit_detail.workflow_id, audit_detail.workflow_type)
 
     # 准备消息内容
     if workflow_type == WorkflowDict.workflow_type["query"]:
@@ -269,6 +271,7 @@ def notify_for_audit(audit_id, **kwargs):
         feishu_webhook=feishu_webhook,
         dingding_webhook=dingding_webhook,
         qywx_webhook=qywx_webhook,
+        group_webhook=group_webhook,
     )
 
 

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -479,10 +479,10 @@ class Audit(object):
                 )
             except Exception:
                 audit_auth_group = audit_info.audit_auth_groups
-        if audit_info.current_audit == "-1":
-            current_audit_auth_group = None
-            current_audit_auth_group_notification = ""
-        else:
+
+        current_audit_auth_group = None
+        current_audit_auth_group_notification = ""
+        if audit_info.current_audit != "-1":
             try:
                 current_audit_auth_group = Group.objects.get(
                     id=audit_info.current_audit

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -15,6 +15,7 @@ from sql.models import (
     QueryPrivilegesApply,
     Users,
     ArchiveConfig,
+    GroupNotification,
 )
 from common.config import SysConfig
 
@@ -438,6 +439,29 @@ class Audit(object):
             except Exception:
                 current_audit_auth_group = audit_info.current_audit
         return audit_auth_group, current_audit_auth_group
+
+    # 获取当前工单审批流程,当前审核组和审核组dingding通知
+    @staticmethod
+    def review_info_with_notification(workflow_id, workflow_type):
+        audit_info = WorkflowAudit.objects.get(workflow_id=workflow_id, workflow_type=workflow_type)
+        if audit_info.audit_auth_groups == '':
+            audit_auth_group = '无需审批'
+        else:
+            try:
+                audit_auth_group = '->'.join([Group.objects.get(id=auth_group_id).name for auth_group_id in
+                                              audit_info.audit_auth_groups.split(',')])
+            except Exception:
+                audit_auth_group = audit_info.audit_auth_groups
+        if audit_info.current_audit == '-1':
+            current_audit_auth_group = None
+            current_audit_auth_group_notification = ''
+        else:
+            try:
+                current_audit_auth_group = Group.objects.get(id=audit_info.current_audit).name
+                current_audit_auth_group_notification = GroupNotification.objects.get(group=audit_info.current_audit).ding_webhook
+            except Exception:
+                current_audit_auth_group = audit_info.current_audit
+        return audit_auth_group, current_audit_auth_group, current_audit_auth_group_notification
 
     # 新增工单日志
     @staticmethod

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -464,25 +464,39 @@ class Audit(object):
     # 获取当前工单审批流程,当前审核组和审核组dingding通知
     @staticmethod
     def review_info_with_notification(workflow_id, workflow_type):
-        audit_info = WorkflowAudit.objects.get(workflow_id=workflow_id, workflow_type=workflow_type)
-        if audit_info.audit_auth_groups == '':
-            audit_auth_group = '无需审批'
+        audit_info = WorkflowAudit.objects.get(
+            workflow_id=workflow_id, workflow_type=workflow_type
+        )
+        if audit_info.audit_auth_groups == "":
+            audit_auth_group = "无需审批"
         else:
             try:
-                audit_auth_group = '->'.join([Group.objects.get(id=auth_group_id).name for auth_group_id in
-                                              audit_info.audit_auth_groups.split(',')])
+                audit_auth_group = "->".join(
+                    [
+                        Group.objects.get(id=auth_group_id).name
+                        for auth_group_id in audit_info.audit_auth_groups.split(",")
+                    ]
+                )
             except Exception:
                 audit_auth_group = audit_info.audit_auth_groups
-        if audit_info.current_audit == '-1':
+        if audit_info.current_audit == "-1":
             current_audit_auth_group = None
-            current_audit_auth_group_notification = ''
+            current_audit_auth_group_notification = ""
         else:
             try:
-                current_audit_auth_group = Group.objects.get(id=audit_info.current_audit).name
-                current_audit_auth_group_notification = GroupNotification.objects.get(group=audit_info.current_audit).ding_webhook
+                current_audit_auth_group = Group.objects.get(
+                    id=audit_info.current_audit
+                ).name
+                current_audit_auth_group_notification = GroupNotification.objects.get(
+                    group=audit_info.current_audit
+                ).ding_webhook
             except Exception:
                 current_audit_auth_group = audit_info.current_audit
-        return audit_auth_group, current_audit_auth_group, current_audit_auth_group_notification
+        return (
+            audit_auth_group,
+            current_audit_auth_group,
+            current_audit_auth_group_notification,
+        )
 
     # 新增工单日志
     @staticmethod


### PR DESCRIPTION
工单审批的流程通知是通知到固定的一个目标。 实际上审批流可能会涉及不同的部门、小组。 如提交工单后，先由开发组leader审批， 然后再由系统运维组审批。 两个审批环节分属不同小组，单个审批环节的通知能支持通知到不同小组会更加友好