### PR TITLE
修改bootstrap-table生成的详情+号td标签样式

### DIFF
--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -807,7 +807,8 @@
                             isdetail = true
                         }
                         var showExport = {{can_download}}===1
-                        $(`#query_result${n}`).bootstrapTable('destroy').bootstrapTable({
+                        var query_result_id=(`query_result${n}`);
+                        $(`#${query_result_id}`).bootstrapTable('destroy').bootstrapTable({
                             escape: true,
                             data: result['rows'],
                             columns: columns,
@@ -869,6 +870,15 @@
                                     }
                                 });
                                 return html.join('');
+                            },
+                            onPostBody: function(data) {
+                                //此处的属性及样式名称，来自于bootstrap-table.js
+                                //有detail的表头，添加sytle
+                                var thHasDetail=$(`#${query_result_id} th.detail`);
+                                thHasDetail.css('white-space', 'nowrap');
+                                //有详情+号的的td,添加sytle。
+                                var tdHasDetail=$(`#${query_resultId} tr[data-has-detail-view="true"] .detail-icon`).parent('td');
+                                tdHasDetail.css('white-space', 'nowrap');
                             },
                             locale: 'zh-CN',
                             onExportSaved: function (e) {


### PR DESCRIPTION
修改详情+号的td样式。 
 fix https://github.com/hhyo/Archery/issues/2603



修复前：

![1oRn3tZiRn](https://github.com/hhyo/Archery/assets/21078128/691998e6-8196-49ae-a53c-5d6ad3046eee)


修复后如图：
点击+号，显示正常。
搜索后样式也正常。
查询有换行的数据 也正常撑开行。

![img_v3_02a7_2104a171-68b8-4141-9032-48f5bf0cabbg](https://github.com/hhyo/Archery/assets/21078128/357d23aa-bca7-4a49-84bd-f47eff93a51d)


