### PR TITLE
添加公告支持

### DIFF
--- a/common/templates/base.html
+++ b/common/templates/base.html
@@ -378,9 +378,6 @@
     <!-- Page Content -->
     <div id="page-wrapper">
         <div class="clearfix">
-            {% if announcement_content_enabled %}
-            <span style="font-size:20px;color:red;padding-left:0px;display:block;"><br>{{announcement_content}}</span>
-            {% endif %}
             <br>
             {% if announcement_content_enabled %}
             <div class="alert alert-info h4"  role="alert">{{announcement_content}}</div>

--- a/common/templates/base.html
+++ b/common/templates/base.html
@@ -378,6 +378,9 @@
     <!-- Page Content -->
     <div id="page-wrapper">
         <div class="clearfix">
+            {% if announcement_content_enabled %}
+            <span style="font-size:20px;color:red;padding-left:0px;display:block;"><br>{{announcement_content}}</span>
+            {% endif %}
             <br>
             {% block content %}
             {% endblock content %}

--- a/common/templates/base.html
+++ b/common/templates/base.html
@@ -378,10 +378,10 @@
     <!-- Page Content -->
     <div id="page-wrapper">
         <div class="clearfix">
-            {% if announcement_content_enabled %}
-            <span style="font-size:20px;color:red;padding-left:0px;display:block;"><br>{{announcement_content}}</span>
-            {% endif %}
             <br>
+            {% if announcement_content_enabled %}
+            <div class="alert alert-info h4"  role="alert">{{announcement_content}}</div>
+            {% endif %}
             {% block content %}
             {% endblock content %}
             <!--底部部分 -->

--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -1078,7 +1078,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="announcement_content_enabled"
-                                       class="col-sm-4 control-label">Announcement_Content_Enabled</label>
+                                       class="col-sm-4 control-label">ANNOUNCEMENT_CONTENT_ENABLED</label>
                                 <div class="col-sm-8">
                                     <div class="switch switch-small">
                                         <label>

--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -1078,7 +1078,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="announcement_content_enabled"
-                                       class="col-sm-4 control-label">announcement_content_enabled</label>
+                                       class="col-sm-4 control-label">ANNOUNCEMENT_CONTENT_ENABLED</label>
                                 <div class="col-sm-8">
                                     <div class="switch switch-small">
                                         <label>
@@ -1091,7 +1091,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="announcement_content"
-                                       class="col-sm-4 control-label">announcement_content</label>
+                                       class="col-sm-4 control-label">ANNOUNCEMENT_CONTENT</label>
                                 <div class="col-sm-5">
                                     <input type="text" class="form-control"
                                            id="announcement_content"

--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -1076,6 +1076,31 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="form-group">
+                                <label for="announcement_content_enabled"
+                                       class="col-sm-4 control-label">Announcement_Content_Enabled</label>
+                                <div class="col-sm-8">
+                                    <div class="switch switch-small">
+                                        <label>
+                                            <input id="announcement_content_enabled" key="announcement_content_enabled"
+                                                   value="{{ config.announcement_content_enabled }}"
+                                                   type="checkbox"> 是否开启公告
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label for="announcement_content"
+                                       class="col-sm-4 control-label">公告内容</label>
+                                <div class="col-sm-5">
+                                    <input type="text" class="form-control"
+                                           id="announcement_content"
+                                           key="announcement_content"
+                                           value="{{ config.announcement_content }}"
+                                           placeholder="公告内容">
+                                            
+                                </div>
+                            </div>
                         </div>
                         <hr />
                         <div class="form-group">

--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -1091,7 +1091,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="announcement_content"
-                                       class="col-sm-4 control-label">公告内容</label>
+                                       class="col-sm-4 control-label">ANNOUNCEMENT_CONTENT</label>
                                 <div class="col-sm-5">
                                     <input type="text" class="form-control"
                                            id="announcement_content"

--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -1078,7 +1078,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="announcement_content_enabled"
-                                       class="col-sm-4 control-label">Announcement_Content_Enabled</label>
+                                       class="col-sm-4 control-label">announcement_content_enabled</label>
                                 <div class="col-sm-8">
                                     <div class="switch switch-small">
                                         <label>
