### PR TITLE
增加配置项控制是否获取dml真实影响行数

### DIFF
--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -319,6 +319,21 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="form-group">
+                                <label for="real_row_count"
+                                       class="col-sm-4 control-label">REAL_ROW_COUNT</label>
+                                <div class="col-sm-8">
+                                    <div class="switch switch-small">
+                                        <label>
+                                            <input id="real_row_count"
+                                                   key="real_row_count"
+                                                   value="{{ config.real_row_count }}"
+                                                   type="checkbox">
+                                            是否获取DML真实影响行数(MySQL、MongoDB)
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <h5 style="color: darkgrey"><b>SQL查询</b></h5>
                         <h6 style="color:red">注：开启脱敏功能必须要配置goInception信息，用于SQL语法解析</h6>

--- a/sql/engines/goinception.py
+++ b/sql/engines/goinception.py
@@ -76,7 +76,10 @@ class GoInceptionEngine(EngineBase):
         # inception 校验
         check_result.rows = []
         variables, set_session_sql = get_session_variables(instance)
-        inception_sql = f"""/*--user='{user}';--password='{password}';--host='{host}';--port={port};--check=1;*/
+        # 获取real_row_count参数选项
+        real_row_count = SysConfig().get("real_row_count", False)
+        real_row_count_option = "--real_row_count=true;" if real_row_count else ""
+        inception_sql = f"""/*--user='{user}';--password='{password}';--host='{host}';--port={port};--check=1;{real_row_count_option}*/
                             inception_magic_start;
                             {set_session_sql}
                             use `{db_name}`;

--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -16,6 +16,7 @@ from bson.int64 import Int64
 
 from . import EngineBase
 from .models import ResultSet, ReviewSet, ReviewResult
+from common.config import SysConfig
 
 logger = logging.getLogger("default")
 
@@ -508,6 +509,9 @@ class MongoEngine(EngineBase):
         count = 0
         check_result = ReviewSet(full_sql=sql)
 
+        # 获取real_row_count参数选项
+        real_row_count = SysConfig().get("real_row_count", False)
+
         sql = sql.strip()
         # sql 检查过滤注释语句
         sql = re.sub(r"^\s*//.*$", "", sql, flags=re.MULTILINE)
@@ -682,55 +686,57 @@ class MongoEngine(EngineBase):
                                     sql=check_sql,
                                     execute_time=0,
                                 )
-                            if methodStr == "insertOne":
-                                count = 1
-                            elif methodStr in ("insert", "insertMany"):
-                                insert_str = re.search(
-                                    rf"{methodStr}\((.*)\)", sql_str, re.S
-                                ).group(1)
-                                first_char = insert_str.replace(" ", "").replace(
-                                    "\n", ""
-                                )[0]
-                                if first_char == "{":
+                            if real_row_count:
+                                if methodStr == "insertOne":
                                     count = 1
