### PR TITLE
修复最新基础镜像mssql连接问题

### DIFF
--- a/sql/engines/mssql.py
+++ b/sql/engines/mssql.py
@@ -16,7 +16,7 @@ class MssqlEngine(EngineBase):
     test_query = "SELECT 1"
 
     def get_connection(self, db_name=None):
-        connstr = """DRIVER=ODBC Driver 18ls for SQL Server;SERVER={0},{1};UID={2};PWD={3};
+        connstr = """DRIVER=ODBC Driver 18 for SQL Server;SERVER={0},{1};UID={2};PWD={3};
 client charset = UTF-8;connect timeout=10;CHARSET={4};TrustServerCertificate=yes;""".format(
             self.host,
             self.port,

--- a/sql/engines/mssql.py
+++ b/sql/engines/mssql.py
@@ -16,8 +16,8 @@ class MssqlEngine(EngineBase):
     test_query = "SELECT 1"
 
     def get_connection(self, db_name=None):
-        connstr = """DRIVER=ODBC Driver 17 for SQL Server;SERVER={0},{1};UID={2};PWD={3};
-client charset = UTF-8;connect timeout=10;CHARSET={4};""".format(
+        connstr = """DRIVER=ODBC Driver 18ls for SQL Server;SERVER={0},{1};UID={2};PWD={3};
+client charset = UTF-8;connect timeout=10;CHARSET={4};TrustServerCertificate=yes;""".format(
             self.host,
             self.port,
             self.user,


### PR DESCRIPTION
基础镜像更新了驱动版本，需要做些调整

参考：https://stackoverflow.com/questions/71732117/laravel-sql-server-error-odbc-driver-18-for-sql-serverssl-provider-error141