### PR TITLE
mongo语法解析中NumberLong判断的bug修复

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -231,7 +231,7 @@ class JsonDecoder:
                 date_content = date_regex.findall(outstr)
                 if len(date_content) > 0:
                     return parse(date_content[0], yearfirst=True)
-            elif data_type.replace(" ", "") in ("NumberLong"):
+            elif data_type.replace(" ", "") in ("NumberLong",):
                 nuStr = re.findall(r"NumberLong\(.*?\)", outstr)  # 单独处理NumberLong
                 if len(nuStr) > 0:
                     id_str = re.findall(r"\(.*?\)", nuStr[0])

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1503,8 +1503,10 @@ class MongoTest(TestCase):
     @patch("sql.engines.mongo.MongoEngine.get_connection")
     def test_query(self, mock_get_connection):
         # TODO 正常查询还没做
-        test_sql = """db.job.find().count()"""
-        self.assertIsInstance(self.engine.query("some_db", test_sql), ResultSet)
+        test_sql1 = """db.job.find().count()"""
+        test_sql2 = """db.job.find({ goofy :{"$exists":false}})"""
+        self.assertIsInstance(self.engine.query("some_db", test_sql1), ResultSet)
+        self.assertIsInstance(self.engine.query("some_db", test_sql2), ResultSet)
 
     @patch("sql.engines.mongo.MongoEngine.get_all_tables")
     def test_query_check(self, mock_get_all_tables):


### PR DESCRIPTION
如代码所示，现在的代码空字符串会被判断进入这个if分支，原因：("NumberLong")会被认为是个字符串