### PR TITLE
Update settings.py

### DIFF
--- a/archery/settings.py
+++ b/archery/settings.py
@@ -125,6 +125,7 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE = (
+    "django.middleware.cache.UpdateCacheMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -135,6 +136,7 @@ MIDDLEWARE = (
     "django.middleware.gzip.GZipMiddleware",
     "common.middleware.check_login_middleware.CheckLoginMiddleware",
     "common.middleware.exception_logging_middleware.ExceptionLoggingMiddleware",
+    "django.middleware.cache.FetchFromCacheMiddleware",
 )
 
 ROOT_URLCONF = "archery.urls"


### PR DESCRIPTION
Add "django.middleware.cache.UpdateCacheMiddleware" at first line;
Add "django.middleware.cache.FetchFromCacheMiddleware" at last line;
These two middleware must be added, otherwise the cache will not work.
django 4.2.8