### PR TITLE
在前端独立展示审批流

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -190,3 +190,9 @@ def create_audit_workflow(normal_user, create_resource_group):
     )
     yield audit_wf
     audit_wf.delete()
+
+
+@pytest.fixture
+def clean_auth_group(db):
+    yield
+    Group.objects.all().delete()

--- a/sql/templates/archivedetail.html
+++ b/sql/templates/archivedetail.html
@@ -21,18 +21,20 @@
     <input type="hidden" id="sqlMaxRowNumber" value="{{ rows|length }}">
     <input type="hidden" id="editSqlContent" value="{{ archive_config.sql_content }}"/>
     <hr>
+    <h4>
+        审批流
+    </h4>
+    <h5>
+    {% include "workflow_display.html" %}
+    <h4>
+        其他信息
+    </h4>
     <table data-toggle="table" class="table table-striped table-hover"
            style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
         <thead>
         <tr>
             <th>
                 申请人
-            </th>
-            <th>
-                审批流程
-            </th>
-            <th>
-                当前审批
             </th>
             <th>
                 实例
@@ -64,12 +66,6 @@
         <tr class="success">
             <td>
                 {{ archive_config.user_display }}
-            </td>
-            <td>
-                {{ audit_auth_group }}
-            </td>
-            <td>
-                {{ current_audit_auth_group }}
             </td>
             <td>
                 {{ archive_config.src_instance }}
@@ -240,7 +236,7 @@
         <br>
     {% endif %}
     {% if archive_config.status == 0 %}
-        {% if is_can_review %}
+        {% if can_review %}
             <textarea id="remark" name="remark" class="form-control" data-name="审核备注"
                       placeholder="请填写审核备注" rows=3></textarea>
             <br>

--- a/sql/templates/detail.html
+++ b/sql/templates/detail.html
@@ -18,18 +18,20 @@
     <input type="hidden" id="sqlMaxRowNumber" value="{{ rows|length }}">
     <input type="hidden" id="editSqlContent" value="{{ workflow_detail.sqlworkflowcontent.sql_content }}"/>
     <hr>
+    <h4>
+        审批流
+    </h4>
+    <h5>
+    {% include "workflow_display.html" %}
+    <h4>
+        其他信息
+    </h4>
     <table data-toggle="table" class="table table-striped table-hover"
            style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
         <thead>
         <tr>
             <th>
                 发起人
-            </th>
-            <th>
-                审批流程
-            </th>
-            <th>
-                当前审批
             </th>
             <th>
                 目标实例
@@ -64,12 +66,6 @@
         <tr class="success">
             <td>
                 {{ workflow_detail.engineer_display }}
-            </td>
-            <td>
-                {{ audit_auth_group }}
-            </td>
-            <td>
-                {{ current_audit_auth_group }}
             </td>
             <td>
                 {{ workflow_detail.instance.instance_name }}

--- a/sql/templates/queryapplydetail.html
+++ b/sql/templates/queryapplydetail.html
@@ -10,18 +10,20 @@
     <input type="hidden" id="sqlMaxRowNumber" value="{{ rows|length }}">
     <input type="hidden" id="editSqlContent" value="{{ workflow_detail.sql_content }}"/>
     <hr>
+    <h4>
+        审批流
+    </h4>
+    <h5>
+    {% include "workflow_display.html" %}
+    <h4>
+        其他信息
+    </h4>
     <table data-toggle="table" class="table table-striped table-hover"
            style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
         <thead>
         <tr>
             <th>
                 申请人
-            </th>
-            <th>
-                审批流程
-            </th>
-            <th>
-                当前审批
             </th>
             <th>
                 实例
@@ -53,12 +55,6 @@
         <tr class="success">
             <td>
                 {{ workflow_detail.user_display }}
-            </td>
-            <td>
-                {{ audit_auth_group }}
-            </td>
-            <td>
-                {{ current_audit_auth_group }}
             </td>
             <td>
                 {{ workflow_detail.instance.instance_name }}

