### PR TITLE
add generic webhook

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,8 @@
 [run]
-include =
-    common*
-    sql*
-    sql_api*
+source =
+    .
 omit =
     src*
     downloads*
     sql/migrations/*
+    venv*

--- a/.env.list
+++ b/.env.list
@@ -13,6 +13,6 @@ AUTH_LDAP_USER_ATTR_MAP=username=cn,display=displayname,email=email
 CSRF_TRUSTED_ORIGINS=http://127.0.0.1:9123
 
 # https://django-q.readthedocs.io/en/latest/configure.html#
-Q_CLUISTER_WORKERS=4
-Q_CLUISTER_TIMEOUT=60
+Q_CLUSTER_WORKERS=4
+Q_CLUSTER_TIMEOUT=60
 Q_CLUISTER_SYNC=false

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         python manage.py makemigrations
         python manage.py makemigrations sql
-        coverage run --source='.' manage.py test -v 3 --keepdb
+        coverage run manage.py test -v 3 --keepdb
         coverage xml
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -78,8 +78,7 @@ jobs:
       run: |
         mysql -h127.0.0.1 -uroot -e "CREATE DATABASE archery CHARSET UTF8MB4;"
         mysql -h127.0.0.1 -uroot -e "DROP DATABASE IF EXISTS test_archery;CREATE DATABASE test_archery CHARSET UTF8MB4;"
-        mysql -h127.0.0.1 -uroot test_archery<src/init_sql/mysql_slow_query_review.sql
-      
+
     - name: Run Tests
       run: |
         python manage.py makemigrations

--- a/archery/settings.py
+++ b/archery/settings.py
@@ -54,6 +54,18 @@ env = environ.Env(
             "cassandra",
         ],
     ),
+    ENABLED_NOTIFIERS=(
+        list,
+        [
+            "sql.notify:DingdingWebhookNotifier",
+            "sql.notify:DingdingPersonNotifier",
+            "sql.notify:FeishuWebhookNotifier",
+            "sql.notify:FeishuPersonNotifier",
+            "sql.notify:QywxWebhookNotifier",
+            "sql.notify:MailNotifier",
+            "sql.notify:GenericWebhookNotifier",
+        ]
+    )
 )
 
 # SECURITY WARNING: keep the secret key used in production secret!
@@ -87,15 +99,7 @@ AVAILABLE_ENGINES = {
     "odps": {"path": "sql.engines.odps:ODPSEngine"},
 }
 
-ENABLED_NOTIFIERS = (
-    "sql.notify:DingdingWebhookNotifier",
-    "sql.notify:DingdingPersonNotifier",
-    "sql.notify:FeishuWebhookNotifier",
-    "sql.notify:FeishuPersonNotifier",
-    "sql.notify:QywxWebhookNotifier",
-    "sql.notify:MailNotifier",
-    "sql.notify:GenericWebhookNotifier",
-)
+ENABLED_NOTIFIERS = env("ENABLED_NOTIFIERS")
 
 ENABLED_ENGINES = env("ENABLED_ENGINES")
 

--- a/archery/settings.py
+++ b/archery/settings.py
@@ -86,6 +86,10 @@ AVAILABLE_ENGINES = {
     "phoenix": {"path": "sql.engines.phoenix:PhoenixEngine"},
     "odps": {"path": "sql.engines.odps:ODPSEngine"},
 }
+ENABLED_NOTIFIERS = (
+    "sql.notify:FeishuWebhookNotifier",
+    "sql.notify:GenericWebhookNotifier"
+)
 ENABLED_ENGINES = env("ENABLED_ENGINES")
 
 # Application definition

--- a/archery/settings.py
+++ b/archery/settings.py
@@ -86,7 +86,17 @@ AVAILABLE_ENGINES = {
     "phoenix": {"path": "sql.engines.phoenix:PhoenixEngine"},
     "odps": {"path": "sql.engines.odps:ODPSEngine"},
 }
-ENABLED_NOTIFIERS = ("sql.notify:FeishuWebhookNotifier",)
+
+ENABLED_NOTIFIERS = (
+    "sql.notify:DingdingWebhookNotifier",
+    "sql.notify:DingdingPersonNotifier",
+    "sql.notify:FeishuWebhookNotifier",
+    "sql.notify:FeishuPersonNotifier",
+    "sql.notify:QywxWebhookNotifier",
+    "sql.notify:MailNotifier",
+    "sql.notify:GenericWebhookNotifier",
+)
+
 ENABLED_ENGINES = env("ENABLED_ENGINES")
 
 # Application definition

--- a/archery/settings.py
+++ b/archery/settings.py
@@ -88,7 +88,6 @@ AVAILABLE_ENGINES = {
 }
 ENABLED_NOTIFIERS = (
     "sql.notify:FeishuWebhookNotifier",
-    "sql.notify:GenericWebhookNotifier"
 )
 ENABLED_ENGINES = env("ENABLED_ENGINES")
 

--- a/archery/settings.py
+++ b/archery/settings.py
@@ -64,8 +64,8 @@ env = environ.Env(
             "sql.notify:QywxWebhookNotifier",
             "sql.notify:MailNotifier",
             "sql.notify:GenericWebhookNotifier",
-        ]
-    )
+        ],
+    ),
 )
 
 # SECURITY WARNING: keep the secret key used in production secret!

--- a/archery/settings.py
+++ b/archery/settings.py
@@ -86,9 +86,7 @@ AVAILABLE_ENGINES = {
     "phoenix": {"path": "sql.engines.phoenix:PhoenixEngine"},
     "odps": {"path": "sql.engines.odps:ODPSEngine"},
 }
-ENABLED_NOTIFIERS = (
-    "sql.notify:FeishuWebhookNotifier",
-)
+ENABLED_NOTIFIERS = ("sql.notify:FeishuWebhookNotifier",)
 ENABLED_ENGINES = env("ENABLED_ENGINES")
 
 # Application definition

--- a/common/config.py
+++ b/common/config.py
@@ -15,7 +15,6 @@ logger = logging.getLogger("default")
 class SysConfig(object):
     def __init__(self):
         self.sys_config = {}
-        self.get_all_config()
 
     def get_all_config(self):
         try:
@@ -34,10 +33,28 @@ class SysConfig(object):
             self.sys_config = {}
 
     def get(self, key, default_value=None):
-        value = self.sys_config.get(key, default_value)
+        value = self.sys_config.get(key)
+        if value:
+            return value
+        # 尝试去数据库里取
+        config_entry = Config.objects.filter(item=key).last()
+        if config_entry:
+            # 清洗成 python 的 bool
+            value = self.filter_bool(config_entry.value)
         # 是字符串的话, 如果是空, 或者全是空格, 返回默认值
         if isinstance(value, str) and value.strip() == "":
             return default_value
+        if value is not None:
+            self.sys_config[key] = value
+            return value
+        return default_value
+
+    @staticmethod
+    def filter_bool(value: str):
+        if value.lower() == "true":
+            return True
+        if value.lower() == "false":
+            return False
         return value
 
     def set(self, key, value):

--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -736,6 +736,17 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="form-group">
+                                <label for="generic_webhook_url"
+                                       class="col-sm-4 control-label">通用Webhook地址</label>
+                                <div class="col-sm-5">
+                                    <input class="form-control"
+                                           id="generic_webhook_url"
+                                           key="generic_webhook_url"
+                                           value="{{ config.generic_webhook_url }}"
+                                           placeholder="通用 webhook 地址, 每个工单的每个状态转变均会调用" />
+                                </div>
+                            </div>
                             <h5 style="color: darkgrey"><b>短信服务</b></h5>
                             <hr/>
                             <div class="form-group">

--- a/common/tests.py
+++ b/common/tests.py
@@ -509,15 +509,6 @@ class ChartTest(TestCase):
         expected_rows = ((self.u2.display, 3), (self.u1.display, 2))
         self.assertEqual(result["rows"], expected_rows)
 
-    def testDashboard(self):
-        """Dashboard测试"""
-        # TODO 这部分测试并没有遵循单元测试, 而是某种集成测试, 直接从响应到结果, 并且只检查状态码
-        # TODO 需要具体查看pyecharst有没有被调用, 以及调用的参数
-        c = Client()
-        c.force_login(self.superuser1)
-        r = c.get("/dashboard/")
-        self.assertEqual(r.status_code, 200)
-
 
 class AuthTest(TestCase):
     def setUp(self):

--- a/sql/archiver.py
+++ b/sql/archiver.py
@@ -202,7 +202,9 @@ def archive_apply(request):
             )
             archive_id = archive_info.id
             # 调用工作流插入审核信息
-            audit_result, audit_detail = Audit.add(WorkflowDict.workflow_type["archive"], archive_id)
+            audit_result, audit_detail = Audit.add(
+                WorkflowDict.workflow_type["archive"], archive_id
+            )
     except Exception as msg:
         logger.error(traceback.format_exc())
         result["status"] = 1

--- a/sql/archiver.py
+++ b/sql/archiver.py
@@ -272,6 +272,7 @@ def archive_audit(request):
         return render(request, "error.html", context)
     else:
         # 消息通知
+        workflow_audit.refresh_from_db()
         async_task(
             notify_for_audit,
             workflow_audit=workflow_audit,

--- a/sql/notify.py
+++ b/sql/notify.py
@@ -114,7 +114,7 @@ class GenericWebhookNotifier(Notifier):
         }
 
     def send(self):
-        url = self.sys_config.get("generic_webhook")
+        url = self.sys_config.get(self.sys_config_key)
         requests.post(url, json=self.request_data)
 
 

--- a/sql/notify.py
+++ b/sql/notify.py
@@ -17,12 +17,11 @@ from sql.models import (
     Users,
     SqlWorkflow,
     ResourceGroup,
-    ArchiveConfig, WorkflowAudit,
+    ArchiveConfig, WorkflowAudit, WorkflowAuditDetail,
 )
 from sql_api.serializers import (
-    UserSerializer,
     WorkflowSerializer,
-    AuditWorkflowSerializer,
+    WorkflowAuditListSerializer,
     QueryPrivilegesApplySerializer,
     ArchiveConfigSerializer
 )
@@ -71,231 +70,12 @@ def __notify_cnf_status():
         return True
 
 
-def __send(msg_title, msg_content, msg_to, msg_cc=None, **kwargs):
-    """
-    按照通知配置发送通知消息
-    :param msg_title: 通知标题
-    :param msg_content: 通知内容
-    :param msg_to:  通知人user list
-    :return:
-    """
-    sys_config = SysConfig()
-    msg_sender = MsgSender()
-    msg_cc = msg_cc if msg_cc else []
-    dingding_webhook = kwargs.get("dingding_webhook")
-    feishu_webhook = kwargs.get("feishu_webhook")
-    qywx_webhook = kwargs.get("qywx_webhook")
-    msg_to_email = [user.email for user in msg_to if user.email]
-    msg_cc_email = [user.email for user in msg_cc if user.email]
-    msg_to_ding_user = [
-        user.ding_user_id for user in chain(msg_to, msg_cc) if user.ding_user_id
-    ]
-    msg_to_wx_user = [
-        user.wx_user_id if user.wx_user_id else user.username
-        for user in chain(msg_to, msg_cc)
-    ]
-    logger.info(f"{msg_to_email}{msg_cc_email}{msg_to_wx_user}{chain(msg_to, msg_cc)}")
-    if sys_config.get("mail"):
-        msg_sender.send_email(
-            msg_title, msg_content, msg_to_email, list_cc_addr=msg_cc_email
-        )
-    if sys_config.get("ding") and dingding_webhook:
-        msg_sender.send_ding(dingding_webhook, msg_title + "\n" + msg_content)
-    if sys_config.get("ding_to_person"):
-        msg_sender.send_ding2user(msg_to_ding_user, msg_title + "\n" + msg_content)
-    if sys_config.get("wx"):
-        msg_sender.send_wx2user(msg_title + "\n" + msg_content, msg_to_wx_user)
-    if sys_config.get("feishu_webhook") and feishu_webhook:
-        msg_sender.send_feishu_webhook(feishu_webhook, msg_title, msg_content)
-    if sys_config.get("feishu"):
-        open_id = [
-            user.feishu_open_id for user in chain(msg_to, msg_cc) if user.feishu_open_id
-        ]
-        user_mail = [
-            user.email for user in chain(msg_to, msg_cc) if not user.feishu_open_id
-        ]
-        msg_sender.send_feishu_user(msg_title, msg_content, open_id, user_mail)
-    if sys_config.get("qywx_webhook") and qywx_webhook:
-        msg_sender.send_qywx_webhook(qywx_webhook, msg_title + "\n" + msg_content)
-
-
-def notify_for_audit(audit_id, **kwargs):
-    """
-    工作流消息通知，不包含工单执行结束的通知
-    :param audit_id:
-    :param kwargs:
-    :return:
-    """
-    # 判断是否开启消息通知，未开启直接返回
-    if not __notify_cnf_status():
-        return None
-    sys_config = SysConfig()
-
-    # 获取审核信息
-    audit_data = AuditWorkflowSerializer(Audit).data
-    audit_detail = Audit.detail(audit_id=audit_id)
-    audit_id = audit_detail.audit_id
-    workflow_audit_remark = kwargs.get("audit_remark", "")
-    base_url = sys_config.get("archery_base_url", "http://127.0.0.1:8000").rstrip("/")
-    workflow_url = "{base_url}/workflow/{audit_id}".format(
-        base_url=base_url, audit_id=audit_detail.audit_id
-    )
-    workflow_id = audit_detail.workflow_id
-    workflow_type = audit_detail.workflow_type
-    status = audit_detail.current_status
-    workflow_title = audit_detail.workflow_title
-    workflow_from = audit_detail.create_user_display
-    group_name = audit_detail.group_name
-    dingding_webhook = ResourceGroup.objects.get(
-        group_id=audit_detail.group_id
-    ).ding_webhook
-    feishu_webhook = ResourceGroup.objects.get(
-        group_id=audit_detail.group_id
-    ).feishu_webhook
-    qywx_webhook = ResourceGroup.objects.get(
-        group_id=audit_detail.group_id
-    ).qywx_webhook
-    # 获取当前审批和审批流程
-    workflow_auditors, current_workflow_auditors = Audit.review_info(
-        audit_detail.workflow_id, audit_detail.workflow_type
-    )
-
-    # 准备消息内容
-    if workflow_type == WorkflowDict.workflow_type["query"]:
-        workflow_type_display = WorkflowDict.workflow_type["query_display"]
-        workflow_detail = QueryPrivilegesApply.objects.get(apply_id=workflow_id)
-        workflow_dict = QueryPrivilegesApplySerializer(workflow_detail).data
-        instance = workflow_detail.instance.instance_name
-        db_name = " "
-        if workflow_detail.priv_type == 1:
-            workflow_content = """数据库清单：{}\n授权截止时间：{}\n结果集：{}\n""".format(
-                workflow_detail.db_list,
-                datetime.datetime.strftime(
-                    workflow_detail.valid_date, "%Y-%m-%d %H:%M:%S"
-                ),
-                workflow_detail.limit_num,
-            )
-        elif workflow_detail.priv_type == 2:
-            db_name = workflow_detail.db_list
-            workflow_content = """数据库：{}\n表清单：{}\n授权截止时间：{}\n结果集：{}\n""".format(
-                workflow_detail.db_list,
-                workflow_detail.table_list,
-                datetime.datetime.strftime(
-                    workflow_detail.valid_date, "%Y-%m-%d %H:%M:%S"
-                ),
-                workflow_detail.limit_num,
-            )
-        else:
-            workflow_content = ""
-    elif workflow_type == WorkflowDict.workflow_type["sqlreview"]:
-        workflow_type_display = WorkflowDict.workflow_type["sqlreview_display"]
-        workflow_detail = SqlWorkflow.objects.get(pk=workflow_id)
-        workflow_dict = WorkflowSerializer(workflow_detail).data
-        instance = workflow_detail.instance.instance_name
-        db_name = workflow_detail.db_name
-        workflow_content = re.sub(
-            "[\r\n\f]{2,}",
-            "\n",
-            workflow_detail.sqlworkflowcontent.sql_content[0:500].replace("\r", ""),
-        )
-    elif workflow_type == WorkflowDict.workflow_type["archive"]:
-        workflow_type_display = WorkflowDict.workflow_type["archive_display"]
-        workflow_detail = ArchiveConfig.objects.get(pk=workflow_id)
-        workflow_dict = ArchiveConfigSerializer(workflow_detail).data
-        instance = workflow_detail.src_instance.instance_name
-        db_name = workflow_detail.src_db_name
-        workflow_content = """归档表：{}\n归档模式：{}\n归档条件：{}\n""".format(
-            workflow_detail.src_table_name,
-            workflow_detail.mode,
-            workflow_detail.condition,
-        )
-    else:
-        raise Exception("工单类型不正确")
-
-    # 准备消息格式
-    if status == WorkflowDict.workflow_status["audit_wait"]:  # 申请阶段
-        msg_title = "[{}]新的工单申请#{}".format(workflow_type_display, audit_id)
-        # 接收人，发送给该资源组内对应权限组所有的用户
-        auth_group_names = Group.objects.get(id=audit_detail.current_audit).name
-        msg_to = auth_group_users([auth_group_names], audit_detail.group_id)
-        msg_cc = Users.objects.filter(username__in=kwargs.get("cc_users", []))
-        # 消息内容
-        msg_content = """发起时间：{}\n发起人：{}\n组：{}\n目标实例：{}\n数据库：{}\n审批流程：{}\n当前审批：{}\n工单名称：{}\n工单地址：{}\n工单详情预览：{}\n""".format(
-            workflow_detail.create_time.strftime("%Y-%m-%d %H:%M:%S"),
-            workflow_from,
-            group_name,
-            instance,
-            db_name,
-            workflow_auditors,
-            current_workflow_auditors,
-            workflow_title,
-            workflow_url,
-            workflow_content,
-        )
-    elif status == WorkflowDict.workflow_status["audit_success"]:  # 审核通过
-        msg_title = "[{}]工单审核通过#{}".format(workflow_type_display, audit_id)
-        # 接收人，仅发送给申请人
-        msg_to = [Users.objects.get(username=audit_detail.create_user)]
-        msg_cc = Users.objects.filter(username__in=kwargs.get("cc_users", []))
-        # 消息内容
-        msg_content = """发起时间：{}\n发起人：{}\n组：{}\n目标实例：{}\n数据库：{}\n审批流程：{}\n工单名称：{}\n工单地址：{}\n工单详情预览：{}\n""".format(
-            workflow_detail.create_time.strftime("%Y-%m-%d %H:%M:%S"),
-            workflow_from,
-            group_name,
-            instance,
-            db_name,
-            workflow_auditors,
-            workflow_title,
-            workflow_url,
-            workflow_content,
-        )
-    elif status == WorkflowDict.workflow_status["audit_reject"]:  # 审核驳回
-        msg_title = "[{}]工单被驳回#{}".format(workflow_type_display, audit_id)
-        # 接收人，仅发送给申请人
-        msg_to = [Users.objects.get(username=audit_detail.create_user)]
-        msg_cc = Users.objects.filter(username__in=kwargs.get("cc_users", []))
-        # 消息内容
-        msg_content = """发起时间：{}\n目标实例：{}\n数据库：{}\n工单名称：{}\n工单地址：{}\n驳回原因：{}\n提醒：此工单被审核不通过，请按照驳回原因进行修改！""".format(
-            workflow_detail.create_time.strftime("%Y-%m-%d %H:%M:%S"),
-            instance,
-            db_name,
-            workflow_title,
-            workflow_url,
-            re.sub("[\r\n\f]{2,}", "\n", workflow_audit_remark),
-        )
-    elif status == WorkflowDict.workflow_status["audit_abort"]:  # 审核取消，通知所有审核人
-        msg_title = "[{}]提交人主动终止工单#{}".format(workflow_type_display, audit_id)
-        # 接收人，发送给该资源组内对应权限组所有的用户
-        auth_group_names = [
-            Group.objects.get(id=auth_group_id).name
-            for auth_group_id in audit_detail.audit_auth_groups.split(",")
-        ]
-        msg_to = auth_group_users(auth_group_names, audit_detail.group_id)
-        msg_cc = Users.objects.filter(username__in=kwargs.get("cc_users", []))
-        # 消息内容
-        msg_content = """发起时间：{}\n发起人：{}\n组：{}\n目标实例：{}\n数据库：{}\n工单名称：{}\n工单地址：{}\n终止原因：{}""".format(
-            workflow_detail.create_time.strftime("%Y-%m-%d %H:%M:%S"),
-            workflow_from,
-            group_name,
-            instance,
-            db_name,
-            workflow_title,
-            workflow_url,
-            re.sub("[\r\n\f]{2,}", "\n", workflow_audit_remark),
-        )
-    else:
-        raise Exception("工单状态不正确")
-    logger.info(f"通知Debug{msg_to}{msg_cc}")
-    # 发送通知
-    __send(
-        msg_title,
-        msg_content,
-        msg_to,
-        msg_cc,
-        feishu_webhook=feishu_webhook,
-        dingding_webhook=dingding_webhook,
-        qywx_webhook=qywx_webhook,
-    )
+@dataclass
+class My2SqlResult:
+    submitter: str
+    success: bool
+    file_path: str = ""
+    error: str = ""
 
 
 def notify_for_my2sql(task):
@@ -304,38 +84,43 @@ def notify_for_my2sql(task):
     :param task:
     :return:
     """
-    # 判断是否开启消息通知，未开启直接返回
-    if not __notify_cnf_status():
-        return None
     if task.success:
-        msg_title = "[Archery 通知]My2SQL执行结束"
-        msg_content = f"解析的SQL文件在{task.result[1]}目录下，请前往查看"
+        result = My2SqlResult(
+            success=True,
+            submitter=task.kwargs["user"],
+            file_path=task.result[1]
+        )
     else:
-        msg_title = "[Archery 通知]My2SQL执行失败"
-        msg_content = f"{task.result}"
+        result = My2SqlResult(
+            success=False,
+            submitter=task.kwargs["user"],
+            error=task.result
+        )
     # 发送
-    msg_to = [task.kwargs["user"]]
-    __send(msg_title, msg_content, msg_to)
+    sys_config = SysConfig()
+    auto_notify(workflow=result, sys_config=sys_config, event_type=EventType.M2SQL)
 
 
 class Notifier:
     name = "base"
 
     def __init__(self,
-                 workflow: Union[SqlWorkflow, ArchiveConfig, QueryPrivilegesApply],
+                 workflow: Union[SqlWorkflow, ArchiveConfig, QueryPrivilegesApply, My2SqlResult],
                  sys_config: SysConfig,
                  audit: WorkflowAudit = None,
+                 audit_detail: WorkflowAuditDetail = None,
                  event_type: EventType = EventType.AUDIT):
         self.workflow = workflow
         self.audit = audit
+        self.audit_detail = audit_detail
         self.event_type = event_type
         self.sys_config = sys_config
 
     def render(self):
-        raise NotImplemented
+        raise NotImplementedError
 
     def send(self):
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class GenericWebhookNotifier(Notifier):
@@ -355,7 +140,7 @@ class GenericWebhookNotifier(Notifier):
         else:
             raise ValueError(f"workflow type `{type(self.workflow)}` not supported yet")
 
-        audit_dict = AuditWorkflowSerializer(self.audit).data
+        audit_dict = WorkflowAuditListSerializer(self.audit).data
         self.request_data = {
             "audit": audit_dict,
             "workflow": workflow_dict,
@@ -379,6 +164,155 @@ class LegacyRender(Notifier):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.messages = []
+
+    def render_audit(self):
+        # 获取审核信息
+        audit_id = self.audit.audit_id
+        base_url = self.sys_config.get("archery_base_url", "http://127.0.0.1:8000").rstrip("/")
+        workflow_url = "{base_url}/workflow/{audit_id}".format(
+            base_url=base_url, audit_id=self.audit.audit_id
+        )
+        workflow_id = self.audit.workflow_id
+        workflow_type = self.audit.workflow_type
+        status = self.audit.current_status
+        workflow_title = self.audit.workflow_title
+        workflow_from = self.audit.create_user_display
+        group_name = self.audit.group_name
+        # 获取当前审批和审批流程
+        workflow_auditors, current_workflow_auditors = Audit.review_info(
+            self.audit.workflow_id, self.audit.workflow_type
+        )
+        # 准备消息内容
+        if workflow_type == WorkflowDict.workflow_type["query"]:
+            workflow_type_display = WorkflowDict.workflow_type["query_display"]
+            workflow_detail = QueryPrivilegesApply.objects.get(apply_id=workflow_id)
+            instance = workflow_detail.instance.instance_name
+            db_name = " "
+            if workflow_detail.priv_type == 1:
+                workflow_content = """数据库清单：{}\n授权截止时间：{}\n结果集：{}\n""".format(
+                    workflow_detail.db_list,
+                    datetime.datetime.strftime(
+                        workflow_detail.valid_date, "%Y-%m-%d %H:%M:%S"
+                    ),
+                    workflow_detail.limit_num,
+                )
+            elif workflow_detail.priv_type == 2:
+                db_name = workflow_detail.db_list
+                workflow_content = """数据库：{}\n表清单：{}\n授权截止时间：{}\n结果集：{}\n""".format(
+                    workflow_detail.db_list,
+                    workflow_detail.table_list,
+                    datetime.datetime.strftime(
+                        workflow_detail.valid_date, "%Y-%m-%d %H:%M:%S"
+                    ),
+                    workflow_detail.limit_num,
+                )
+            else:
+                workflow_content = ""
+        elif workflow_type == WorkflowDict.workflow_type["sqlreview"]:
+            workflow_type_display = WorkflowDict.workflow_type["sqlreview_display"]
+            workflow_detail = SqlWorkflow.objects.get(pk=workflow_id)
+            instance = workflow_detail.instance.instance_name
+            db_name = workflow_detail.db_name
+            workflow_content = re.sub(
+                "[\r\n\f]{2,}",
+                "\n",
+                workflow_detail.sqlworkflowcontent.sql_content[0:500].replace("\r", ""),
+            )
+        elif workflow_type == WorkflowDict.workflow_type["archive"]:
+            workflow_type_display = WorkflowDict.workflow_type["archive_display"]
+            workflow_detail = ArchiveConfig.objects.get(pk=workflow_id)
+            instance = workflow_detail.src_instance.instance_name
+            db_name = workflow_detail.src_db_name
+            workflow_content = """归档表：{}\n归档模式：{}\n归档条件：{}\n""".format(
+                workflow_detail.src_table_name,
+                workflow_detail.mode,
+                workflow_detail.condition,
+            )
+        else:
+            raise Exception("工单类型不正确")
+        # 准备消息格式
+        if status == WorkflowDict.workflow_status["audit_wait"]:  # 申请阶段
+            msg_title = "[{}]新的工单申请#{}".format(workflow_type_display, audit_id)
+            # 接收人，发送给该资源组内对应权限组所有的用户
+            auth_group_names = Group.objects.get(id=self.audit.current_audit).name
+            msg_to = auth_group_users([auth_group_names], self.audit.group_id)
+            # 消息内容
+            msg_content = """发起时间：{}
+发起人：{}
+组：{}
+目标实例：{}
+数据库：{}
+审批流程：{}
+当前审批：{}
+工单名称：{}
+工单地址：{}
+工单详情预览：{}""".format(
+                workflow_detail.create_time.strftime("%Y-%m-%d %H:%M:%S"),
+                workflow_from,
+                group_name,
+                instance,
+                db_name,
+                workflow_auditors,
+                current_workflow_auditors,
+                workflow_title,
+                workflow_url,
+                workflow_content,
+            )
+        elif status == WorkflowDict.workflow_status["audit_success"]:  # 审核通过
+            msg_title = "[{}]工单审核通过#{}".format(workflow_type_display, audit_id)
+            # 接收人，仅发送给申请人
+            msg_to = [Users.objects.get(username=self.audit.create_user)]
+            # 消息内容
+            msg_content = """发起时间：{}\n发起人：{}\n组：{}\n目标实例：{}\n数据库：{}\n审批流程：{}\n工单名称：{}\n工单地址：{}\n工单详情预览：{}\n""".format(
+                workflow_detail.create_time.strftime("%Y-%m-%d %H:%M:%S"),
+                workflow_from,
+                group_name,
+                instance,
+                db_name,
+                workflow_auditors,
+                workflow_title,
+                workflow_url,
+                workflow_content,
+            )
+        elif status == WorkflowDict.workflow_status["audit_reject"]:  # 审核驳回
+            msg_title = "[{}]工单被驳回#{}".format(workflow_type_display, audit_id)
+            # 接收人，仅发送给申请人
+            msg_to = [Users.objects.get(username=self.audit.create_user)]
+            # 消息内容
+            msg_content = """发起时间：{}\n目标实例：{}\n数据库：{}\n工单名称：{}\n工单地址：{}\n驳回原因：{}\n提醒：此工单被审核不通过，请按照驳回原因进行修改！""".format(
+                workflow_detail.create_time.strftime("%Y-%m-%d %H:%M:%S"),
+                instance,
+                db_name,
+                workflow_title,
+                workflow_url,
+                re.sub("[\r\n\f]{2,}", "\n", self.audit_detail.remark),
+            )
+        elif status == WorkflowDict.workflow_status["audit_abort"]:  # 审核取消，通知所有审核人
+            msg_title = "[{}]提交人主动终止工单#{}".format(workflow_type_display, audit_id)
+            # 接收人，发送给该资源组内对应权限组所有的用户
+            auth_group_names = [
+                Group.objects.get(id=auth_group_id).name
+                for auth_group_id in self.audit.audit_auth_groups.split(",")
+            ]
+            msg_to = auth_group_users(auth_group_names, self.audit.group_id)
+            # 消息内容
+            msg_content = """发起时间：{}\n发起人：{}\n组：{}\n目标实例：{}\n数据库：{}\n工单名称：{}\n工单地址：{}\n终止原因：{}""".format(
+                workflow_detail.create_time.strftime("%Y-%m-%d %H:%M:%S"),
+                workflow_from,
+                group_name,
+                instance,
+                db_name,
+                workflow_title,
+                workflow_url,
+                re.sub("[\r\n\f]{2,}", "\n", self.audit_detail.remark),
+            )
+        else:
+            raise Exception("工单状态不正确")
+        logger.info(f"通知Debug{msg_to}")
+        self.messages.append(LegacyMessage(
+            msg_title, msg_content, msg_to
+        ))
 
     def render_execute(self):
         base_url = self.sys_config.get("archery_base_url", "http://127.0.0.1:8000").rstrip("/")
@@ -428,10 +362,30 @@ class LegacyRender(Notifier):
                     msg_title, msg_content, msg_to
                 ))
 
+    def render_m2sql(self):
+        submitter_in_db = Users.objects.get(username=self.workflow.submitter)
+        if self.workflow.success:
+            title = "[Archery 通知]My2SQL执行结束"
+            content = f"解析的SQL文件在{self.workflow.file_path}目录下，请前往查看"
+        else:
+            title = "[Archery 通知]My2SQL执行失败"
+            content = self.workflow.error
+        self.messages = [
+            LegacyMessage(
+                msg_to=[submitter_in_db],
+                msg_title=title,
+                msg_content=content,
+            )
+        ]
+
     def render(self):
         """渲染消息, 存储到 self.messages"""
         if self.event_type == EventType.EXECUTE:
             self.render_execute()
+        if self.event_type == EventType.AUDIT:
+            self.render_audit()
+        if self.event_type == EventType.M2SQL:
+            self.render_m2sql()
 
 
 class DingdingWebhookNotifier(LegacyRender):
@@ -441,9 +395,23 @@ class DingdingWebhookNotifier(LegacyRender):
         dingding_webhook = ResourceGroup.objects.get(
             group_id=self.audit.group_id
         ).ding_webhook
+        if not dingding_webhook:
+            return
         msg_sender = MsgSender()
         for m in self.messages:
             msg_sender.send_ding(dingding_webhook, f"{m.msg_title}\n{m.msg_content}")
+
+
+class DingdingPersonNotifier(LegacyRender):
+    name = "ding_to_person"
+
+    def send(self):
+        msg_sender = MsgSender()
+        for m in self.messages:
+            ding_user_id_list = [
+                user.ding_user_id for user in chain(m.msg_to, m.msg_cc) if user.ding_user_id
+            ]
+            msg_sender.send_ding2user(ding_user_id_list, f"{m.msg_title}\n{m.msg_content}")
 
 
 class FeishuWebhookNotifier(LegacyRender):
@@ -451,19 +419,87 @@ class FeishuWebhookNotifier(LegacyRender):
 
     def send(self):
         feishu_webhook = ResourceGroup.objects.get(group_id=self.audit.group_id).feishu_webhook
+        if not feishu_webhook:
+            return
         msg_sender = MsgSender()
         for m in self.messages:
             msg_sender.send_feishu_webhook(feishu_webhook, m.msg_title, m.msg_content)
 
 
-def auto_notify(workflow: Union[SqlWorkflow, ArchiveConfig, QueryPrivilegesApply],
-                sys_config: SysConfig,
+class FeishuPersonNotifier(LegacyRender):
+    name = "feishu_to_person"
+
+    def send(self):
+        msg_sender = MsgSender()
+        for m in self.messages:
+            open_id = [
+                user.feishu_open_id for user in chain(m.msg_to, m.msg_cc) if user.feishu_open_id
+            ]
+            user_mail = [
+                user.email for user in chain(m.msg_to, m.msg_cc) if not user.feishu_open_id
+            ]
+            msg_sender.send_feishu_user(m.msg_title, m.msg_content, open_id, user_mail)
+
+
+class QywxWebhookNotifier(LegacyRender):
+    name = "qywx_webhook"
+
+    def send(self):
+        qywx_webhook = ResourceGroup.objects.get(
+            group_id=self.audit.group_id
+        ).qywx_webhook
+        if not qywx_webhook:
+            return
+        msg_sender = MsgSender()
+        for m in self.messages:
+            msg_sender.send_qywx_webhook(qywx_webhook, f"{m.msg_title}\n{m.msg_content}")
+
+
+def auto_notify(sys_config: SysConfig,
+                workflow: Union[SqlWorkflow, ArchiveConfig, QueryPrivilegesApply, My2SqlResult] = None,
                 audit: WorkflowAudit = None,
+                audit_detail: WorkflowAuditDetail = None,
                 event_type: EventType = EventType.AUDIT):
+    """
+    加载所有的 notifier, 调用 notifier 的 render 和 send 方法
+    内部方法, 有数据库查询, 为了方便测试, 请勿使用 async_task 调用, 防止 patch 后调用失败
+    """
+    if not workflow and event_type == EventType.AUDIT:
+        if audit.workflow_type == 1:
+            workflow = QueryPrivilegesApply.objects.get(apply_id=audit.workflow_id)
+        if audit.workflow_type == 2:
+            workflow = SqlWorkflow.objects.get(id=audit.workflow_id)
     for notifier in settings.ENABLED_NOTIFIERS:
         file, _class = notifier.split(":")
         notify_module = importlib.import_module(file)
         notifier = getattr(notify_module, _class)
-        notifier = notifier(workflow=workflow, audit=audit, event_type=event_type, sys_config=sys_config)
+        notifier = notifier(workflow=workflow, audit=audit, audit_detail=audit_detail,
+                            event_type=event_type, sys_config=sys_config)
         notifier.render()
         notifier.send()
+
+
+def notify_for_execute(workflow: SqlWorkflow, sys_config: SysConfig = None):
+    if not sys_config:
+        sys_config = SysConfig()
+    auto_notify(
+        workflow=workflow,
+        sys_config=sys_config
+    )
+
+
+def notify_for_audit(workflow_audit: WorkflowAudit, workflow_audit_detail: WorkflowAuditDetail = None):
+    """
+    工作流消息通知适配器, 供 async_task 调用, 方便后续的 mock
+    直接传 model 对象, 注意函数内部不要做数据库相关的查询, 以免测试不好mock
+    :param workflow_audit:
+    :param workflow_audit_detail:
+    :return:
+    """
+    sys_config = SysConfig()
+    auto_notify(
+        workflow=None,
+        audit=workflow_audit,
+        audit_detail=workflow_audit_detail,
+        sys_config=sys_config
+    )

--- a/sql/query_privileges.py
+++ b/sql/query_privileges.py
@@ -301,12 +301,12 @@ def query_priv_apply(request):
     else:
         result = audit_result
         # 消息通知
-        audit_id = Audit.detail_by_workflow_id(
+        workflow_audit = Audit.detail_by_workflow_id(
             workflow_id=apply_id, workflow_type=WorkflowDict.workflow_type["query"]
-        ).audit_id
+        )
         async_task(
             notify_for_audit,
-            audit_id=audit_id,
+            workflow_audit=workflow_audit,
             timeout=60,
             task_name=f"query-priv-apply-{apply_id}",
         )
@@ -444,7 +444,7 @@ def query_priv_audit(request):
             ).audit_id
 
             # 调用工作流接口审核
-            audit_result, _ = Audit.audit(
+            audit_result, workflow_audit_detail = Audit.audit(
                 audit_id, audit_status, user.username, audit_remark
             )
 
@@ -462,10 +462,11 @@ def query_priv_audit(request):
         return render(request, "error.html", context)
     else:
         # 消息通知
+        audit_detail.refresh_from_db()
         async_task(
             notify_for_audit,
-            audit_id=audit_id,
-            audit_remark=audit_remark,
+            workflow_audit=audit_detail,
+            workflow_audit_detail=workflow_audit_detail,
             timeout=60,
             task_name=f"query-priv-audit-{apply_id}",
         )

--- a/sql/query_privileges.py
+++ b/sql/query_privileges.py
@@ -444,7 +444,7 @@ def query_priv_audit(request):
             ).audit_id
 
             # 调用工作流接口审核
-            audit_result = Audit.audit(
+            audit_result, _ = Audit.audit(
                 audit_id, audit_status, user.username, audit_remark
             )
 

--- a/sql/sql_workflow.py
+++ b/sql/sql_workflow.py
@@ -18,7 +18,7 @@ from common.utils.const import WorkflowDict
 from common.utils.extend_json_encoder import ExtendJSONEncoder
 from sql.engines import get_engine
 from sql.engines.models import ReviewResult, ReviewSet
-from sql.notify import notify_for_audit, EventType, auto_notify
+from sql.notify import notify_for_audit, EventType, notify_for_execute
 from sql.utils.resource_group import user_groups
 from sql.utils.sql_review import (
     can_timingtask,
@@ -248,11 +248,12 @@ def passed(request):
     try:
         with transaction.atomic():
             # 调用工作流接口审核
-            audit_id = Audit.detail_by_workflow_id(
+            workflow_audit = Audit.detail_by_workflow_id(
                 workflow_id=workflow_id,
                 workflow_type=WorkflowDict.workflow_type["sqlreview"],
-            ).audit_id
-            audit_result = Audit.audit(
+            )
+            audit_id = workflow_audit.audit_id
+            audit_result, audit_detail = Audit.audit(
                 audit_id,
                 WorkflowDict.workflow_status["audit_success"],
                 user.username,
@@ -283,8 +284,8 @@ def passed(request):
         if is_notified:
             async_task(
                 notify_for_audit,
-                audit_id=audit_id,
-                audit_remark=audit_remark,
+                workflow_audit=workflow_audit,
+                workflow_audit_detail=audit_detail,
                 timeout=60,
                 task_name=f"sqlreview-pass-{workflow_id}",
             )
@@ -375,9 +376,7 @@ def execute(request):
             else True
         )
         if is_notified:
-            auto_notify(workflow=SqlWorkflow.objects.get(id=workflow_id),
-                        sys_config=sys_config,
-                        event_type=EventType.EXECUTE)
+            notify_for_execute(workflow=SqlWorkflow.objects.get(id=workflow_id))
     return HttpResponseRedirect(reverse("sql:detail", args=(workflow_id,)))
 
 

--- a/sql/test_notify.py
+++ b/sql/test_notify.py
@@ -190,7 +190,7 @@ class TestNotify(TestCase):
                 "run_date_end": None,
                 "finish_time": None,
                 "is_manual": 0,
-                "instance": 2,
+                "instance": self.ins.id,
                 "create_time": self.wf.create_time.isoformat(),
             },
         )

--- a/sql/test_notify.py
+++ b/sql/test_notify.py
@@ -439,12 +439,15 @@ class TestNotify(TestCase):
                 "run_date_end": None,
                 "finish_time": None,
                 "is_manual": 0,
-                "instance": ANY,
+                "instance": self.ins.id,
                 "create_time": self.wf.create_time.isoformat(),
             },
         )
         self.assertEqual(
             notifier.request_data["workflow_content"]["sql_content"], "some_sql"
+        )
+        self.assertEqual(
+            notifier.request_data["instance"]["instance_name"], self.ins.instance_name
         )
 
 
@@ -496,7 +499,7 @@ class TestNotifySend(TestCase):
     def tearDown(self):
         self.patcher.stop()
 
-    def generate_notifier(self, module) -> object:
+    def generate_notifier(self, module) -> Notifier:
         return module(workflow=None, audit=self.audit_wf, sys_config=self.sys_config)
 
     def test_ding_webhook_send(self):

--- a/sql/test_notify.py
+++ b/sql/test_notify.py
@@ -1,7 +1,6 @@
-import importlib
+import json
 from datetime import datetime, timedelta
 from unittest.mock import patch, Mock, ANY
-from typing import ClassVar
 
 from django.contrib.auth.models import Group
 from django.contrib.auth import get_user_model
@@ -406,6 +405,7 @@ class TestNotify(TestCase):
         )
         notifier.render()
         self.assertIsNotNone(notifier.request_data)
+        print(json.dumps(notifier.request_data))
         self.assertDictEqual(
             notifier.request_data["audit"],
             {
@@ -421,7 +421,7 @@ class TestNotify(TestCase):
             },
         )
         self.assertDictEqual(
-            notifier.request_data["workflow"],
+            notifier.request_data["workflow_content"]["workflow"],
             {
                 "id": self.wf.id,
                 "workflow_name": "some_name",
@@ -439,9 +439,12 @@ class TestNotify(TestCase):
                 "run_date_end": None,
                 "finish_time": None,
                 "is_manual": 0,
-                "instance": self.ins.id,
+                "instance": ANY,
                 "create_time": self.wf.create_time.isoformat(),
             },
+        )
+        self.assertEqual(
+            notifier.request_data["workflow_content"]["sql_content"], "some_sql"
         )
 
 

--- a/sql/test_notify.py
+++ b/sql/test_notify.py
@@ -1,6 +1,10 @@
+import importlib
 from datetime import datetime, timedelta
+from unittest.mock import patch, Mock, ANY
+from typing import ClassVar
 
 from django.contrib.auth.models import Group
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from common.config import SysConfig
@@ -12,9 +16,28 @@ from sql.models import (
     WorkflowAudit,
     WorkflowAuditDetail,
     ResourceGroup,
+    ArchiveConfig,
 )
-from sql.notify import auto_notify, EventType, LegacyRender, GenericWebhookNotifier
-from sql.tests import User
+from sql.notify import (
+    auto_notify,
+    EventType,
+    LegacyRender,
+    GenericWebhookNotifier,
+    My2SqlResult,
+    DingdingWebhookNotifier,
+    DingdingPersonNotifier,
+    FeishuPersonNotifier,
+    FeishuWebhookNotifier,
+    QywxWebhookNotifier,
+    LegacyMessage,
+    Notifier,
+    notify_for_execute,
+    notify_for_audit,
+    notify_for_my2sql,
+    MailNotifier,
+)
+
+User = get_user_model()
 
 
 class TestNotify(TestCase):
@@ -24,12 +47,18 @@ class TestNotify(TestCase):
 
     def setUp(self):
         self.sys_config = SysConfig()
+        self.aug = Group.objects.create(id=1, name="auth_group")
         self.user = User.objects.create(
             username="test_user", display="中文显示", is_active=True
         )
         self.su = User.objects.create(
-            username="s_user", display="中文显示", is_active=True, is_superuser=True
+            username="s_user",
+            display="中文显示",
+            is_active=True,
+            is_superuser=True,
         )
+        self.su.groups.add(self.aug)
+
         tomorrow = datetime.today() + timedelta(days=1)
         self.ins = Instance.objects.create(
             instance_name="some_ins",
@@ -80,10 +109,11 @@ class TestNotify(TestCase):
             workflow_type=2,
             workflow_title="申请标题",
             workflow_remark="申请备注",
-            audit_auth_groups="1,2,3",
+            audit_auth_groups="1",
             current_audit="1",
             next_audit="2",
             current_status=0,
+            create_user=self.user.username,
         )
         self.audit_wf_detail = WorkflowAuditDetail.objects.create(
             audit_id=self.audit_wf.audit_id,
@@ -104,8 +134,42 @@ class TestNotify(TestCase):
             next_audit="2",
             current_status=0,
         )
-        self.aug = Group.objects.create(id=1, name="auth_group")
+        self.audit_query_detail = WorkflowAuditDetail.objects.create(
+            audit_id=self.audit_query.audit_id,
+            audit_user=self.user.display,
+            audit_time=datetime.now(),
+            audit_status=1,
+            remark="测试query备注",
+        )
+
         self.rs = ResourceGroup.objects.create(group_id=1, ding_webhook="url")
+
+        self.archive_apply = ArchiveConfig.objects.create(
+            title="测试归档",
+            resource_group=self.rs,
+            src_instance=self.ins,
+            src_db_name="foo",
+            src_table_name="bar",
+            dest_db_name="foo-dest",
+            dest_table_name="bar-dest",
+            mode="purge",
+            no_delete=False,
+            status=0,
+            user_name=self.user.username,
+            user_display=self.user.display,
+        )
+        self.archive_apply_audit = WorkflowAudit.objects.create(
+            group_id=1,
+            group_name="some_group",
+            workflow_id=self.archive_apply.id,
+            workflow_type=3,
+            workflow_title=self.archive_apply.title,
+            workflow_remark="申请备注",
+            audit_auth_groups="1,2,3",
+            current_audit="1",
+            next_audit="2",
+            current_status=0,
+        )
 
     def tearDown(self):
         self.sys_config.purge()
@@ -113,6 +177,8 @@ class TestNotify(TestCase):
         SqlWorkflow.objects.all().delete()
         SqlWorkflowContent.objects.all().delete()
         WorkflowAudit.objects.all().delete()
+        WorkflowAuditDetail.objects.all().delete()
+        ArchiveConfig.objects.all().delete()
         ResourceGroup.objects.all().delete()
 
     def test_empty_notifiers(self):
@@ -123,7 +189,62 @@ class TestNotify(TestCase):
                 sys_config=self.sys_config,
             )
 
-    # 测试该调用 auto_notify 的地方要调用
+    def test_base_notifier(self):
+        self.sys_config.set("foo", "bar")
+        n = Notifier(workflow=self.wf, sys_config=self.sys_config)
+        n.sys_config_key = "foo"
+        self.assertTrue(n.should_run())
+        n.sys_config_key = "not-foo"
+        self.assertFalse(n.should_run())
+
+    @patch("sql.notify.FeishuWebhookNotifier.run")
+    def test_auto_notify(self, mock_run):
+        with self.settings(ENABLED_NOTIFIERS=("sql.notify:FeishuWebhookNotifier",)):
+            auto_notify(self.sys_config, event_type=EventType.EXECUTE)
+            mock_run.assert_called_once()
+
+    @patch("sql.notify.auto_notify")
+    def test_notify_for_execute(self, mock_auto_notify: Mock):
+        """测试适配器"""
+        notify_for_execute(self.wf)
+        mock_auto_notify.assert_called_once_with(workflow=self.wf, sys_config=ANY)
+
+    @patch("sql.notify.auto_notify")
+    def test_notify_for_audit(self, mock_auto_notify: Mock):
+        """测试适配器"""
+        notify_for_audit(
+            workflow_audit=self.audit_wf, workflow_audit_detail=self.audit_wf_detail
+        )
+        mock_auto_notify.assert_called_once_with(
+            workflow=None,
+            sys_config=ANY,
+            audit=self.audit_wf,
+            audit_detail=self.audit_wf_detail,
+        )
+
+    @patch("sql.notify.auto_notify")
+    def test_notify_for_m2sql(self, mock_auto_notify: Mock):
+        """测试适配器"""
+        task = Mock()
+        task.success = True
+        task.kwargs = {"user": "foo"}
+        task.result = ["", "/foo"]
+        expect_workflow = My2SqlResult(success=True, submitter="foo", file_path="/foo")
+        notify_for_my2sql(task)
+        mock_auto_notify.assert_called_once_with(
+            workflow=expect_workflow, sys_config=ANY, event_type=EventType.M2SQL
+        )
+        mock_auto_notify.reset_mock()
+        # 测试失败的情况
+        task.success = False
+        task.result = "Traceback blahblah"
+        expect_workflow = My2SqlResult(
+            success=False, submitter="foo", error=task.result
+        )
+        notify_for_my2sql(task)
+        mock_auto_notify.assert_called_once_with(
+            workflow=expect_workflow, sys_config=ANY, event_type=EventType.M2SQL
+        )
 
     # 下面的测试均为 notifier 的测试, 测试 render 和 send
     def test_legacy_render_execution(self):
@@ -136,6 +257,19 @@ class TestNotify(TestCase):
         with self.assertRaises(NotImplementedError):
             notifier.send()
 
+    def test_legacy_render_execution_ddl(self):
+        """DDL 比普通的工单多一个通知 dba"""
+        self.wf.syntax_type = 1
+        self.wf.status = "workflow_finish"
+        self.wf.save()
+        self.sys_config.set("ddl_notify_auth_group", self.aug.name)
+        notifier = LegacyRender(
+            workflow=self.wf, event_type=EventType.EXECUTE, sys_config=self.sys_config
+        )
+        notifier.render()
+        self.assertEqual(len(notifier.messages), 2)
+        self.assertIn("有新的DDL语句执行完成", notifier.messages[1].msg_title)
+
     def test_legacy_render_audit(self):
         notifier = LegacyRender(
             workflow=self.wf,
@@ -146,6 +280,121 @@ class TestNotify(TestCase):
         )
         notifier.render()
         self.assertEqual(len(notifier.messages), 1)
+        self.assertIn("新的工单申请", notifier.messages[0].msg_title)
+
+    def test_legacy_render_query_audit(self):
+        # 默认是库权限的
+        notifier = LegacyRender(
+            workflow=self.query_apply_1,
+            event_type=EventType.AUDIT,
+            audit=self.audit_query,
+            audit_detail=self.audit_query_detail,
+            sys_config=self.sys_config,
+        )
+        notifier.render()
+        self.assertEqual(len(notifier.messages), 1)
+        self.assertIn("数据库清单", notifier.messages[0].msg_content)
+
+        # 表级别的权限申请
+        self.query_apply_1.priv_type = 2
+        self.query_apply_1.table_list = "foo,bar"
+        self.query_apply_1.save()
+        notifier = LegacyRender(
+            workflow=self.query_apply_1,
+            event_type=EventType.AUDIT,
+            audit=self.audit_query,
+            audit_detail=self.audit_query_detail,
+            sys_config=self.sys_config,
+        )
+        notifier.render()
+        self.assertEqual(len(notifier.messages), 1)
+        self.assertIn("表清单", notifier.messages[0].msg_content)
+        self.assertIn("foo,bar", notifier.messages[0].msg_content)
+
+    def test_legacy_render_archive_audit(self):
+        notifier = LegacyRender(
+            workflow=self.archive_apply,
+            event_type=EventType.AUDIT,
+            audit=self.archive_apply_audit,
+            sys_config=self.sys_config,
+        )
+        notifier.render()
+        self.assertEqual(len(notifier.messages), 1)
+        self.assertIn("归档表", notifier.messages[0].msg_content)
+
+    def test_legacy_render_audit_success(self):
+        """审核通过消息"""
+        # 只测试上线工单
+        self.audit_wf.current_status = 1
+        self.audit_wf.save()
+        notifier = LegacyRender(
+            workflow=self.wf,
+            event_type=EventType.AUDIT,
+            audit=self.audit_wf,
+            sys_config=self.sys_config,
+        )
+        notifier.render()
+        self.assertEqual(len(notifier.messages), 1)
+        self.assertIn("工单审核通过", notifier.messages[0].msg_title)
+
+    def test_legacy_render_audit_reject(self):
+        self.audit_wf.current_status = 2
+        self.audit_wf.save()
+        self.audit_wf_detail.remark = "驳回foo-bar"
+        self.audit_wf_detail.save()
+        notifier = LegacyRender(
+            workflow=self.wf,
+            event_type=EventType.AUDIT,
+            audit=self.audit_wf,
+            audit_detail=self.audit_wf_detail,
+            sys_config=self.sys_config,
+        )
+        notifier.render()
+        self.assertEqual(len(notifier.messages), 1)
+        self.assertIn("工单被驳回", notifier.messages[0].msg_title)
+        self.assertIn("驳回foo-bar", notifier.messages[0].msg_content)
+
+    def test_legacy_render_audit_abort(self):
+        self.audit_wf.current_status = 3
+        self.audit_wf.save()
+        self.audit_wf_detail.remark = "撤回foo-bar"
+        self.audit_wf_detail.save()
+        notifier = LegacyRender(
+            workflow=self.wf,
+            event_type=EventType.AUDIT,
+            audit=self.audit_wf,
+            audit_detail=self.audit_wf_detail,
+            sys_config=self.sys_config,
+        )
+        notifier.render()
+        self.assertEqual(len(notifier.messages), 1)
+        self.assertIn("提交人主动终止工单", notifier.messages[0].msg_title)
+        self.assertIn("撤回foo-bar", notifier.messages[0].msg_content)
+
+    def test_legacy_render_m2sql(self):
+        successful_workflow = My2SqlResult(
+            submitter=self.user.username, success=True, file_path="/foo/bar"
+        )
+        notifier = LegacyRender(
+            workflow=successful_workflow,
+            sys_config=self.sys_config,
+            event_type=EventType.M2SQL,
+        )
+        notifier.render()
+        self.assertEqual(len(notifier.messages), 1)
+        self.assertEqual(notifier.messages[0].msg_title, "[Archery 通知]My2SQL执行结束")
+        # 失败
+        failed_workflow = My2SqlResult(
+            submitter=self.user.username, success=False, error="Traceback blahblah"
+        )
+        notifier = LegacyRender(
+            workflow=failed_workflow,
+            sys_config=self.sys_config,
+            event_type=EventType.M2SQL,
+        )
+        notifier.render()
+        self.assertEqual(len(notifier.messages), 1)
+        self.assertEqual(notifier.messages[0].msg_title, "[Archery 通知]My2SQL执行失败")
 
     def test_general_webhook(self):
         notifier = GenericWebhookNotifier(
@@ -165,7 +414,7 @@ class TestNotify(TestCase):
                 "workflow_type": 2,
                 "create_user_display": "",
                 "workflow_title": "申请标题",
-                "audit_auth_groups": "1,2,3",
+                "audit_auth_groups": self.audit_wf.audit_auth_groups,
                 "current_audit": "1",
                 "current_status": 0,
                 "create_time": self.audit_wf.create_time.isoformat(),
@@ -194,3 +443,115 @@ class TestNotify(TestCase):
                 "create_time": self.wf.create_time.isoformat(),
             },
         )
+
+
+class TestNotifySend(TestCase):
+    audit_wf: WorkflowAudit = None
+    rs: ResourceGroup = None
+    user: User = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.user = User.objects.create(
+            username="test",
+            email="test@example.com",
+            ding_user_id="1234",
+            wx_user_id="1234",
+            feishu_open_id="1234",
+        )
+        cls.rs = ResourceGroup.objects.create(
+            group_name="test",
+            ding_webhook="ding_url",
+            feishu_webhook="feishu_url",
+            qywx_webhook="qywx_url",
+        )
+        cls.audit_wf = WorkflowAudit.objects.create(
+            group_id=cls.rs.group_id,
+            group_name="some_group",
+            workflow_id=1,
+            workflow_type=2,
+            workflow_title="申请标题",
+            workflow_remark="申请备注",
+            audit_auth_groups="1",
+            current_audit="1",
+            next_audit="2",
+            current_status=0,
+            create_user=cls.user.username,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete()
+        cls.rs.delete()
+        cls.audit_wf.delete()
+
+    def setUp(self):
+        self.patcher = patch("sql.notify.MsgSender")
+        self.mock_msg_sender = self.patcher.start()
+        self.sys_config = SysConfig()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def generate_notifier(self, module) -> object:
+        return module(workflow=None, audit=self.audit_wf, sys_config=self.sys_config)
+
+    def test_ding_webhook_send(self):
+        mocker = Mock()
+        setattr(self.mock_msg_sender.return_value, "send_ding", mocker)
+        notifier = self.generate_notifier(DingdingWebhookNotifier)
+        notifier.messages = [
+            LegacyMessage(msg_to=[self.user], msg_title="test", msg_content="test")
+        ]
+        notifier.send()
+        mocker.assert_called_once()
+
+    def test_ding_person_send(self):
+        mocker = Mock()
+        setattr(self.mock_msg_sender.return_value, "send_ding2user", mocker)
+        notifier = self.generate_notifier(DingdingPersonNotifier)
+        notifier.messages = [
+            LegacyMessage(msg_to=[self.user], msg_title="test", msg_content="test")
+        ]
+        notifier.send()
+        mocker.assert_called_once()
+
+    def test_feishu_webhook(self):
+        mocker = Mock()
+        setattr(self.mock_msg_sender.return_value, "send_feishu_webhook", mocker)
+        notifier = self.generate_notifier(FeishuWebhookNotifier)
+        notifier.messages = [
+            LegacyMessage(msg_to=[self.user], msg_title="test", msg_content="test")
+        ]
+        notifier.send()
+        mocker.assert_called_once()
+
+    def test_feishu_person(self):
+        mocker = Mock()
+        setattr(self.mock_msg_sender.return_value, "send_feishu_user", mocker)
+        notifier = self.generate_notifier(FeishuPersonNotifier)
+        notifier.messages = [
+            LegacyMessage(msg_to=[self.user], msg_title="test", msg_content="test")
+        ]
+        notifier.send()
+        mocker.assert_called_once()
+
+    def test_qywx_webhook(self):
+        mocker = Mock()
+        setattr(self.mock_msg_sender.return_value, "send_qywx_webhook", mocker)
+        notifier = self.generate_notifier(QywxWebhookNotifier)
+        notifier.messages = [
+            LegacyMessage(msg_to=[self.user], msg_title="test", msg_content="test")
+        ]
+        notifier.send()
+        mocker.assert_called_once()
+
+    def test_mail(self):
+        mocker = Mock()
+        setattr(self.mock_msg_sender.return_value, "send_email", mocker)
+        notifier = self.generate_notifier(MailNotifier)
+        notifier.messages = [
+            LegacyMessage(msg_to=[self.user], msg_title="test", msg_content="test")
+        ]
+        notifier.send()
+        mocker.assert_called_once()

--- a/sql/test_notify.py
+++ b/sql/test_notify.py
@@ -1,0 +1,303 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from django.contrib.auth.models import Group
+from django.test import TestCase
+
+from common.config import SysConfig
+from common.utils.const import WorkflowDict
+from sql.models import Instance, SqlWorkflow, SqlWorkflowContent, QueryPrivilegesApply, WorkflowAudit, ResourceGroup
+from sql.notify import notify_for_audit, notify_for_my2sql, auto_notify, EventType
+from sql.tests import User
+
+
+class TestNotify(TestCase):
+    """
+    测试消息
+    """
+
+    def setUp(self):
+        self.sys_config = SysConfig()
+        self.user = User.objects.create(
+            username="test_user", display="中文显示", is_active=True
+        )
+        self.su = User.objects.create(
+            username="s_user", display="中文显示", is_active=True, is_superuser=True
+        )
+        tomorrow = datetime.today() + timedelta(days=1)
+        self.ins = Instance.objects.create(
+            instance_name="some_ins",
+            type="slave",
+            db_type="mysql",
+            host="some_host",
+            port=3306,
+            user="ins_user",
+            password="some_str",
+        )
+        self.wf = SqlWorkflow.objects.create(
+            workflow_name="some_name",
+            group_id=1,
+            group_name="g1",
+            engineer=self.user.username,
+            engineer_display=self.user.display,
+            audit_auth_groups="some_audit_group",
+            create_time=datetime.now(),
+            status="workflow_timingtask",
+            is_backup=True,
+            instance=self.ins,
+            db_name="some_db",
+            syntax_type=1,
+        )
+        SqlWorkflowContent.objects.create(
+            workflow=self.wf, sql_content="some_sql", execute_result=""
+        )
+        self.query_apply_1 = QueryPrivilegesApply.objects.create(
+            group_id=1,
+            group_name="some_name",
+            title="some_title1",
+            user_name="some_user",
+            instance=self.ins,
+            db_list="some_db,some_db2",
+            limit_num=100,
+            valid_date=tomorrow,
+            priv_type=1,
+            status=0,
+            audit_auth_groups="some_audit_group",
+        )
+        self.audit = WorkflowAudit.objects.create(
+            group_id=1,
+            group_name="some_group",
+            workflow_id=1,
+            workflow_type=1,
+            workflow_title="申请标题",
+            workflow_remark="申请备注",
+            audit_auth_groups="1,2,3",
+            current_audit="1",
+            next_audit="2",
+            current_status=0,
+        )
+        self.aug = Group.objects.create(id=1, name="auth_group")
+        self.rs = ResourceGroup.objects.create(group_id=1, ding_webhook="url")
+
+    def tearDown(self):
+        self.sys_config.purge()
+        User.objects.all().delete()
+        SqlWorkflow.objects.all().delete()
+        SqlWorkflowContent.objects.all().delete()
+        WorkflowAudit.objects.all().delete()
+        ResourceGroup.objects.all().delete()
+
+    def test_empty_notifiers(self):
+        with self.settings(ENABLED_NOTIFIERS=()):
+            auto_notify(workflow=self.wf, event_type=EventType.EXECUTE, sys_config=self.sys_config)
+
+    def test_notify_disable(self):
+        """
+        测试关闭通知
+        :return:
+        """
+        # 关闭消息通知
+        self.sys_config.set("mail", "false")
+        self.sys_config.set("ding", "false")
+        r = notify_for_audit(audit_id=self.audit.audit_id)
+        self.assertIsNone(r)
+
+    @patch("sql.notify.MsgSender")
+    @patch("sql.notify.auth_group_users")
+    def test_notify_for_sqlreview_audit_wait(self, _auth_group_users, _msg_sender):
+        """
+        测试SQL上线申请审核通知
+        :return:
+        """
+        # 通知人修改
+        _auth_group_users.return_value = [self.user]
+        # 开启消息通知
+        self.sys_config.set("mail", "true")
+        self.sys_config.set("ding", "true")
+        # 修改工单状态为待审核
+        self.audit.workflow_type = WorkflowDict.workflow_type["sqlreview"]
+        self.audit.workflow_id = self.wf.id
+        self.audit.current_status = WorkflowDict.workflow_status["audit_wait"]
+        self.audit.save()
+        r = notify_for_audit(audit_id=self.audit.audit_id)
+        self.assertIsNone(r)
+        _msg_sender.assert_called_once()
+
+    @patch("sql.notify.MsgSender")
+    @patch("sql.notify.auth_group_users")
+    def test_notify_for_sqlreview_audit_success(self, _auth_group_users, _msg_sender):
+        """
+        测试SQL上线申请审核通过通知
+        :return:
+        """
+        # 通知人修改
+        _auth_group_users.return_value = [self.user]
+        # 开启消息通知
+        self.sys_config.set("mail", "true")
+        self.sys_config.set("ding", "true")
+        # 修改工单状态审核通过
+        self.audit.workflow_type = WorkflowDict.workflow_type["sqlreview"]
+        self.audit.workflow_id = self.wf.id
+        self.audit.current_status = WorkflowDict.workflow_status["audit_success"]
+        self.audit.create_user = self.user.username
+        self.audit.save()
+        r = notify_for_audit(audit_id=self.audit.audit_id)
+        self.assertIsNone(r)
+        _msg_sender.assert_called_once()
+
+    @patch("sql.notify.MsgSender")
+    @patch("sql.notify.auth_group_users")
+    def test_notify_for_sqlreview_audit_reject(self, _auth_group_users, _msg_sender):
+        """
+        测试SQL上线申请审核驳回通知
+        :return:
+        """
+        # 通知人修改
+        _auth_group_users.return_value = [self.user]
+        # 开启消息通知
+        self.sys_config.set("mail", "true")
+        self.sys_config.set("ding", "true")
+        # 修改工单状态审核通过
+        self.audit.workflow_type = WorkflowDict.workflow_type["sqlreview"]
+        self.audit.workflow_id = self.wf.id
+        self.audit.current_status = WorkflowDict.workflow_status["audit_reject"]
+        self.audit.create_user = self.user.username
+        self.audit.save()
+        r = notify_for_audit(audit_id=self.audit.audit_id)
+        self.assertIsNone(r)
+        _msg_sender.assert_called_once()
+
+    @patch("sql.notify.MsgSender")
+    @patch("sql.notify.auth_group_users")
+    def test_notify_for_sqlreview_audit_abort(self, _auth_group_users, _msg_sender):
+        """
+        测试SQL上线申请审核取消通知
+        :return:
+        """
+        # 通知人修改
+        _auth_group_users.return_value = [self.user]
+        # 开启消息通知
+        self.sys_config.set("mail", "true")
+        self.sys_config.set("ding", "true")
+        # 修改工单状态审核取消
+        self.audit.workflow_type = WorkflowDict.workflow_type["sqlreview"]
+        self.audit.workflow_id = self.wf.id
+        self.audit.current_status = WorkflowDict.workflow_status["audit_abort"]
+        self.audit.create_user = self.user.username
+        self.audit.audit_auth_groups = self.aug.id
+        self.audit.save()
+        r = notify_for_audit(audit_id=self.audit.audit_id)
+        self.assertIsNone(r)
+        _msg_sender.assert_called_once()
+
+    @patch("sql.notify.MsgSender")
+    @patch("sql.notify.auth_group_users")
+    def test_notify_for_sqlreview_wrong_workflow_type(
+        self, _auth_group_users, _msg_sender
+    ):
+        """
+        测试不存在的工单类型
+        :return:
+        """
+        # 通知人修改
+        _auth_group_users.return_value = [self.user]
+        # 开启消息通知
+        self.sys_config.set("mail", "true")
+        self.sys_config.set("ding", "true")
+        # 修改工单状态审核取消
+        self.audit.workflow_type = 10
+        self.audit.save()
+        with self.assertRaisesMessage(Exception, "工单类型不正确"):
+            notify_for_audit(audit_id=self.audit.audit_id)
+
+    @patch("sql.notify.MsgSender")
+    @patch("sql.notify.auth_group_users")
+    def test_notify_for_query_audit_wait_apply_db_perm(
+        self, _auth_group_users, _msg_sender
+    ):
+        """
+        测试查询申请库权限
+        :return:
+        """
+        # 通知人修改
+        _auth_group_users.return_value = [self.user]
+        # 开启消息通知
+        self.sys_config.set("mail", "true")
+        self.sys_config.set("ding", "true")
+        # 修改工单状态为待审核
+        self.audit.workflow_type = WorkflowDict.workflow_type["query"]
+        self.audit.workflow_id = self.query_apply_1.apply_id
+        self.audit.current_status = WorkflowDict.workflow_status["audit_wait"]
+        self.audit.save()
+        # 修改工单为库权限申请
+        self.query_apply_1.priv_type = 1
+        self.query_apply_1.save()
+        r = notify_for_audit(audit_id=self.audit.audit_id)
+        self.assertIsNone(r)
+        _msg_sender.assert_called_once()
+
+    @patch("sql.notify.MsgSender")
+    @patch("sql.notify.auth_group_users")
+    def test_notify_for_query_audit_wait_apply_tb_perm(
+        self, _auth_group_users, _msg_sender
+    ):
+        """
+        测试查询申请表权限
+        :return:
+        """
+        # 通知人修改
+        _auth_group_users.return_value = [self.user]
+        # 开启消息通知
+        self.sys_config.set("mail", "true")
+        self.sys_config.set("ding", "true")
+        # 修改工单状态为待审核
+        self.audit.workflow_type = WorkflowDict.workflow_type["query"]
+        self.audit.workflow_id = self.query_apply_1.apply_id
+        self.audit.current_status = WorkflowDict.workflow_status["audit_wait"]
+        self.audit.save()
+        # 修改工单为表权限申请
+        self.query_apply_1.priv_type = 2
+        self.query_apply_1.save()
+        r = notify_for_audit(audit_id=self.audit.audit_id)
+        self.assertIsNone(r)
+        _msg_sender.assert_called_once()
+
+    @patch("sql.notify.MsgSender")
+    def test_notify_for_execute_disable(self, _msg_sender):
+        """
+        测试执行消息关闭
+        :return:
+        """
+        # 开启消息通知
+        self.sys_config.set("mail", "false")
+        self.sys_config.set("ding", "false")
+        r = auto_notify(self.wf, event_type=EventType.M2SQL)
+        self.assertIsNone(r)
+
+    @patch("sql.notify.auth_group_users")
+    @patch("sql.notify.Audit")
+    @patch("sql.notify.MsgSender")
+    def test_notify_for_execute(self, _msg_sender, _audit, _auth_group_users):
+        """
+        测试执行消息
+        :return:
+        """
+        _auth_group_users.return_value = [self.user]
+        # 处理工单信息
+        _audit.review_info.return_value = (
+            self.audit.audit_auth_groups,
+            self.audit.current_audit,
+        )
+        # 开启消息通知
+        self.sys_config.set("mail", "true")
+        self.sys_config.set("ding", "true")
+        self.sys_config.set("ddl_notify_auth_group", self.aug.name)
+        # 修改工单状态为执行结束，修改为DDL工单
+        self.wf.status = "workflow_finish"
+        self.wf.syntax_type = 1
+        self.wf.save()
+        r = auto_notify(workflow=self.wf, sys_config=self.sys_config)
+        self.assertIsNone(r)
+        _msg_sender.assert_called()
+
+    # 下面的测试均为 notifier 的测试, 测试 render 和 send

--- a/sql/test_notify.py
+++ b/sql/test_notify.py
@@ -160,7 +160,7 @@ class TestNotify(TestCase):
         self.assertDictEqual(
             notifier.request_data["audit"],
             {
-                "audit_id": 3,
+                "audit_id": self.audit_wf.audit_id,
                 "group_name": "some_group",
                 "workflow_type": 2,
                 "create_user_display": "",
@@ -174,7 +174,7 @@ class TestNotify(TestCase):
         self.assertDictEqual(
             notifier.request_data["workflow"],
             {
-                "id": 2,
+                "id": self.wf.id,
                 "workflow_name": "some_name",
                 "demand_url": "",
                 "group_id": 1,

--- a/sql/test_notify.py
+++ b/sql/test_notify.py
@@ -4,8 +4,15 @@ from django.contrib.auth.models import Group
 from django.test import TestCase
 
 from common.config import SysConfig
-from sql.models import (Instance, SqlWorkflow, SqlWorkflowContent,
-                        QueryPrivilegesApply, WorkflowAudit, WorkflowAuditDetail, ResourceGroup)
+from sql.models import (
+    Instance,
+    SqlWorkflow,
+    SqlWorkflowContent,
+    QueryPrivilegesApply,
+    WorkflowAudit,
+    WorkflowAuditDetail,
+    ResourceGroup,
+)
 from sql.notify import auto_notify, EventType, LegacyRender, GenericWebhookNotifier
 from sql.tests import User
 
@@ -110,16 +117,18 @@ class TestNotify(TestCase):
 
     def test_empty_notifiers(self):
         with self.settings(ENABLED_NOTIFIERS=()):
-            auto_notify(workflow=self.wf, event_type=EventType.EXECUTE, sys_config=self.sys_config)
+            auto_notify(
+                workflow=self.wf,
+                event_type=EventType.EXECUTE,
+                sys_config=self.sys_config,
+            )
 
     # 测试该调用 auto_notify 的地方要调用
 
     # 下面的测试均为 notifier 的测试, 测试 render 和 send
     def test_legacy_render_execution(self):
         notifier = LegacyRender(
-            workflow=self.wf,
-            event_type=EventType.EXECUTE,
-            sys_config=self.sys_config
+            workflow=self.wf, event_type=EventType.EXECUTE, sys_config=self.sys_config
         )
         notifier.render()
         self.assertEqual(len(notifier.messages), 1)
@@ -133,7 +142,7 @@ class TestNotify(TestCase):
             event_type=EventType.AUDIT,
             audit=self.audit_wf,
             audit_detail=self.audit_wf_detail,
-            sys_config=self.sys_config
+            sys_config=self.sys_config,
         )
         notifier.render()
         self.assertEqual(len(notifier.messages), 1)
@@ -144,21 +153,44 @@ class TestNotify(TestCase):
             event_type=EventType.AUDIT,
             audit=self.audit_wf,
             audit_detail=self.audit_wf_detail,
-            sys_config=self.sys_config
+            sys_config=self.sys_config,
         )
         notifier.render()
         self.assertIsNotNone(notifier.request_data)
-        self.assertDictEqual(notifier.request_data["audit"],
-                             {
-                                 "audit_id": 3, "group_name": "some_group", "workflow_type": 2,
-                                 "create_user_display": "",
-                                 "workflow_title": "申请标题", "audit_auth_groups": "1,2,3", "current_audit": "1",
-                                 "current_status": 0, "create_time": self.audit_wf.create_time.isoformat()
-                             })
-        self.assertDictEqual(notifier.request_data["workflow"],
-                             {"id": 2, "workflow_name": "some_name", "demand_url": "", "group_id": 1,
-                              "group_name": "g1", "db_name": "some_db", "syntax_type": 1, "is_backup": True,
-                              "engineer": "test_user", "engineer_display": "中文显示", "status": "workflow_timingtask",
-                              "audit_auth_groups": "some_audit_group", "run_date_start": None, "run_date_end": None,
-                              "finish_time": None, "is_manual": 0, "instance": 2,
-                              "create_time": self.wf.create_time.isoformat()})
+        self.assertDictEqual(
+            notifier.request_data["audit"],
+            {
+                "audit_id": 3,
+                "group_name": "some_group",
+                "workflow_type": 2,
+                "create_user_display": "",
+                "workflow_title": "申请标题",
+                "audit_auth_groups": "1,2,3",
+                "current_audit": "1",
+                "current_status": 0,
+                "create_time": self.audit_wf.create_time.isoformat(),
+            },
+        )
+        self.assertDictEqual(
+            notifier.request_data["workflow"],
+            {
+                "id": 2,
+                "workflow_name": "some_name",
+                "demand_url": "",
+                "group_id": 1,
+                "group_name": "g1",
+                "db_name": "some_db",
+                "syntax_type": 1,
+                "is_backup": True,
+                "engineer": "test_user",
+                "engineer_display": "中文显示",
+                "status": "workflow_timingtask",
+                "audit_auth_groups": "some_audit_group",
+                "run_date_start": None,
+                "run_date_end": None,
+                "finish_time": None,
+                "is_manual": 0,
+                "instance": 2,
+                "create_time": self.wf.create_time.isoformat(),
+            },
+        )

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -121,7 +121,9 @@ class TestView(TransactionTestCase):
         QueryPrivilegesApply.objects.all().delete()
         ResourceGroup.objects.all().delete()
         with connection.cursor() as cursor:
-            cursor.execute("DROP table mysql_slow_query_review,mysql_slow_query_review_history")
+            cursor.execute(
+                "DROP table mysql_slow_query_review,mysql_slow_query_review_history"
+            )
 
     def test_index(self):
         """测试index页面"""
@@ -1597,7 +1599,10 @@ class TestWorkflowView(TransactionTestCase):
         mock_audit_detail = PickableMock()
         mock_audit_detail.audit_id = 123
         _detail_by_id.return_value = mock_audit_detail
-        _audit.return_value = ({"data": {"workflow_status": 1}},{"foo": "bar"})  # TODO 改为audit_success
+        _audit.return_value = (
+            {"data": {"workflow_status": 1}},
+            {"foo": "bar"},
+        )  # TODO 改为audit_success
         r = c.post(
             "/passed/",
             data={"workflow_id": self.wf1.id, "audit_remark": "some_audit"},
@@ -2092,11 +2097,14 @@ class TestArchiver(TestCase):
         :return:
         """
         _audit.detail_by_workflow_id.return_value.audit_id = 1
-        _audit.audit.return_value = ({
-            "status": 0,
-            "msg": "ok",
-            "data": {"workflow_status": 1},
-        }, None)
+        _audit.audit.return_value = (
+            {
+                "status": 0,
+                "msg": "ok",
+                "data": {"workflow_status": 1},
+            },
+            None,
+        )
         data = {
             "archive_id": self.archive_apply.id,
             "audit_status": WorkflowDict.workflow_status["audit_success"],

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 from datetime import timedelta, datetime, date
 from unittest.mock import MagicMock, patch, ANY
 from django.conf import settings
@@ -12,8 +11,7 @@ from common.config import SysConfig
 from common.utils.const import WorkflowDict
 from sql.archiver import add_archive_task, archive
 from sql.binlog import my2sql_file
-from sql.engines.models import ResultSet, ReviewSet, ReviewResult
-from sql.notify import notify_for_audit, notify_for_execute, notify_for_my2sql
+from sql.engines.models import ResultSet
 from sql.utils.execute_sql import execute_callback
 from sql.query import kill_query_conn
 from sql.models import (
@@ -31,7 +29,6 @@ from sql.models import (
     WorkflowAuditSetting,
     ArchiveConfig,
 )
-from common.dashboard import ChartDao
 
 User = Users
 
@@ -1596,10 +1593,11 @@ class TestWorkflowView(TransactionTestCase):
         self.wf1.refresh_from_db()
         self.assertEqual(self.wf1.status, "workflow_review_pass")
 
+    @patch("sql.sql_workflow.auto_notify")
     @patch("sql.sql_workflow.Audit.add_log")
     @patch("sql.sql_workflow.Audit.detail_by_workflow_id")
     @patch("sql.sql_workflow.can_execute")
-    def test_workflow_execute(self, mock_can_excute, mock_detail_by_id, mock_add_log):
+    def test_workflow_execute(self, mock_can_excute, _, _1, _2):
         """测试工单执行"""
         c = Client()
         c.force_login(self.executor1)
@@ -1609,7 +1607,6 @@ class TestWorkflowView(TransactionTestCase):
         r = c.post("/execute/", data={"workflow_id": self.wf2.id})
         self.assertContains(r, "你无权操作当前工单！")
         mock_can_excute.return_value = True
-        mock_detail_by_id = 123
         r = c.post("/execute/", data={"workflow_id": self.wf2.id, "mode": "manual"})
         self.wf2.refresh_from_db()
         self.assertEqual("workflow_finish", self.wf2.status)
@@ -2656,319 +2653,6 @@ class TestParam(TestCase):
         self.assertEqual(
             json.loads(r.content), {"status": 1, "msg": "设置错误，错误信息：修改报错", "data": []}
         )
-
-
-class TestNotify(TestCase):
-    """
-    测试消息
-    """
-
-    def setUp(self):
-        self.sys_config = SysConfig()
-        self.user = User.objects.create(
-            username="test_user", display="中文显示", is_active=True
-        )
-        self.su = User.objects.create(
-            username="s_user", display="中文显示", is_active=True, is_superuser=True
-        )
-        tomorrow = datetime.today() + timedelta(days=1)
-        self.ins = Instance.objects.create(
-            instance_name="some_ins",
-            type="slave",
-            db_type="mysql",
-            host="some_host",
-            port=3306,
-            user="ins_user",
-            password="some_str",
-        )
-        self.wf = SqlWorkflow.objects.create(
-            workflow_name="some_name",
-            group_id=1,
-            group_name="g1",
-            engineer=self.user.username,
-            engineer_display=self.user.display,
-            audit_auth_groups="some_audit_group",
-            create_time=datetime.now(),
-            status="workflow_timingtask",
-            is_backup=True,
-            instance=self.ins,
-            db_name="some_db",
-            syntax_type=1,
-        )
-        SqlWorkflowContent.objects.create(
-            workflow=self.wf, sql_content="some_sql", execute_result=""
-        )
-        self.query_apply_1 = QueryPrivilegesApply.objects.create(
-            group_id=1,
-            group_name="some_name",
-            title="some_title1",
-            user_name="some_user",
-            instance=self.ins,
-            db_list="some_db,some_db2",
-            limit_num=100,
-            valid_date=tomorrow,
-            priv_type=1,
-            status=0,
-            audit_auth_groups="some_audit_group",
-        )
-        self.audit = WorkflowAudit.objects.create(
-            group_id=1,
-            group_name="some_group",
-            workflow_id=1,
-            workflow_type=1,
-            workflow_title="申请标题",
-            workflow_remark="申请备注",
-            audit_auth_groups="1,2,3",
-            current_audit="1",
-            next_audit="2",
-            current_status=0,
-        )
-        self.aug = Group.objects.create(id=1, name="auth_group")
-        self.rs = ResourceGroup.objects.create(group_id=1, ding_webhook="url")
-
-    def tearDown(self):
-        self.sys_config.purge()
-        User.objects.all().delete()
-        SqlWorkflow.objects.all().delete()
-        SqlWorkflowContent.objects.all().delete()
-        WorkflowAudit.objects.all().delete()
-        ResourceGroup.objects.all().delete()
-
-    def test_notify_disable(self):
-        """
-        测试关闭通知
-        :return:
-        """
-        # 关闭消息通知
-        self.sys_config.set("mail", "false")
-        self.sys_config.set("ding", "false")
-        r = notify_for_audit(audit_id=self.audit.audit_id)
-        self.assertIsNone(r)
-
-    @patch("sql.notify.MsgSender")
-    @patch("sql.notify.auth_group_users")
-    def test_notify_for_sqlreview_audit_wait(self, _auth_group_users, _msg_sender):
-        """
-        测试SQL上线申请审核通知
-        :return:
-        """
-        # 通知人修改
-        _auth_group_users.return_value = [self.user]
-        # 开启消息通知
-        self.sys_config.set("mail", "true")
-        self.sys_config.set("ding", "true")
-        # 修改工单状态为待审核
-        self.audit.workflow_type = WorkflowDict.workflow_type["sqlreview"]
-        self.audit.workflow_id = self.wf.id
-        self.audit.current_status = WorkflowDict.workflow_status["audit_wait"]
-        self.audit.save()
-        r = notify_for_audit(audit_id=self.audit.audit_id)
-        self.assertIsNone(r)
-        _msg_sender.assert_called_once()
-
-    @patch("sql.notify.MsgSender")
-    @patch("sql.notify.auth_group_users")
-    def test_notify_for_sqlreview_audit_success(self, _auth_group_users, _msg_sender):
-        """
-        测试SQL上线申请审核通过通知
-        :return:
-        """
-        # 通知人修改
-        _auth_group_users.return_value = [self.user]
-        # 开启消息通知
-        self.sys_config.set("mail", "true")
-        self.sys_config.set("ding", "true")
-        # 修改工单状态审核通过
-        self.audit.workflow_type = WorkflowDict.workflow_type["sqlreview"]
-        self.audit.workflow_id = self.wf.id
-        self.audit.current_status = WorkflowDict.workflow_status["audit_success"]
-        self.audit.create_user = self.user.username
-        self.audit.save()
-        r = notify_for_audit(audit_id=self.audit.audit_id)
-        self.assertIsNone(r)
-        _msg_sender.assert_called_once()
-
-    @patch("sql.notify.MsgSender")
-    @patch("sql.notify.auth_group_users")
-    def test_notify_for_sqlreview_audit_reject(self, _auth_group_users, _msg_sender):
-        """
-        测试SQL上线申请审核驳回通知
-        :return:
-        """
-        # 通知人修改
-        _auth_group_users.return_value = [self.user]
-        # 开启消息通知
-        self.sys_config.set("mail", "true")
-        self.sys_config.set("ding", "true")
-        # 修改工单状态审核通过
-        self.audit.workflow_type = WorkflowDict.workflow_type["sqlreview"]
-        self.audit.workflow_id = self.wf.id
-        self.audit.current_status = WorkflowDict.workflow_status["audit_reject"]
-        self.audit.create_user = self.user.username
-        self.audit.save()
-        r = notify_for_audit(audit_id=self.audit.audit_id)
-        self.assertIsNone(r)
-        _msg_sender.assert_called_once()
-
-    @patch("sql.notify.MsgSender")
-    @patch("sql.notify.auth_group_users")
-    def test_notify_for_sqlreview_audit_abort(self, _auth_group_users, _msg_sender):
-        """
-        测试SQL上线申请审核取消通知
-        :return:
-        """
-        # 通知人修改
-        _auth_group_users.return_value = [self.user]
-        # 开启消息通知
-        self.sys_config.set("mail", "true")
-        self.sys_config.set("ding", "true")
-        # 修改工单状态审核取消
-        self.audit.workflow_type = WorkflowDict.workflow_type["sqlreview"]
-        self.audit.workflow_id = self.wf.id
-        self.audit.current_status = WorkflowDict.workflow_status["audit_abort"]
-        self.audit.create_user = self.user.username
-        self.audit.audit_auth_groups = self.aug.id
-        self.audit.save()
-        r = notify_for_audit(audit_id=self.audit.audit_id)
-        self.assertIsNone(r)
-        _msg_sender.assert_called_once()
-
-    @patch("sql.notify.MsgSender")
-    @patch("sql.notify.auth_group_users")
-    def test_notify_for_sqlreview_wrong_workflow_type(
-        self, _auth_group_users, _msg_sender
-    ):
-        """
-        测试不存在的工单类型
-        :return:
-        """
-        # 通知人修改
-        _auth_group_users.return_value = [self.user]
-        # 开启消息通知
-        self.sys_config.set("mail", "true")
-        self.sys_config.set("ding", "true")
-        # 修改工单状态审核取消
-        self.audit.workflow_type = 10
-        self.audit.save()
-        with self.assertRaisesMessage(Exception, "工单类型不正确"):
-            notify_for_audit(audit_id=self.audit.audit_id)
-
-    @patch("sql.notify.MsgSender")
-    @patch("sql.notify.auth_group_users")
-    def test_notify_for_query_audit_wait_apply_db_perm(
-        self, _auth_group_users, _msg_sender
-    ):
-        """
-        测试查询申请库权限
-        :return:
-        """
-        # 通知人修改
-        _auth_group_users.return_value = [self.user]
-        # 开启消息通知
-        self.sys_config.set("mail", "true")
-        self.sys_config.set("ding", "true")
-        # 修改工单状态为待审核
-        self.audit.workflow_type = WorkflowDict.workflow_type["query"]
-        self.audit.workflow_id = self.query_apply_1.apply_id
-        self.audit.current_status = WorkflowDict.workflow_status["audit_wait"]
-        self.audit.save()
-        # 修改工单为库权限申请
-        self.query_apply_1.priv_type = 1
-        self.query_apply_1.save()
-        r = notify_for_audit(audit_id=self.audit.audit_id)
-        self.assertIsNone(r)
-        _msg_sender.assert_called_once()
-
-    @patch("sql.notify.MsgSender")
-    @patch("sql.notify.auth_group_users")
-    def test_notify_for_query_audit_wait_apply_tb_perm(
-        self, _auth_group_users, _msg_sender
-    ):
-        """
-        测试查询申请表权限
-        :return:
-        """
-        # 通知人修改
-        _auth_group_users.return_value = [self.user]
-        # 开启消息通知
-        self.sys_config.set("mail", "true")
-        self.sys_config.set("ding", "true")
-        # 修改工单状态为待审核
-        self.audit.workflow_type = WorkflowDict.workflow_type["query"]
-        self.audit.workflow_id = self.query_apply_1.apply_id
-        self.audit.current_status = WorkflowDict.workflow_status["audit_wait"]
-        self.audit.save()
-        # 修改工单为表权限申请
-        self.query_apply_1.priv_type = 2
-        self.query_apply_1.save()
-        r = notify_for_audit(audit_id=self.audit.audit_id)
-        self.assertIsNone(r)
-        _msg_sender.assert_called_once()
-
-    @patch("sql.notify.MsgSender")
-    def test_notify_for_execute_disable(self, _msg_sender):
-        """
-        测试执行消息关闭
-        :return:
-        """
-        # 开启消息通知
-        self.sys_config.set("mail", "false")
-        self.sys_config.set("ding", "false")
-        r = notify_for_execute(self.wf)
-        self.assertIsNone(r)
-
-    @patch("sql.notify.auth_group_users")
-    @patch("sql.notify.Audit")
-    @patch("sql.notify.MsgSender")
-    def test_notify_for_execute(self, _msg_sender, _audit, _auth_group_users):
-        """
-        测试执行消息
-        :return:
-        """
-        _auth_group_users.return_value = [self.user]
-        # 处理工单信息
-        _audit.review_info.return_value = (
-            self.audit.audit_auth_groups,
-            self.audit.current_audit,
-        )
-        # 开启消息通知
-        self.sys_config.set("mail", "true")
-        self.sys_config.set("ding", "true")
-        self.sys_config.set("ddl_notify_auth_group", self.aug.name)
-        # 修改工单状态为执行结束，修改为DDL工单
-        self.wf.status = "workflow_finish"
-        self.wf.syntax_type = 1
-        self.wf.save()
-        r = notify_for_execute(self.wf)
-        self.assertIsNone(r)
-        _msg_sender.assert_called()
-
-    @patch("sql.notify.MsgSender")
-    def test_notify_for_my2sql_disable(self, _msg_sender):
-        """
-        测试执行消息关闭
-        :return:
-        """
-        # 开启消息通知
-        self.sys_config.set("mail", "false")
-        self.sys_config.set("ding", "false")
-        r = notify_for_execute(self.wf)
-        self.assertIsNone(r)
-
-    @patch("django_q.tasks.async_task")
-    @patch("sql.notify.MsgSender")
-    def test_notify_for_my2sql(self, _msg_sender, _async_task):
-        """
-        测试执行消息
-        :return:
-        """
-        # 开启消息通知
-        self.sys_config.set("mail", "true")
-        # 设置为task成功
-        _async_task.return_value.success.return_value = True
-        r = notify_for_my2sql(_async_task)
-        self.assertIsNone(r)
-        _msg_sender.assert_called_once()
 
 
 class TestDataDictionary(TestCase):

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -1655,7 +1655,8 @@ class TestWorkflowView(TransactionTestCase):
         self.assertContains(r, "你无权操作当前工单！")
         _can_cancel.return_value = True
         _detail_by_id = 123
-        r = c.post(
+        _audit.return_value = (None, None)
+        c.post(
             "/cancel/",
             data={"workflow_id": self.wf2.id, "cancel_remark": "some_reason"},
         )

--- a/sql/utils/execute_sql.py
+++ b/sql/utils/execute_sql.py
@@ -8,7 +8,7 @@ from common.utils.const import WorkflowDict
 from common.config import SysConfig
 from sql.engines.models import ReviewResult, ReviewSet
 from sql.models import SqlWorkflow
-from sql.notify import notify_for_execute
+from sql.notify import auto_notify, EventType
 from sql.utils.workflow_audit import Audit
 from sql.engines import get_engine
 
@@ -120,4 +120,4 @@ def execute_callback(task):
         else True
     )
     if is_notified:
-        notify_for_execute(workflow)
+        auto_notify(workflow=workflow, sys_config=sys_config, event_type=EventType.EXECUTE)

--- a/sql/utils/execute_sql.py
+++ b/sql/utils/execute_sql.py
@@ -8,7 +8,7 @@ from common.utils.const import WorkflowDict
 from common.config import SysConfig
 from sql.engines.models import ReviewResult, ReviewSet
 from sql.models import SqlWorkflow
-from sql.notify import auto_notify, EventType
+from sql.notify import notify_for_execute, EventType
 from sql.utils.workflow_audit import Audit
 from sql.engines import get_engine
 
@@ -120,4 +120,4 @@ def execute_callback(task):
         else True
     )
     if is_notified:
-        auto_notify(workflow=workflow, sys_config=sys_config, event_type=EventType.EXECUTE)
+        notify_for_execute(workflow)

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -946,7 +946,7 @@ class TestExecuteSql(TestCase):
             operator_display="系统",
         )
 
-    @patch("sql.utils.execute_sql.notify_for_execute")
+    @patch("sql.utils.execute_sql.auto_notify")
     @patch("sql.utils.execute_sql.Audit")
     def test_execute_callback_success(self, _audit, _notify):
         # 初始化工单执行返回对象
@@ -978,7 +978,7 @@ class TestExecuteSql(TestCase):
         )
         _notify.assert_called_once()
 
-    @patch("sql.utils.execute_sql.notify_for_execute")
+    @patch("sql.utils.execute_sql.auto_notify")
     @patch("sql.utils.execute_sql.Audit")
     def test_execute_callback_failure(self, _audit, _notify):
         # 初始化工单执行返回对象
@@ -1006,7 +1006,7 @@ class TestExecuteSql(TestCase):
         )
         _notify.assert_called_once()
 
-    @patch("sql.utils.execute_sql.notify_for_execute")
+    @patch("sql.utils.execute_sql.auto_notify")
     @patch("sql.utils.execute_sql.Audit")
     def test_execute_callback_failure_no_execute_result(self, _audit, _notify):
         # 初始化工单执行返回对象

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -155,11 +155,11 @@ class Audit(object):
         # 增加审核id
         result["data"]["audit_id"] = audit_detail.audit_id
         # 返回添加结果
-        return result
+        return result, audit_detail
 
     # 工单审核
     @staticmethod
-    def audit(audit_id, audit_status, audit_user, audit_remark):
+    def audit(audit_id, audit_status, audit_user, audit_remark) -> (dict, WorkflowAuditDetail):
         result = {"status": 0, "msg": "ok", "data": 0}
         audit_detail = WorkflowAudit.objects.get(audit_id=audit_id)
 
@@ -310,7 +310,7 @@ class Audit(object):
 
         # 返回审核结果
         result["data"] = {"workflow_status": audit_result.current_status}
-        return result
+        return result, audit_detail_result
 
     # 获取用户待办工单数量
     @staticmethod
@@ -340,7 +340,7 @@ class Audit(object):
 
     # 通过业务id获取审核信息
     @staticmethod
-    def detail_by_workflow_id(workflow_id, workflow_type):
+    def detail_by_workflow_id(workflow_id, workflow_type) -> WorkflowAudit:
         try:
             return WorkflowAudit.objects.get(
                 workflow_id=workflow_id, workflow_type=workflow_type

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -470,14 +470,16 @@ class Audit(object):
         operator,
         operator_display,
     ):
-        WorkflowLog(
+        log = WorkflowLog(
             audit_id=audit_id,
             operation_type=operation_type,
             operation_type_desc=operation_type_desc,
             operation_info=operation_info,
             operator=operator,
             operator_display=operator_display,
-        ).save()
+        )
+        log.save()
+        return log
 
     # 获取工单日志
     @staticmethod

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -159,7 +159,9 @@ class Audit(object):
 
     # 工单审核
     @staticmethod
-    def audit(audit_id, audit_status, audit_user, audit_remark) -> (dict, WorkflowAuditDetail):
+    def audit(
+        audit_id, audit_status, audit_user, audit_remark
+    ) -> (dict, WorkflowAuditDetail):
         result = {"status": 0, "msg": "ok", "data": 0}
         audit_detail = WorkflowAudit.objects.get(audit_id=audit_id)
 

--- a/sql_api/api_workflow.py
+++ b/sql_api/api_workflow.py
@@ -573,9 +573,11 @@ class ExecuteWorkflow(views.APIView):
                     else True
                 )
                 if is_notified:
-                    auto_notify(worflow=SqlWorkflow.objects.get(id=workflow_id),
-                                sys_config=sys_config,
-                                event_type=EventType.EXECUTE)
+                    auto_notify(
+                        worflow=SqlWorkflow.objects.get(id=workflow_id),
+                        sys_config=sys_config,
+                        event_type=EventType.EXECUTE,
+                    )
         # 执行数据归档工单
         elif workflow_type == 3:
             async_task(

--- a/sql_api/api_workflow.py
+++ b/sql_api/api_workflow.py
@@ -1,4 +1,3 @@
-import MySQLdb
 from django.contrib.auth.decorators import permission_required
 from django.utils.decorators import method_decorator
 from rest_framework import views, generics, status, serializers, permissions
@@ -134,24 +133,24 @@ class WorkflowList(generics.ListAPIView):
     def post(self, request):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        workflow_content = serializer.save()
         sys_config = SysConfig()
         is_notified = (
             "Apply" in sys_config.get("notify_phase_control").split(",")
             if sys_config.get("notify_phase_control")
             else True
         )
-        if serializer.workflow.workflow_status == "workflow_manreviewing" and is_notified:
+        if workflow_content.workflow.status == "workflow_manreviewing" and is_notified:
             # 获取审核信息
-            audit_id = Audit.detail_by_workflow_id(
-                workflow_id=serializer.workflow.id,
+            workflow_audit = Audit.detail_by_workflow_id(
+                workflow_id=workflow_content.workflow.id,
                 workflow_type=WorkflowDict.workflow_type["sqlreview"],
-            ).audit_id
+            )
             async_task(
                 notify_for_audit,
-                audit_id=audit_id,
+                workflow_audit=workflow_audit,
                 timeout=60,
-                task_name=f"sqlreview-submit-{serializer.workflow.id}",
+                task_name=f"sqlreview-submit-{workflow_content.workflow.id}",
             )
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
@@ -247,19 +246,19 @@ class AuditWorkflow(views.APIView):
                     ).audit_id
 
                     # 调用工作流接口审核
-                    audit_result = Audit.audit(
+                    audit_result, audit_detail = Audit.audit(
                         audit_id, audit_status, user.username, audit_remark
                     )
 
                     # 按照审核结果更新业务表审核状态
-                    audit_detail = Audit.detail(audit_id)
+                    workflow_audit = Audit.detail(audit_id)
                     if (
-                        audit_detail.workflow_type
+                        workflow_audit.workflow_type
                         == WorkflowDict.workflow_type["query"]
                     ):
                         # 更新业务表审核状态,插入权限信息
                         _query_apply_audit_call_back(
-                            audit_detail.workflow_id,
+                            workflow_audit.workflow_id,
                             audit_result["data"]["workflow_status"],
                         )
 
@@ -271,7 +270,7 @@ class AuditWorkflow(views.APIView):
                 async_task(
                     notify_for_audit,
                     audit_id=audit_id,
-                    audit_remark=audit_remark,
+                    audit_detail_id=audit_detail.audit_detail_id,
                     timeout=60,
                     task_name=f"query-priv-audit-{workflow_id}",
                 )
@@ -292,11 +291,12 @@ class AuditWorkflow(views.APIView):
                 try:
                     with transaction.atomic():
                         # 调用工作流接口审核
-                        audit_id = Audit.detail_by_workflow_id(
+                        workflow_audit = Audit.detail_by_workflow_id(
                             workflow_id=workflow_id,
                             workflow_type=WorkflowDict.workflow_type["sqlreview"],
-                        ).audit_id
-                        audit_result = Audit.audit(
+                        )
+                        audit_id = workflow_audit.audit_id
+                        audit_result, audit_detail = Audit.audit(
                             audit_id,
                             WorkflowDict.workflow_status["audit_success"],
                             user.username,
@@ -326,8 +326,8 @@ class AuditWorkflow(views.APIView):
                     if is_notified:
                         async_task(
                             notify_for_audit,
-                            audit_id=audit_id,
-                            audit_remark=audit_remark,
+                            workflow_audit=workflow_audit,
+                            workflow_audit_detail=audit_detail,
                             timeout=60,
                             task_name=f"sqlreview-pass-{workflow_id}",
                         )
@@ -354,7 +354,7 @@ class AuditWorkflow(views.APIView):
                         if workflow_detail.status != "workflow_manreviewing":
                             # 增加工单日志
                             if user.username == workflow_detail.engineer:
-                                Audit.add_log(
+                                _, audit_detail = Audit.add_log(
                                     audit_id=audit_id,
                                     operation_type=3,
                                     operation_type_desc="取消执行",
@@ -363,7 +363,7 @@ class AuditWorkflow(views.APIView):
                                     operator_display=user.display,
                                 )
                             else:
-                                Audit.add_log(
+                                _, audit_detail = Audit.add_log(
                                     audit_id=audit_id,
                                     operation_type=2,
                                     operation_type_desc="审批不通过",
@@ -373,7 +373,7 @@ class AuditWorkflow(views.APIView):
                                 )
                         else:
                             if user.username == workflow_detail.engineer:
-                                Audit.audit(
+                                _, audit_detail = Audit.audit(
                                     audit_id,
                                     WorkflowDict.workflow_status["audit_abort"],
                                     user.username,
@@ -381,7 +381,7 @@ class AuditWorkflow(views.APIView):
                                 )
                             # 非提交人需要校验审核权限
                             elif user.has_perm("sql.sql_review"):
-                                Audit.audit(
+                                _, audit_detail = Audit.audit(
                                     audit_id,
                                     WorkflowDict.workflow_status["audit_reject"],
                                     user.username,
@@ -411,18 +411,18 @@ class AuditWorkflow(views.APIView):
                         else True
                     )
                     if is_notified:
-                        audit_detail = Audit.detail_by_workflow_id(
+                        workflow_audit = Audit.detail_by_workflow_id(
                             workflow_id=workflow_id,
                             workflow_type=WorkflowDict.workflow_type["sqlreview"],
                         )
-                        if audit_detail.current_status in (
+                        if workflow_audit.current_status in (
                             WorkflowDict.workflow_status["audit_abort"],
                             WorkflowDict.workflow_status["audit_reject"],
                         ):
                             async_task(
                                 notify_for_audit,
-                                audit_id=audit_detail.audit_id,
-                                audit_remark=audit_remark,
+                                workflow_audit=workflow_audit,
+                                workflow_audit_detail=audit_detail,
                                 timeout=60,
                                 task_name=f"sqlreview-cancel-{workflow_id}",
                             )
@@ -446,9 +446,10 @@ class AuditWorkflow(views.APIView):
                     ).audit_id
 
                     # 调用工作流插入审核信息，更新业务表审核状态
-                    audit_status = Audit.audit(
+                    audit_status, audit_detail = Audit.audit(
                         audit_id, audit_status, user.username, audit_remark
-                    )["data"]["workflow_status"]
+                    )
+                    audit_status = audit_status["data"]["workflow_status"]
                     ArchiveConfig(
                         id=workflow_id,
                         status=audit_status,
@@ -464,7 +465,7 @@ class AuditWorkflow(views.APIView):
                 async_task(
                     notify_for_audit,
                     audit_id=audit_id,
-                    audit_remark=audit_remark,
+                    audit_detail_id=audit_detail.audit_detail_id,
                     timeout=60,
                     task_name=f"archive-audit-{workflow_id}",
                 )

--- a/sql_api/api_workflow.py
+++ b/sql_api/api_workflow.py
@@ -574,7 +574,7 @@ class ExecuteWorkflow(views.APIView):
                 )
                 if is_notified:
                     notify_for_execute(
-                        worflow=SqlWorkflow.objects.get(id=workflow_id),
+                        workflow=SqlWorkflow.objects.get(id=workflow_id),
                     )
         # 执行数据归档工单
         elif workflow_type == 3:

--- a/sql_api/api_workflow.py
+++ b/sql_api/api_workflow.py
@@ -28,7 +28,7 @@ from sql.utils.sql_review import can_cancel, can_execute, on_correct_time_period
 from sql.utils.resource_group import user_groups
 from sql.utils.workflow_audit import Audit
 from sql.utils.tasks import del_schedule
-from sql.notify import notify_for_audit, auto_notify, EventType
+from sql.notify import notify_for_audit, notify_for_execute
 from sql.query_privileges import _query_apply_audit_call_back
 from sql.engines import get_engine
 from common.utils.const import WorkflowDict
@@ -573,10 +573,8 @@ class ExecuteWorkflow(views.APIView):
                     else True
                 )
                 if is_notified:
-                    auto_notify(
+                    notify_for_execute(
                         worflow=SqlWorkflow.objects.get(id=workflow_id),
-                        sys_config=sys_config,
-                        event_type=EventType.EXECUTE,
                     )
         # 执行数据归档工单
         elif workflow_type == 3:

--- a/sql_api/api_workflow.py
+++ b/sql_api/api_workflow.py
@@ -240,10 +240,11 @@ class AuditWorkflow(views.APIView):
             # 使用事务保持数据一致性
             try:
                 with transaction.atomic():
-                    audit_id = Audit.detail_by_workflow_id(
+                    workflow_audit = Audit.detail_by_workflow_id(
                         workflow_id=workflow_id,
                         workflow_type=WorkflowDict.workflow_type["query"],
-                    ).audit_id
+                    )
+                    audit_id = workflow_audit.audit_id
 
                     # 调用工作流接口审核
                     audit_result, audit_detail = Audit.audit(
@@ -269,8 +270,8 @@ class AuditWorkflow(views.APIView):
                 # 消息通知
                 async_task(
                     notify_for_audit,
-                    audit_id=audit_id,
-                    audit_detail_id=audit_detail.audit_detail_id,
+                    workflow_audit=workflow_audit,
+                    workflow_audit_detail=audit_detail,
                     timeout=60,
                     task_name=f"query-priv-audit-{workflow_id}",
                 )
@@ -440,10 +441,11 @@ class AuditWorkflow(views.APIView):
             # 使用事务保持数据一致性
             try:
                 with transaction.atomic():
-                    audit_id = Audit.detail_by_workflow_id(
+                    workflow_audit = Audit.detail_by_workflow_id(
                         workflow_id=workflow_id,
                         workflow_type=WorkflowDict.workflow_type["archive"],
-                    ).audit_id
+                    )
+                    audit_id = workflow_audit.audit_id
 
                     # 调用工作流插入审核信息，更新业务表审核状态
                     audit_status, audit_detail = Audit.audit(
@@ -464,8 +466,8 @@ class AuditWorkflow(views.APIView):
                 # 消息通知
                 async_task(
                     notify_for_audit,
-                    audit_id=audit_id,
-                    audit_detail_id=audit_detail.audit_detail_id,
+                    workflow_audit=workflow_audit,
+                    workflow_audit_detail=audit_detail,
                     timeout=60,
                     task_name=f"archive-audit-{workflow_id}",
                 )

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -10,6 +10,8 @@ from sql.models import (
     ResourceGroup,
     WorkflowAudit,
     WorkflowLog,
+    QueryPrivilegesApply,
+    ArchiveConfig
 )
 from django.contrib.auth.models import Group
 from django.contrib.auth.password_validation import validate_password
@@ -246,6 +248,18 @@ class AliyunRdsSerializer(serializers.ModelSerializer):
     class Meta:
         model = AliyunRdsConfig
         fields = ("id", "rds_dbinstanceid", "is_enable", "instance", "ak")
+
+
+class QueryPrivilegesApplySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = QueryPrivilegesApply
+        fields = "__all__"
+
+
+class ArchiveConfigSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ArchiveConfig
+        fields = "__all__"
 
 
 class InstanceResourceSerializer(serializers.Serializer):

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -317,6 +317,8 @@ class ExecuteCheckResultSerializer(serializers.Serializer):
 
 
 class WorkflowSerializer(serializers.ModelSerializer):
+    instance = InstanceSerializer()
+
     def to_internal_value(self, data):
         if data.get("run_date_start") == "":
             data["run_date_start"] = None

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -317,8 +317,6 @@ class ExecuteCheckResultSerializer(serializers.Serializer):
 
 
 class WorkflowSerializer(serializers.ModelSerializer):
-    instance = InstanceSerializer()
-
     def to_internal_value(self, data):
         if data.get("run_date_start") == "":
             data["run_date_start"] = None

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -17,11 +17,9 @@ from django.contrib.auth.models import Group
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django_q.tasks import async_task
 from sql.engines import get_engine
 from sql.utils.workflow_audit import Audit
 from sql.utils.resource_group import user_instances
-from sql.notify import notify_for_audit
 from common.utils.const import WorkflowDict
 from common.config import SysConfig
 import traceback
@@ -433,26 +431,7 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
         except Exception as e:
             logger.error(f"提交工单报错，错误信息：{traceback.format_exc()}")
             raise serializers.ValidationError({"errors": str(e)})
-        else:
-            # 自动审核通过且开启了Apply阶段通知参数才发送消息通知
-            is_notified = (
-                "Apply" in sys_config.get("notify_phase_control").split(",")
-                if sys_config.get("notify_phase_control")
-                else True
-            )
-            if workflow_status == "workflow_manreviewing" and is_notified:
-                # 获取审核信息
-                audit_id = Audit.detail_by_workflow_id(
-                    workflow_id=workflow.id,
-                    workflow_type=WorkflowDict.workflow_type["sqlreview"],
-                ).audit_id
-                async_task(
-                    notify_for_audit,
-                    audit_id=audit_id,
-                    timeout=60,
-                    task_name=f"sqlreview-submit-{workflow.id}",
-                )
-            return workflow_content
+        return workflow_content
 
     class Meta:
         model = SqlWorkflowContent

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -11,7 +11,7 @@ from sql.models import (
     WorkflowAudit,
     WorkflowLog,
     QueryPrivilegesApply,
-    ArchiveConfig
+    ArchiveConfig,
 )
 from django.contrib.auth.models import Group
 from django.contrib.auth.password_validation import validate_password

--- a/sql_api/tests.py
+++ b/sql_api/tests.py
@@ -422,9 +422,7 @@ class TestWorkflow(APITestCase):
         self.token = r.data["access"]
         self.client.credentials(HTTP_AUTHORIZATION="Bearer " + self.token)
         SysConfig().set("api_user_whitelist", self.user.id)
-        self.notify_patcher = patch("sql_api.api_workflow.auto_notify")
-        self.notify_patcher2 = patch("sql.notify.auto_notify")
-        self.notify_patcher2.start()
+        self.notify_patcher = patch("sql.notify.auto_notify")
         self.notify_patcher.start()
 
     def tearDown(self):
@@ -436,7 +434,6 @@ class TestWorkflow(APITestCase):
         WorkflowAudit.objects.all().delete()
         WorkflowLog.objects.all().delete()
         self.notify_patcher.stop()
-        self.notify_patcher2.stop()
 
     def test_get_sql_workflow_list(self):
         """测试获取SQL上线工单列表"""


### PR DESCRIPTION
1. 重构 notify 部分的代码, 和engine 的类似, 也是提供一个 base Notifier, 属性有 workflow, audit, 都是原生的 django model, 开发者可以很方便地开发支持的通知方式
2. 增加 generic webhook 支持, 方便高度的定制需求.

fix https://github.com/hhyo/Archery/discussions/1480
