### PR TITLE
修复查询 tab 随意跳转的 bug

### DIFF
--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -713,7 +713,7 @@
                         tb_name = result['full_sql'].match(/^show\s+create\s+table\s+(.*);/)[1];
                     }
                 }
-                if (data.is_describe) {
+                if (data.is_describe || need_describe_display) {
                     if (tb_name === undefined) {
                         tb_name = $("#table_name").val();
                     }

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -995,6 +995,7 @@
                 complete: function () {
                     $('input[type=button]').removeClass('disabled');
                     $('input[type=button]').prop('disabled', false);
+                    optgroup_control();
                 },
                 success: function (data) {
                     var target = $("#instance_name").val()+"/"+$("#db_name").val();
@@ -1016,19 +1017,61 @@
     </script>
     <!-- common -->
     <script>
+        // 按钮和控制器展示配置
+        const defaultDisplayConfig = {
+            showTableName: true,
+            showSchemaName: false,
+            showFormat: true,
+            showExplain: true,
+            showRedisHelp: false,
+        }
+        const createDisplayConfig = function(extraArgs = null) {
+            if (extraArgs === null) {
+                extraArgs = {}
+            }
+            return Object.assign({}, defaultDisplayConfig, extraArgs)
+        }
+        const engineDisplayConfig = {
+            "MsSQL": createDisplayConfig({showExplain: false}),
+            "Redis": createDisplayConfig({showTableName: false, showSchemaName: false,
+                showRedisHelp: true,
+                showFormat: false, showExplain: false}),
+            "PgSQL": createDisplayConfig({showSchemaName: true}),
+            "Mongo": createDisplayConfig({showFormat: false}),
+            "Phoenix": createDisplayConfig({showExplain: false}),
+            // 如有特殊的显示需求, 在此处添加配置, 并在下方的optgroup_control中添加对应的控制逻辑
+            // 如无特殊需求, 可以直接不填写, 这样会使用默认配置
+        };
         //控制按钮和选择器显示
         function optgroup_control(change) {
-            var optgroup = $('#instance_name :selected').parent().attr('label');
-            if (change) {
-                $("#div-table_name").show();
-                $("#div-schema_name").hide();
-            }
-            $("#btn-format").attr('disabled', false);
-            $("#btn-explain").attr('disabled', false);
-            if (optgroup === "Redis") {
-                redis_help_tab_add();
+            let optgroup = $('#instance_name :selected').parent().attr('label');
+            let displayConfig = engineDisplayConfig[optgroup] || defaultDisplayConfig
+            if (displayConfig.showExplain) {
+                $("#btn-explain").attr('disabled', false);
             } else {
-                redis_help_tab_remove();
+                $("#btn-explain").attr('disabled', true);
+            }
+            if (displayConfig.showFormat) {
+                $("#btn-format").attr('disabled', false);
+            } else {
+                $("#btn-format").attr('disabled', true);
+            }
+            if (change) {
+                if (displayConfig.showTableName) {
+                    $("#div-table_name").show();
+                } else {
+                    $("#div-table_name").hide();
+                }
+                if (displayConfig.showSchemaName) {
+                    $("#div-schema_name").show();
+                } else {
+                    $("#div-schema_name").hide();
+                }
+                if (displayConfig.showRedisHelp) {
+                    redis_help_tab_add();
+                } else {
+                    redis_help_tab_remove();
+                }
             }
         }
 

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -1040,6 +1040,7 @@
             "PgSQL": createDisplayConfig({showSchemaName: true}),
             "Mongo": createDisplayConfig({showFormat: false}),
             "Phoenix": createDisplayConfig({showExplain: false}),
+            "Cassandra": createDisplayConfig({showExplain: false}),
             // 如有特殊的显示需求, 在此处添加配置, 并在下方的optgroup_control中添加对应的控制逻辑
             // 如无特殊需求, 可以直接不填写, 这样会使用默认配置
         };

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -702,7 +702,7 @@
             //获取当前的标签页,如果当前不在执行结果页，则默认新增一个页面
             var active_li_id = sessionStorage.getItem('active_li_id');
             let active_li_title = sessionStorage.getItem('active_li_title');
-            let tb_name
+            let tb_name, n
             let need_describe_display = false
             if (data.status === 0) {
                 // 查看表结构默认新增tab，相同表结构获取不新增
@@ -726,7 +726,7 @@
                 }
                 // 执行结果页默认不新增
                 else if (active_li_title.match(/^执行结果\d$/)) {
-                    let n = active_li_id.split("execute_result_tab")[1];
+                     n = active_li_id.split("execute_result_tab")[1];
                 } else {
                     tab_add();
                     n = sessionStorage.getItem('tab_num');
@@ -774,7 +774,7 @@
                     });
                     if (need_describe_display) {
                         //初始化表结构显示
-                        $("#" + ("query_result" + n)).bootstrapTable('destroy').bootstrapTable({
+                        $(`#query_result${n}`).bootstrapTable('destroy').bootstrapTable({
                                 escape: false,
                                 data: result['rows'],
                                 columns: [{
@@ -806,7 +806,7 @@
                             isdetail = true
                         }
                         var showExport = {{can_download}}===1
-                        $("#" + ('query_result' + n)).bootstrapTable('destroy').bootstrapTable({
+                        $(`#query_result${n}`).bootstrapTable('destroy').bootstrapTable({
                             escape: true,
                             data: result['rows'],
                             columns: columns,
@@ -995,7 +995,6 @@
                 complete: function () {
                     $('input[type=button]').removeClass('disabled');
                     $('input[type=button]').prop('disabled', false);
-                    optgroup_control();
                 },
                 success: function (data) {
                     var target = $("#instance_name").val()+"/"+$("#db_name").val();

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -633,8 +633,9 @@
         //先做表单验证，验证成功再成功提交执行计划查看
         $("#btn-explain").click(function () {
                 if (sqlquery_validate()) {
-                    $('input[type=button]').addClass('disabled');
-                    $('input[type=button]').prop('disabled', true);
+                    const inputButton = $('input[type=button]')
+                    inputButton.addClass('disabled');
+                    inputButton.prop("disabled", true)
                     sqlquery('explain')
                 }
             }
@@ -1355,36 +1356,28 @@
         });
 
         function show(o) {
-            if (o.value == "key") {
-                document.getElementById("keyHelp").style.display = "block";
-                document.getElementById("stringHelp").style.display = "none";
-                document.getElementById("hashHelp").style.display = "none";
-                document.getElementById("setHelp").style.display = "none";
-                document.getElementById("zsetHelp").style.display = "none";
-            } else if (o.value == "string") {
-                document.getElementById("keyHelp").style.display = "none";
-                document.getElementById("stringHelp").style.display = "block";
-                document.getElementById("hashHelp").style.display = "none";
-                document.getElementById("setHelp").style.display = "none";
-                document.getElementById("zsetHelp").style.display = "none";
-            } else if (o.value == "hash") {
-                document.getElementById("keyHelp").style.display = "none";
-                document.getElementById("stringHelp").style.display = "none";
-                document.getElementById("hashHelp").style.display = "block";
-                document.getElementById("setHelp").style.display = "none";
-                document.getElementById("zsetHelp").style.display = "none";
-            } else if (o.value == "set") {
-                document.getElementById("keyHelp").style.display = "none";
-                document.getElementById("stringHelp").style.display = "none";
-                document.getElementById("hashHelp").style.display = "none";
-                document.getElementById("setHelp").style.display = "block";
-                document.getElementById("zsetHelp").style.display = "none";
-            } else if (o.value == "zset") {
-                document.getElementById("keyHelp").style.display = "none";
-                document.getElementById("stringHelp").style.display = "none";
-                document.getElementById("hashHelp").style.display = "none";
-                document.getElementById("setHelp").style.display = "none";
-                document.getElementById("zsetHelp").style.display = "block";
+            let allHelpPages = ["keyHelp", "stringHelp", "hashHelp", "setHelp", "zsetHelp"]
+            allHelpPages.forEach(function (item) {
+                document.getElementById(item).style.display = "none";
+            })
+            switch(o.value) {
+                case "key":
+                    document.getElementById("keyHelp").style.display = "block";
+                    break;
+                case "string":
+                    document.getElementById("stringHelp").style.display = "block";
+                    break;
+                case "hash":
+                    document.getElementById("hashHelp").style.display = "block";
+                    break;
+                case "set":
+                    document.getElementById("setHelp").style.display = "block";
+                    break;
+                case "zset":
+                    document.getElementById("zsetHelp").style.display = "block";
+                    break;
+                default:
+                    break;
             }
         }
     </script>

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -726,7 +726,7 @@
                 }
                 // 执行结果页默认不新增
                 else if (active_li_title.match(/^执行结果\d$/)) {
-                     n = active_li_id.split("execute_result_tab")[1];
+                    n = active_li_id.split("execute_result_tab")[1];
                 } else {
                     tab_add();
                     n = sessionStorage.getItem('tab_num');


### PR DESCRIPTION
fix #2290
fix #2267 

主要问题都是 #2230 没有还原之前的逻辑

有几个问题:
1. let 的作用域仅在当前的大括号内, 所以应该预先定义, 后续重新赋值
2. 相同表结构查看没有复用结果tab
3. 各个引擎的自定义显示没有复刻

这几个问题都已经修复了, mongo 的表结构显示也看了下, 现在可以正常显示了