--- a/sql/templates/workflow_display.html
+++ b/sql/templates/workflow_display.html
@@ -1,0 +1,19 @@
+{# review_info 应为 ReviewInfo 对象, 本模板为所有用到 audit 工作流的审批共用 #}
+{% for n in review_info.nodes %}
+    {% if n.is_passed_node %}
+        <span class="text-success">{{ n.group.name }}</span>
+    {% elif n.is_current_node %}
+    <!-- 当前节点 -->
+        <u class="text-danger">
+            {{ n.group.name }}(
+            {% for u in n.group.user_set.all %}
+            <span class="text-primary">{{ u.username }}</span>
+            {% endfor %})
+        </u>
+    {% else %}
+        {{ n.group.name }}
+    {% endif %}
+    {% if not forloop.last %}
+        <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span>
+    {% endif %}
+{% endfor %}

--- a/sql/test_notify.py
+++ b/sql/test_notify.py
@@ -131,9 +131,9 @@ class TestNotify(TestCase):
             workflow_type=1,
             workflow_title="申请标题",
             workflow_remark="申请备注",
-            audit_auth_groups="1,2,3",
-            current_audit="1",
-            next_audit="2",
+            audit_auth_groups=",".join([str(self.aug.id)]),
+            current_audit=str(self.aug.id),
+            next_audit="-1",
             current_status=0,
         )
         self.audit_query_detail = WorkflowAuditDetail.objects.create(
@@ -167,9 +167,9 @@ class TestNotify(TestCase):
             workflow_type=3,
             workflow_title=self.archive_apply.title,
             workflow_remark="申请备注",
-            audit_auth_groups="1,2,3",
-            current_audit="1",
-            next_audit="2",
+            audit_auth_groups=",".join([str(self.aug.id)]),
+            current_audit=str(self.aug.id),
+            next_audit="-1",
             current_status=0,
         )
 

