### PR TITLE
修复表结构显示不正确的 bug

### DIFF
--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -703,11 +703,12 @@
             var active_li_id = sessionStorage.getItem('active_li_id');
             let active_li_title = sessionStorage.getItem('active_li_title');
             let tb_name
+            let need_describe_display = false
             if (data.status === 0) {
                 // 查看表结构默认新增tab，相同表结构获取不新增
                 if (result['full_sql'].match(/^show\s+create\s+table\s+(.*)/)) {
                     if (data.is_describe===undefined || !data.is_describe) {
-                        data.is_describe = true
+                        need_describe_display = true
                         tb_name = result['full_sql'].match(/^show\s+create\s+table\s+(.*);/)[1];
                     }
                 }
@@ -719,6 +720,9 @@
                         tab_add(tb_name);
                     }
                     n = sessionStorage.getItem('tab_num');
+                    if (result.column_list === ["table", "create table"]) {
+                        need_describe_display = true
+                    }
                 }
                 // 执行结果页默认不新增
                 else if (active_li_title.match(/^执行结果\d$/)) {
@@ -768,7 +772,7 @@
                             }
                         });
                     });
-                    if (data.is_describe) {
+                    if (need_describe_display) {
                         //初始化表结构显示
                         $("#" + ("query_result" + n)).bootstrapTable('destroy').bootstrapTable({
                                 escape: false,

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -707,8 +707,8 @@
             if (data.status === 0) {
                 // 查看表结构默认新增tab，相同表结构获取不新增
                 if (result['full_sql'].match(/^show\s+create\s+table\s+(.*)/)) {
+                    need_describe_display = true
                     if (data.is_describe===undefined || !data.is_describe) {
-                        need_describe_display = true
                         tb_name = result['full_sql'].match(/^show\s+create\s+table\s+(.*);/)[1];
                     }
                 }


### PR DESCRIPTION
fix #2378
fix #2402

之前的修改(#2230)中, 为了正常显示 cassandra 的表结构信息做的改动, 但是没有考虑到部分数据库的表结构信息并不是像 mysql 的一样, 如 mssql 和 oracle , pg 都是只有字段的列表, 类型, 是否主键等等. 为了兼容这种情况, 把前端重新修改了一下:

引入一个 need_describe_display  的变量, 只有在返回的结果集中, 字段列表为 "table", "create table" , 或语句和 mysql 的 show create table 类似时, 才调用显示表结构的函数, 其他情况下, 都使用普通的表格展示