-                                elif first_char == "[":
-                                    insert_values = re.search(
-                                        r"\[(.*?)\]", insert_str, re.S
-                                    ).group(0)
-                                    de = JsonDecoder()
-                                    insert_values = de.decode(insert_values)
-                                    count = len(insert_values)
-                                else:
-                                    count = 0
-                            elif methodStr in (
-                                "update",
-                                "updateOne",
-                                "updateMany",
-                                "deleteOne",
-                                "deleteMany",
-                                "remove",
-                            ):
-                                if sql_str.find("find(") > 0:
-                                    count_sql = sql_str.replace(methodStr, "count")
-                                else:
-                                    count_sql = (
-                                        sql_str.replace(methodStr, "find") + ".count()"
+                                elif methodStr in ("insert", "insertMany"):
+                                    insert_str = re.search(
+                                        rf"{methodStr}\((.*)\)", sql_str, re.S
+                                    ).group(1)
+                                    first_char = insert_str.replace(" ", "").replace(
+                                        "\n", ""
+                                    )[0]
+                                    if first_char == "{":
+                                        count = 1
+                                    elif first_char == "[":
+                                        insert_values = re.search(
+                                            r"\[(.*?)\]", insert_str, re.S
+                                        ).group(0)
+                                        de = JsonDecoder()
+                                        insert_values = de.decode(insert_values)
+                                        count = len(insert_values)
+                                    else:
+                                        count = 0
+                                elif methodStr in (
+                                    "update",
+                                    "updateOne",
+                                    "updateMany",
+                                    "deleteOne",
+                                    "deleteMany",
+                                    "remove",
+                                ):
+                                    if sql_str.find("find(") > 0:
+                                        count_sql = sql_str.replace(methodStr, "count")
+                                    else:
+                                        count_sql = (
+                                            sql_str.replace(methodStr, "find")
+                                            + ".count()"
+                                        )
+                                    query_dict = self.parse_query_sentence(count_sql)
+                                    count_sql = f"""db.getCollection("{query_dict["collection"]}").find({query_dict["condition"]}).count()"""
+                                    query_result = self.query(db_name, count_sql)
+                                    count = json.loads(query_result.rows[0][0]).get(
+                                        "count", 0
                                     )
-                                query_dict = self.parse_query_sentence(count_sql)
-                                count_sql = f"""db.getCollection("{query_dict["collection"]}").find({query_dict["condition"]}).count()"""
-                                query_result = self.query(db_name, count_sql)
-                                count = json.loads(query_result.rows[0][0]).get(
-                                    "count", 0
-                                )
-                                if (
-                                    methodStr == "update"
-                                    and "multi:true"
-                                    not in sql_str.replace(" ", "")
-                                    .replace('"', "")
-                                    .replace("'", "")
-                                    .replace("\n", "")
-                                ) or methodStr in ("deleteOne", "updateOne"):
-                                    count = 1 if count > 0 else 0
+                                    if (
+                                        methodStr == "update"
+                                        and "multi:true"
+                                        not in sql_str.replace(" ", "")
+                                        .replace('"', "")
+                                        .replace("'", "")
+                                        .replace("\n", "")
+                                    ) or methodStr in ("deleteOne", "updateOne"):
+                                        count = 1 if count > 0 else 0
                             if methodStr in (
                                 "insertOne",
                                 "insert",
@@ -759,7 +765,6 @@ class MongoEngine(EngineBase):
                                 errormessage="仅支持DML和DDL语句，如需查询请使用数据库查询功能！",
                                 sql=check_sql,
                             )
-
                 else:
                     check_result.error = "语法错误"
                     result = ReviewResult(

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1491,6 +1491,7 @@ class MongoTest(TestCase):
             user="ins_user",
         )
         self.engine = MongoEngine(instance=self.ins)
+        self.sys_config = SysConfig()
 
     def tearDown(self) -> None:
         self.ins.delete()
@@ -1606,6 +1607,14 @@ class MongoTest(TestCase):
 
     @patch("sql.engines.mongo.MongoEngine.get_all_tables")
     def test_execute_check_on_dml(self, mock_get_all_tables):
+        sql = """db.job.insert([{"orderCode":1001},{"orderCode":1002}]);"""
+        mock_get_all_tables.return_value.rows = "job"
+        check_result = self.engine.execute_check("some_db", sql)
+        self.assertEqual(check_result.rows[0].__dict__["affected_rows"], 0)
+
+    @patch("sql.engines.mongo.MongoEngine.get_all_tables")
+    def test_execute_check_on_dml_with_real_row_count(self, mock_get_all_tables):
+        self.sys_config.set("real_row_count", True)
         sql = """db.job.insert([{"orderCode":1001},{"orderCode":1002}]);"""
         mock_get_all_tables.return_value.rows = "job"
         check_result = self.engine.execute_check("some_db", sql)

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1606,19 +1606,72 @@ class MongoTest(TestCase):
         )
 
     @patch("sql.engines.mongo.MongoEngine.get_all_tables")
-    def test_execute_check_on_dml(self, mock_get_all_tables):
+    def test_execute_check_on_dml_without_real_row_count(self, mock_get_all_tables):
         sql = """db.job.insert([{"orderCode":1001},{"orderCode":1002}]);"""
         mock_get_all_tables.return_value.rows = "job"
         check_result = self.engine.execute_check("some_db", sql)
         self.assertEqual(check_result.rows[0].__dict__["affected_rows"], 0)
 
     @patch("sql.engines.mongo.MongoEngine.get_all_tables")