--- a/sql/test_workflow.py
+++ b/sql/test_workflow.py
@@ -19,7 +19,8 @@ def test_get_sql_workflow(
     assert response.status_code == 200
     assertTemplateUsed(response, "detail.html")
     # 展示审批人用户名
-    assert (
-        response.context["current_audit_auth_group"]
-        == f"{create_auth_group.name}: {super_user.username}"
+    review_info = response.context["review_info"]
+    assert len(review_info.nodes) == len(
+        fake_generate_audit_setting.return_value.audit_auth_groups
     )
+    assert review_info.nodes[0].group.name == create_auth_group.name

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -825,52 +825,6 @@ class TestWorkflowView(TransactionTestCase):
             r, f"/detail/{self.wf1.id}/", fetch_redirect_response=False
         )
 
-    @patch("sql.utils.workflow_audit.Audit.logs")
-    @patch("sql.utils.workflow_audit.Audit.detail_by_workflow_id")
-    @patch("sql.utils.workflow_audit.Audit.review_info")
-    @patch("sql.utils.workflow_audit.Audit.can_review")
-    def testWorkflowDetailView(self, _can_review, _review_info, _detail_by_id, _logs):
-        """测试工单详情"""
-        _review_info.return_value = ("some_auth_group", "current_auth_group")
-        _can_review.return_value = False
-        _detail_by_id.return_value.audit_id = 123
-        _logs.return_value.latest("id").operation_info = ""
-        c = Client()
-        c.force_login(self.u1)
-        r = c.get("/detail/{}/".format(self.wf1.id))
-        expected_status_display = r"""id="workflow_detail_disaply">已正常结束"""
-        self.assertContains(r, expected_status_display)
-        exepcted_status = r"""id="workflow_detail_status">workflow_finish"""
-        self.assertContains(r, exepcted_status)
-
-        # 测试执行详情解析失败
-        self.wfc1.execute_result = "cannotbedecode:1,:"
-        self.wfc1.save()
-        r = c.get("/detail/{}/".format(self.wf1.id))
-        self.assertContains(r, expected_status_display)
-        self.assertContains(r, exepcted_status)
-
-        # 执行详情为空
-        self.wfc1.review_content = [
-            {
-                "id": 1,
-                "stage": "CHECKED",
-                "errlevel": 0,
-                "stagestatus": "Audit completed",
-                "errormessage": "None",
-                "sql": "use archery",
-                "affected_rows": 0,
-                "sequence": "'0_0_0'",
-                "backup_dbname": "None",
-                "execute_time": "0",
-                "sqlsha1": "",
-                "actual_affected_rows": "",
-            }
-        ]
-        self.wfc1.execute_result = ""
-        self.wfc1.save()
-        r = c.get("/detail/{}/".format(self.wf1.id))
-
     def testWorkflowListView(self):
         """测试工单列表"""
         c = Client()

--- a/sql/utils/test_workflow_audit.py
+++ b/sql/utils/test_workflow_audit.py
@@ -532,17 +532,17 @@ def test_get_review_info(
     audit = AuditV2(workflow=sql_query_apply)
     audit.create_audit()
     review_info = audit.get_review_info()
-    assert review_info[0].group.name == create_auth_group.name
-    assert review_info[0].is_current_node is True
-    assert review_info[0].is_passed_node is False
-    assert review_info[1].is_current_node is False
-    assert review_info[1].is_passed_node is False
+    assert review_info.nodes[0].group.name == create_auth_group.name
+    assert review_info.nodes[0].is_current_node is True
+    assert review_info.nodes[0].is_passed_node is False
+    assert review_info.nodes[1].is_current_node is False
+    assert review_info.nodes[1].is_passed_node is False
 
     # 将当前节点设置为第二个节点, 重新生成
     audit.audit.current_audit = str(g2.id)
     audit.audit.save()
     review_info = audit.get_review_info()
-    assert review_info[0].is_current_node is False
-    assert review_info[0].is_passed_node is True
-    assert review_info[1].is_current_node is True
-    assert review_info[1].is_passed_node is False
+    assert review_info.nodes[0].is_current_node is False
+    assert review_info.nodes[0].is_passed_node is True
+    assert review_info.nodes[1].is_current_node is True
+    assert review_info.nodes[1].is_passed_node is False

--- a/sql/utils/test_workflow_audit.py
+++ b/sql/utils/test_workflow_audit.py
@@ -302,34 +302,6 @@ class TestAudit(TestCase):
                 self.user, self.audit.workflow_id, self.audit.workflow_type
             )
 
-    def test_review_info_no_review(self):
-        """测试获取当前工单审批流程和当前审核组，无需审批"""
-        self.audit.workflow_type = WorkflowType.SQL_REVIEW
-        self.audit.workflow_id = self.wf.id
-        self.audit.audit_auth_groups = ""
-        self.audit.current_audit = "-1"
-        self.audit.save()
-        audit_auth_group, current_audit_auth_group = Audit.review_info(
-            self.audit.workflow_id, self.audit.workflow_type
-        )
-        self.assertEqual(audit_auth_group, "无需审批")
-        self.assertEqual(current_audit_auth_group, None)
-
-    def test_review_info(self):
-        """测试获取当前工单审批流程和当前审核组，无需审批"""
-        aug = Group.objects.create(name="DBA")
-        self.user.groups.add(aug)
-        self.audit.workflow_type = WorkflowType.SQL_REVIEW
-        self.audit.workflow_id = self.wf.id
-        self.audit.audit_auth_groups = str(aug.id)
-        self.audit.current_audit = str(aug.id)
-        self.audit.save()
-        audit_auth_group, current_audit_auth_group = Audit.review_info(
-            self.audit.workflow_id, self.audit.workflow_type
-        )
-        self.assertEqual(audit_auth_group, "DBA")
-        self.assertEqual(current_audit_auth_group, f"DBA: {self.user.username}")
-
     def test_logs(self):
         """测试获取工单日志"""
         r = Audit.logs(self.audit.audit_id).first()
@@ -543,3 +515,34 @@ def test_auto_review_not_applicable(
     audit.sys_config.set("auto_review_max_update_rows", 1000)
     # 全部条件满足, 自动审核通过
     assert audit.is_auto_review() is True
+
+
+def test_get_review_info(
+    sql_query_apply,
+    resource_group,
+    create_auth_group,
+    fake_generate_audit_setting,
+    clean_auth_group,
+):
+    g2 = Group.objects.create(name="g2")
+    g3 = Group.objects.create(name="g3")
+    fake_generate_audit_setting.return_value = AuditSetting(
+        auto_pass=False, audit_auth_groups=[create_auth_group.id, g2.id, g3.id]
+    )
+    audit = AuditV2(workflow=sql_query_apply)
+    audit.create_audit()
+    review_info = audit.get_review_info()
+    assert review_info[0].group.name == create_auth_group.name
+    assert review_info[0].is_current_node is True
+    assert review_info[0].is_passed_node is False
+    assert review_info[1].is_current_node is False
+    assert review_info[1].is_passed_node is False
+
+    # 将当前节点设置为第二个节点, 重新生成
+    audit.audit.current_audit = str(g2.id)
+    audit.audit.save()
+    review_info = audit.get_review_info()
+    assert review_info[0].is_current_node is False
+    assert review_info[0].is_passed_node is True
+    assert review_info[1].is_current_node is True
+    assert review_info[1].is_passed_node is False

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -676,29 +676,6 @@ class Audit(object):
                         result = True
         return result
 
-    # 获取当前工单审批流程和当前审核组
-    @staticmethod
-    def review_info(workflow_id, workflow_type) -> (List[str], Optional[Group]):
-        audit_info = WorkflowAudit.objects.get(
-            workflow_id=workflow_id, workflow_type=workflow_type
-        )
-        if audit_info.audit_auth_groups == "":
-            audit_auth_group = ["无需审批"]
-        else:
-            try:
-                audit_auth_group = [
-                    Group.objects.get(id=auth_group_id).name
-                    for auth_group_id in audit_info.audit_auth_groups.split(",")
-                ]
-            except Group.DoesNotExist:
-                audit_auth_group = [audit_info.audit_auth_groups]
-        if audit_info.current_audit == "-1":
-            current_audit_auth_group = None
-        else:
-            auth_group_in_db = Group.objects.get(id=audit_info.current_audit)
-            current_audit_auth_group = auth_group_in_db
-        return audit_auth_group, current_audit_auth_group
-
     # 新增工单日志
     @staticmethod
     def add_log(

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -509,6 +509,7 @@ class AuditV2:
         如果总体是待审核状态, 当前节点之前为已通过, 当前节点为当前节点, 未通过, 当前节点之后为未通过
         如果总体为其他状态, 节点的属性都不设置, 均为默认值
         """
+        self.get_audit_info()
         review_nodes = []
         has_met_current_node = False
         current_node_group_id = int(self.audit.current_audit)

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -36,6 +36,45 @@ class AuditException(Exception):
 
 
 @dataclass
+class ReviewNode:
+    group: Group
+    is_current_node: bool = False
+    is_passed_node: bool = False
+
+
+@dataclass
+class ReviewInfo:
+    nodes: List[ReviewNode] = field(default_factory=list)
+    current_node_index: int = None
+
+    @property
+    def readable_info(self) -> str:
+        """生成可读的工作流, 形如 g1(passed) -> g2(current) -> g3
+        一般用途是渲染消息
+        """
+        steps = []
+        for index, n in enumerate(self.nodes):
+            if n.is_current_node:
+                self.current_node_index = index
+                steps.append(f"{n.group.name}(current)")
+                continue
+            if n.is_passed_node:
+                steps.append(f"{n.group.name}(passed)")
+                continue
+            steps.append(n.group.name)
+        return " -> ".join(steps)
+
+    @property
+    def current_node(self) -> ReviewNode:
+        if self.current_node_index:
+            return self.nodes[self.current_node_index]
+        for index, n in enumerate(self.nodes):
+            if n.is_current_node:
+                self.current_node_index = n
+                return n
+
+
+@dataclass
 class AuditSetting:
     """
     audit_auth_groups 为 django 组的 id
@@ -283,7 +322,7 @@ class AuditV2:
         return "工单已正常提交"
 
     def can_operate(self, action: WorkflowAction, actor: Users):
-        """检查用户是否有权限做相关操作, 默认不返回, 如有权限问题, raise AuditException"""
+        """检查用户是否有权限做相关操作, 如有权限问题, raise AuditException, 无问题返回 True"""
         # 首先检查工单状态和相关操作是否匹配, 如已通过的工单不能再通过
         allowed_actions = SUPPORTED_OPERATION_GRID.get(self.audit.current_status)
         if not allowed_actions:
@@ -306,12 +345,12 @@ class AuditV2:
         if action == WorkflowAction.ABORT:
             if actor.username != self.audit.create_user:
                 raise AuditException(f"只有工单提交者可以撤回工单")
-            return
+            return True
         if action in [WorkflowAction.PASS, WorkflowAction.REJECT]:
             # 需要检查权限
             # 超级用户可以审批所有工单
             if actor.is_superuser:
-                return
+                return True
             # 看是否本人审核
             if actor.username == self.audit.create_user and self.sys_config.get(
                 "ban_self_audit"
@@ -328,14 +367,14 @@ class AuditV2:
                 raise AuditException("当前审批权限组不存在, 请联系管理员检查并清洗错误数据")
             if not auth_group_users([audit_auth_group.name], self.resource_group_id):
                 raise AuditException("用户不在当前审批审批节点的用户组内, 无权限审核")
-            return
+            return True
         if action in [
             WorkflowAction.EXECUTE_START,
             WorkflowAction.EXECUTE_END,
             WorkflowAction.EXECUTE_SET_TIME,
         ]:
             # 一般是系统自动流转, 自动通过
-            return
+            return True
 
         raise AuditException(f"不支持的操作, 无法判断权限")
 
@@ -465,6 +504,54 @@ class AuditV2:
         )
         return workflow_audit_detail
 
+    def get_review_info(self) -> ReviewInfo:
+        """提供审批流各节点的状态
+        如果总体是待审核状态, 当前节点之前为已通过, 当前节点为当前节点, 未通过, 当前节点之后为未通过
+        如果总体为其他状态, 节点的属性都不设置, 均为默认值
+        """
+        review_nodes = []
+        has_met_current_node = False
+        current_node_group_id = int(self.audit.current_audit)
+        for g in self.audit.audit_auth_groups.split(","):
+            g = int(g)
+            group_in_db = Group.objects.get(id=g)
+            if self.audit.current_status != WorkflowStatus.WAITING:
+                # 总体状态不是待审核, 不设置详细的属性
+                review_nodes.append(
+                    ReviewNode(
+                        group=group_in_db,
+                    )
+                )
+                continue
+            if current_node_group_id == g:
+                # 当前节点, 一定为未通过
+                has_met_current_node = True
+                review_nodes.append(
+                    ReviewNode(
+                        group=group_in_db,
+                        is_current_node=True,
+                        is_passed_node=False,
+                    )
+                )
+                continue
+            if has_met_current_node:
+                # 当前节点之后的节点, 一定为未通过
+                review_nodes.append(
+                    ReviewNode(
+                        group=group_in_db,
+                        is_passed_node=False,
+                    )
+                )
+                continue
+            # 以上情况之外的情况, 一定为已经通过的节点
+            review_nodes.append(
+                ReviewNode(
+                    group=group_in_db,
+                    is_passed_node=True,
+                )
+            )
+        return ReviewInfo(nodes=review_nodes)
+
 
 class Audit(object):
     """老版 Audit, 建议不再更新新内容, 转而使用 AuditV2"""
@@ -590,32 +677,25 @@ class Audit(object):
 
     # 获取当前工单审批流程和当前审核组
     @staticmethod
-    def review_info(workflow_id, workflow_type):
+    def review_info(workflow_id, workflow_type) -> (List[str], Optional[Group]):
         audit_info = WorkflowAudit.objects.get(
             workflow_id=workflow_id, workflow_type=workflow_type
         )
         if audit_info.audit_auth_groups == "":
-            audit_auth_group = "无需审批"
+            audit_auth_group = ["无需审批"]
         else:
             try:
-                audit_auth_group = "->".join(
-                    [
-                        Group.objects.get(id=auth_group_id).name
-                        for auth_group_id in audit_info.audit_auth_groups.split(",")
-                    ]
-                )
-            except Exception:
-                audit_auth_group = audit_info.audit_auth_groups
+                audit_auth_group = [
+                    Group.objects.get(id=auth_group_id).name
+                    for auth_group_id in audit_info.audit_auth_groups.split(",")
+                ]
+            except Group.DoesNotExist:
+                audit_auth_group = [audit_info.audit_auth_groups]
         if audit_info.current_audit == "-1":
             current_audit_auth_group = None
         else:
-            try:
-                auth_group_in_db = Group.objects.get(id=audit_info.current_audit)
-                users = auth_group_in_db.user_set.all()
-                users_display = ",".join(x.username for x in users) or "组内无用户, 请联系管理员"
-                current_audit_auth_group = f"{auth_group_in_db.name}: {users_display}"
-            except Exception:
-                current_audit_auth_group = audit_info.current_audit
+            auth_group_in_db = Group.objects.get(id=audit_info.current_audit)
+            current_audit_auth_group = auth_group_in_db
         return audit_auth_group, current_audit_auth_group
 
     # 新增工单日志

--- a/sql/views.py
+++ b/sql/views.py
@@ -212,12 +212,6 @@ def detail(request, workflow_id):
             last_operation_info = (
                 Audit.logs(audit_id=audit_id).latest("id").operation_info
             )
-            # 等待审批的展示当前全部审批人
-            if workflow_detail.status == "workflow_manreviewing":
-                _, current_audit_users_display = Audit.review_info(
-                    workflow_id, WorkflowType.SQL_REVIEW
-                )
-                last_operation_info += f"，当前审批节点：{current_audit_users_display}"
         except Exception as e:
             logger.debug(f"无审核日志记录，错误信息{e}")
             last_operation_info = ""

--- a/sql/views.py
+++ b/sql/views.py
@@ -32,7 +32,7 @@ from .models import (
     AuditEntry,
     TwoFactorAuthConfig,
 )
-from sql.utils.workflow_audit import Audit
+from sql.utils.workflow_audit import Audit, AuditV2, AuditException
 from sql.utils.sql_review import (
     can_execute,
     can_timingtask,
@@ -40,7 +40,7 @@ from sql.utils.sql_review import (
     can_view,
     can_rollback,
 )
-from common.utils.const import Const, WorkflowType
+from common.utils.const import Const, WorkflowType, WorkflowAction
 from sql.utils.resource_group import user_groups, user_instances, auth_group_users
 
 import logging
@@ -185,13 +185,12 @@ def submit_sql(request):
 def detail(request, workflow_id):
     """展示SQL工单详细页面"""
     workflow_detail = get_object_or_404(SqlWorkflow, pk=workflow_id)
+    audit_handler = AuditV2(workflow=workflow_detail)
     if not can_view(request.user, workflow_id):
         raise PermissionDenied
+    review_info = audit_handler.get_review_info()
     # 自动审批不通过的不需要获取下列信息
     if workflow_detail.status != "workflow_autoreviewwrong":
-        # 获取当前审批和审批流程
-        audit_auth_group, current_audit_auth_group = Audit.review_info(workflow_id, 2)
-
         # 是否可审核
         is_can_review = Audit.can_review(request.user, workflow_id, 2)
         # 是否可执行 TODO 这几个判断方法入参都修改为workflow对象，可减少多次数据库交互
@@ -223,8 +222,6 @@ def detail(request, workflow_id):
             logger.debug(f"无审核日志记录，错误信息{e}")
             last_operation_info = ""
     else:
-        audit_auth_group = "系统自动驳回"
-        current_audit_auth_group = "系统自动驳回"
         is_can_review = False
         is_can_execute = False
         is_can_timingtask = False
@@ -254,9 +251,8 @@ def detail(request, workflow_id):
         "is_can_timingtask": is_can_timingtask,
         "is_can_cancel": is_can_cancel,
         "is_can_rollback": is_can_rollback,
-        "audit_auth_group": audit_auth_group,
+        "review_info": review_info,
         "manual": manual,
-        "current_audit_auth_group": current_audit_auth_group,
         "run_date": run_date,
     }
     return render(request, "detail.html", context)
@@ -348,7 +344,8 @@ def queryapplydetail(request, apply_id):
     """查询权限申请详情页面"""
     workflow_detail = QueryPrivilegesApply.objects.get(apply_id=apply_id)
     # 获取当前审批和审批流程
-    audit_auth_group, current_audit_auth_group = Audit.review_info(apply_id, 1)
+    audit_handler = AuditV2(workflow=workflow_detail)
+    review_info = audit_handler.get_review_info()
 
     # 是否可审核
     is_can_review = Audit.can_review(request.user, apply_id, 1)
@@ -369,9 +366,8 @@ def queryapplydetail(request, apply_id):
 
     context = {
         "workflow_detail": workflow_detail,
-        "audit_auth_group": audit_auth_group,
+        "review_info": review_info,
         "last_operation_info": last_operation_info,
-        "current_audit_auth_group": current_audit_auth_group,
         "is_can_review": is_can_review,
     }
     return render(request, "queryapplydetail.html", context)
@@ -469,13 +465,15 @@ def archive_detail(request, id):
     """归档详情页面"""
     archive_config = ArchiveConfig.objects.get(pk=id)
     # 获取当前审批和审批流程、是否可审核
+    audit_handler = AuditV2(
+        workflow=archive_config, resource_group=archive_config.resource_group
+    )
+    review_info = audit_handler.get_review_info()
     try:
-        audit_auth_group, current_audit_auth_group = Audit.review_info(id, 3)
-        is_can_review = Audit.can_review(request.user, id, 3)
-    except Exception as e:
-        logger.debug(f"归档配置{id}无审核信息，{e}")
-        audit_auth_group, current_audit_auth_group = None, None
-        is_can_review = False
+        audit_handler.can_operate(WorkflowAction.PASS, request.user)
+        can_review = True
+    except AuditException:
+        can_review = False
     # 获取审核日志
     if archive_config.status == 2:
         try:
@@ -493,10 +491,9 @@ def archive_detail(request, id):
 
     context = {
         "archive_config": archive_config,
-        "audit_auth_group": audit_auth_group,
+        "review_info": review_info,
         "last_operation_info": last_operation_info,
-        "current_audit_auth_group": current_audit_auth_group,
-        "is_can_review": is_can_review,
+        "can_review": can_review,
     }
     return render(request, "archivedetail.html", context)
 


### PR DESCRIPTION
![图片](https://github.com/hhyo/Archery/assets/4143818/628311b6-cd10-4061-bc1d-edc309c80981)


https://github.com/hhyo/Archery/pull/2394 合并之后, 发现表格有时候会太宽了, 尤其是节点比较多, 节点名字比较长的情况

所以把这一块直接独立出来了

独立同时也把 query, 上线工单, archive 工单的审批流展示统一了, 现在都是一样都会显示审批流

TODO: 
1. 可能要补一下测试
2. 有一点残留的老 review_info 没删, 等删除了统一把方法也清理掉