### PR TITLE
在不启用 oidc, dingding 认证时, 不include 对应的路由

### DIFF
--- a/archery/urls.py
+++ b/archery/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
 
 if settings.ENABLE_CAS:  # pragma: no cover
     import django_cas_ng.views
+
     # pragma: no cover
     urlpatterns += [
         path(

--- a/archery/urls.py
+++ b/archery/urls.py
@@ -6,8 +6,6 @@ from django.conf import settings
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include(("sql_api.urls", "sql_api"), namespace="sql_api")),
-    path("oidc/", include("mozilla_django_oidc.urls")),
-    path("dingding/", include("django_auth_dingding.urls")),
     path("", include(("sql.urls", "sql"), namespace="sql")),
 ]
 
@@ -20,6 +18,16 @@ if settings.ENABLE_CAS:
             django_cas_ng.views.LoginView.as_view(),
             name="cas-login",
         ),
+    ]
+
+if settings.ENABLE_OIDC:
+    urlpatterns += [
+        path("oidc/", include("mozilla_django_oidc.urls")),
+    ]
+
+if settings.ENABLE_DINGDING:
+    urlpatterns += [
+        path("dingding/", include("django_auth_dingding.urls")),
     ]
 
 handler400 = views.bad_request

--- a/archery/urls.py
+++ b/archery/urls.py
@@ -12,8 +12,7 @@ urlpatterns = [
 if settings.ENABLE_CAS:  # pragma: no cover
     import django_cas_ng.views
 
-    # pragma: no cover
-    urlpatterns += [
+    urlpatterns += [  # pragma: no cover
         path(
             "cas/authenticate/",
             django_cas_ng.views.LoginView.as_view(),

--- a/archery/urls.py
+++ b/archery/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
 
 if settings.ENABLE_CAS:  # pragma: no cover
     import django_cas_ng.views
-
+    # pragma: no cover
     urlpatterns += [
         path(
             "cas/authenticate/",

--- a/archery/urls.py
+++ b/archery/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     path("", include(("sql.urls", "sql"), namespace="sql")),
 ]
 
-if settings.ENABLE_CAS:
+if settings.ENABLE_CAS:  # pragma: no cover
     import django_cas_ng.views
 
     urlpatterns += [
@@ -20,12 +20,12 @@ if settings.ENABLE_CAS:
         ),
     ]
 
-if settings.ENABLE_OIDC:
+if settings.ENABLE_OIDC:  # pragma: no cover
     urlpatterns += [
         path("oidc/", include("mozilla_django_oidc.urls")),
     ]
 
-if settings.ENABLE_DINGDING:
+if settings.ENABLE_DINGDING:  # pragma: no cover
     urlpatterns += [
         path("dingding/", include("django_auth_dingding.urls")),
     ]

--- a/archery/urls.py
+++ b/archery/urls.py
@@ -12,13 +12,13 @@ urlpatterns = [
 if settings.ENABLE_CAS:  # pragma: no cover
     import django_cas_ng.views
 
-    urlpatterns += [  # pragma: no cover
+    urlpatterns += [
         path(
             "cas/authenticate/",
             django_cas_ng.views.LoginView.as_view(),
             name="cas-login",
         ),
-    ]
+    ]  # pragma: no cover
 
 if settings.ENABLE_OIDC:  # pragma: no cover
     urlpatterns += [


### PR DESCRIPTION
有利于精简相关的依赖, 有些用户可能不需要这类的依赖, 这样merge 之后, 即使没装也不会报错