@@ -1091,7 +1091,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="announcement_content"
-                                       class="col-sm-4 control-label">公告内容</label>
+                                       class="col-sm-4 control-label">announcement_content</label>
                                 <div class="col-sm-5">
                                     <input type="text" class="form-control"
                                            id="announcement_content"

--- a/common/utils/global_info.py
+++ b/common/utils/global_info.py
@@ -21,10 +21,17 @@ def global_info(request):
         todo = 0
 
     watermark_enabled = SysConfig().get("watermark_enabled", False)
+    #添加公告
+    announcement_content_enabled = SysConfig().get("announcement_content_enabled", False)
+    announcement_content=""
+    if announcement_content_enabled:
+        announcement_content= SysConfig().get("announcement_content", "")
 
     return {
         "todo": todo,
         "archery_version": display_version,
         "watermark_enabled": watermark_enabled,
+        "announcement_content_enabled":announcement_content_enabled,
+        "announcement_content":announcement_content,
         "twofa_type": twofa_type,
     }

--- a/common/utils/global_info.py
+++ b/common/utils/global_info.py
@@ -19,15 +19,16 @@ def global_info(request):
             todo = 0
     except Exception:
         todo = 0
-
-    watermark_enabled = SysConfig().get("watermark_enabled", False)
+    
+    sys_config = SysConfig()
+    watermark_enabled = sys_config.get("watermark_enabled", False)
     # 添加公告
-    announcement_content_enabled = SysConfig().get(
+    announcement_content_enabled = sys_config.get(
         "announcement_content_enabled", False
     )
     announcement_content = ""
     if announcement_content_enabled:
-        announcement_content = SysConfig().get("announcement_content", "")
+        announcement_content = sys_config.get("announcement_content", "")
 
     return {
         "todo": todo,

--- a/common/utils/global_info.py
+++ b/common/utils/global_info.py
@@ -19,13 +19,11 @@ def global_info(request):
             todo = 0
     except Exception:
         todo = 0
-    
+
     sys_config = SysConfig()
     watermark_enabled = sys_config.get("watermark_enabled", False)
     # 添加公告
-    announcement_content_enabled = sys_config.get(
-        "announcement_content_enabled", False
-    )
+    announcement_content_enabled = sys_config.get("announcement_content_enabled", False)
     announcement_content = sys_config.get("announcement_content", "")
 
     return {

--- a/common/utils/global_info.py
+++ b/common/utils/global_info.py
@@ -21,17 +21,19 @@ def global_info(request):
         todo = 0
 
     watermark_enabled = SysConfig().get("watermark_enabled", False)
-    #添加公告
-    announcement_content_enabled = SysConfig().get("announcement_content_enabled", False)
-    announcement_content=""
+    # 添加公告
+    announcement_content_enabled = SysConfig().get(
+        "announcement_content_enabled", False
+    )
+    announcement_content = ""
     if announcement_content_enabled:
-        announcement_content= SysConfig().get("announcement_content", "")
+        announcement_content = SysConfig().get("announcement_content", "")
 
     return {
         "todo": todo,
         "archery_version": display_version,
         "watermark_enabled": watermark_enabled,
-        "announcement_content_enabled":announcement_content_enabled,
-        "announcement_content":announcement_content,
+        "announcement_content_enabled": announcement_content_enabled,
+        "announcement_content": announcement_content,
         "twofa_type": twofa_type,
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ simplejson==3.17.2
 mybatis_mapper2sql==0.1.9
 django-auth-ldap==4.1.0
 python-dateutil==2.8.1
-pymongo==3.11.0
+pymongo==4.6.3
 psycopg2-binary==2.*
 pymysql==0.9.3
 mysql-replication==0.22


### PR DESCRIPTION
1. 添加公告支持。 使用bootstrap的alert alert-info 样式。
配置截图：
![image](https://github.com/hhyo/Archery/assets/21078128/c42745b7-c872-44e8-9cd5-bb0e5eabfcd4)

效果截图（前台每个菜单都会显示）:

![image](https://github.com/hhyo/Archery/assets/21078128/7a18a9d2-14c3-4868-80e1-834440b810f7)
