### PR TITLE
脱敏规则不区分大小写

### DIFF
--- a/sql/utils/data_masking.py
+++ b/sql/utils/data_masking.py
@@ -89,7 +89,7 @@ def analyze_query_tree(select_list, instance):
     """解析select list, 返回命中脱敏规则的列信息"""
     # 获取实例全部激活的脱敏字段信息，减少循环查询，提升效率
     masking_columns = {
-        f"{i.instance}-{i.table_schema}-{i.table_name}-{i.column_name}": model_to_dict(
+        f"{i.instance}-{i.table_schema}-{i.table_name}-{i.column_name.lower()}": model_to_dict(
             i
         )
         for i in DataMaskingColumns.objects.filter(instance=instance, active=True)

--- a/sql/utils/data_masking.py
+++ b/sql/utils/data_masking.py
@@ -102,6 +102,7 @@ def analyze_query_tree(select_list, instance):
             column.get("table"),
             column.get("field"),
         )
+        field = field.lower()
         masking_column = masking_columns.get(
             f"{instance}-{table_schema}-{table}-{field}"
         )


### PR DESCRIPTION
脱敏规则匹配时，统一转成小写进行匹配
https://github.com/hhyo/Archery/issues/2328