-    def test_execute_check_on_dml_with_real_row_count(self, mock_get_all_tables):
+    def test_execute_check_on_insert_one(self, mock_get_all_tables):
+        self.sys_config.set("real_row_count", True)
+        sql = """db.job.insertOne({"orderCode":1001});"""
+        mock_get_all_tables.return_value.rows = "job"
+        check_result = self.engine.execute_check("some_db", sql)
+        self.assertEqual(check_result.rows[0].__dict__["affected_rows"], 1)
+
+    @patch("sql.engines.mongo.MongoEngine.get_all_tables")
+    def test_execute_check_on_insert_single(self, mock_get_all_tables):
+        self.sys_config.set("real_row_count", True)
+        sql = """db.job.insert({"orderCode":1001});"""
+        mock_get_all_tables.return_value.rows = "job"
+        check_result = self.engine.execute_check("some_db", sql)
+        self.assertEqual(check_result.rows[0].__dict__["affected_rows"], 1)
+
+    @patch("sql.engines.mongo.MongoEngine.get_all_tables")
+    def test_execute_check_on_insert_multiple(self, mock_get_all_tables):
         self.sys_config.set("real_row_count", True)
         sql = """db.job.insert([{"orderCode":1001},{"orderCode":1002}]);"""
         mock_get_all_tables.return_value.rows = "job"
         check_result = self.engine.execute_check("some_db", sql)
         self.assertEqual(check_result.rows[0].__dict__["affected_rows"], 2)
+
+    @patch("sql.engines.mongo.MongoEngine.get_all_tables")
+    def test_execute_check_on_insert_except(self, mock_get_all_tables):
+        self.sys_config.set("real_row_count", True)
+        sql = """db.job.insert(("orderCode":1001));"""
+        mock_get_all_tables.return_value.rows = "job"
+        check_result = self.engine.execute_check("some_db", sql)
+        self.assertEqual(check_result.rows[0].__dict__["affected_rows"], 0)
+
+    @patch("sql.engines.mongo.MongoEngine.get_all_tables")
+    @patch("sql.engines.mongo.MongoEngine.query")
+    def test_execute_check_on_update_with_find(self, mock_get_all_tables, mock_query):
+        self.sys_config.set("real_row_count", True)
+        sql = """db.job.find({"orderCode":1001}).update(({"orderCode":1002}));"""
+        mock_get_all_tables.return_value.rows = "job"
+        mock_query.return_value.rows = (('{"count": 0}',),)
+        check_result = self.engine.execute_check("some_db", sql)
+        self.assertEqual(check_result.rows[0].__dict__["affected_rows"], 0)
+
+    @patch("sql.engines.mongo.MongoEngine.get_all_tables")
+    @patch("sql.engines.mongo.MongoEngine.query")
+    def test_execute_check_on_update_without_find(
+        self, mock_get_all_tables, mock_query
+    ):
+        self.sys_config.set("real_row_count", True)
+        sql = """db.job.update({"orderCode":1001},{$set:{"orderCode":1002}}));"""
+        mock_get_all_tables.return_value.rows = "job"
+        mock_query.return_value.rows = (('{"count": 0}',),)
+        check_result = self.engine.execute_check("some_db", sql)
+        self.assertEqual(check_result.rows[0].__dict__["affected_rows"], 0)
+
+    @patch("sql.engines.mongo.MongoEngine.get_all_tables")
+    def test_execute_check_with_syntax_error(self, mock_get_all_tables):
+        sql = """db.job.insert({"orderCode":1001);"""
+        mock_get_all_tables.return_value.rows = "job"
+        check_result = self.engine.execute_check("some_db", sql)
+        self.assertEqual(check_result.rows[0].__dict__["stagestatus"], "语法错误")
 
     @patch("sql.engines.mongo.MongoEngine.exec_cmd")
     @patch("sql.engines.mongo.MongoEngine.get_master")


### PR DESCRIPTION
增加配置项REAL_ROW_COUNT，控制是否获取dml真实影响行数，从历史issues来看应该有不少人需要用到
1. mysql是通过goinception的real_row_count调用选项实现（https://hanchuanchuan.github.io/goInception/params.html）
2. mongo我之前提交的pr(#2018)里默认开启，现在改为配置项开关控制是否启用