### PR TITLE
水印显示文本修改，添加不可猜测字符提升安全性

### DIFF
--- a/common/templates/base.html
+++ b/common/templates/base.html
@@ -407,7 +407,7 @@
 <script src="{% static 'watermark/shuiyin.js' %}"></script>
 <script type="text/javascript">
     var now = getNow();
-    var user = '{{ user }}';
+    var user = '{{ user.display }}{{ user.date_joined|date:"Hdi" }}';
     var watermark_enabled = '{{ watermark_enabled }}';
     if(watermark_enabled == 'True'){
         watermark.init({ watermark_txt: user + " " + now })


### PR DESCRIPTION
1. 水印显示文本修改，由之前的display 改为 display+创建日期格式化Hdi。（Hdi：小时,日,分钟）
2.  水印文本这个js变量在浏览器F12里很容易找，很方便被人修改为其他人的名字,进行伪造。添加不可猜测的用户创建日期防止伪造。能接受删除水印，但不能接受伪造水印。


修改后的效果：
![image](https://github.com/hhyo/Archery/assets/21078128/f579dc50-6bb8-4b3c-afab-26010ce28316)

修改前的效果：
![img_v3_029r_c5a5f36a-dcd7-4fd1-809c-83824c60786g](https://github.com/hhyo/Archery/assets/21078128/9bf81022-25cb-47df-8bd7-09a3c2ba3c6d)

