### PR TITLE
修复debug api信息缺失问题

### DIFF
--- a/sql_api/views.py
+++ b/sql_api/views.py
@@ -40,16 +40,9 @@ def debug(request):
     full = request.GET.get("full")
 
     # 系统配置
-    sys_config = SysConfig().sys_config
-    # 敏感信息处理
-    secret_keys = [
-        "inception_remote_backup_password",
-        "go_inception_password",
-        "ding_app_secret",
-        "feishu_app_secret",
-        "mail_smtp_password",
-    ]
-    sys_config.update({k: "******" for k in secret_keys})
+    config = SysConfig()
+    config.get_all_config()
+    sys_config = config.sys_config
 
     # MySQL信息
     cursor = connection.cursor()
@@ -178,6 +171,19 @@ def debug(request):
     installed_packages_list = sorted(
         ["%s==%s" % (i.key, i.version) for i in installed_packages]
     )
+
+    # 敏感信息处理
+    secret_keys = [
+        "inception_remote_backup_password",
+        "ding_app_secret",
+        "feishu_app_secret",
+        "mail_smtp_password",
+        "go_inception_password",
+        "wx_app_secret",
+        "aliyun_access_key_secret",
+        "tencent_secret_key",
+    ]
+    sys_config.update({k: "******" for k in secret_keys})
 
     # 最终集合
     system_info = {


### PR DESCRIPTION
sys_config初始获取的是一个空字典，导致config信息为空；敏感信息处理先于goinception与备份库连接导致了连接失败
```
Get /api/debug
Response:
{
    ......
    "inception": {
        "goinception_info": "获取goInception信息报错:connect() argument 1 must be str, not None",
        "backup_info": "无法连接goInception备份库\ninvalid literal for int() with base 10: ''"
    },
    ......
    "sys_config": {
        "inception_remote_backup_password": "******",
        "ding_app_secret": "******",
        "feishu_app_secret": "******",
        "mail_smtp_password": "******"
    },
    ......
}
```