### PR TITLE
修改bootstrap-table生成的详情+号td标签样式

### DIFF
--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -877,7 +877,7 @@
                                 var thHasDetail=$(`#${query_result_id} th.detail`);
                                 thHasDetail.css('white-space', 'nowrap');
                                 //有详情+号的的td,添加sytle。
-                                var tdHasDetail=$(`#${query_resultId} tr[data-has-detail-view="true"] .detail-icon`).parent('td');
+                                var tdHasDetail=$(`#${query_result_id} tr[data-has-detail-view="true"] .detail-icon`).parent('td');
                                 tdHasDetail.css('white-space', 'nowrap');
                             },
                             locale: 'zh-CN',


### PR DESCRIPTION
onPostBody方法有一段代码，我没有合并到。（Bootstrap table的onPostBody事件是在表格渲染完成后触发的事件。）

修复了一下。

v1.11.0 也会有这个问题。这个版本也得修复一下？
 这个影响很大，会导致所有类型的SQL查询都有问题。