### PR TITLE
增强js workflow_type_formatter和workflow_status_formatter方法兼容性.

### DIFF
--- a/common/static/dist/js/formatter.js
+++ b/common/static/dist/js/formatter.js
@@ -60,7 +60,7 @@ function sqlworkflowStatus_formatter(value) {
 function workflow_type_formatter(value) {
     // 检查value是否为字符串，并将其转换为整数
     if (typeof value === "string") {
-        value = parseInt(value, 10); // 使用基数10以确保是十进制转换
+        value = parseInt(value, 10);
     }
     if (value === workflow_type.query) {
         return workflow_type.query_display
@@ -79,7 +79,7 @@ function workflow_type_formatter(value) {
 function workflow_status_formatter(value) {
     // 检查value是否为字符串，并将其转换为整数
     if (typeof value === "string") {
-        value = parseInt(value, 10); // 使用基数10以确保是十进制转换
+        value = parseInt(value, 10);
     }
     if (value === workflow_status.audit_wait) {
         return "<span class='label label-info'>" + workflow_status.audit_wait_display + " </span>"

--- a/common/static/dist/js/formatter.js
+++ b/common/static/dist/js/formatter.js
@@ -58,6 +58,10 @@ function sqlworkflowStatus_formatter(value) {
 }
 
 function workflow_type_formatter(value) {
+    // 检查value是否为字符串，并将其转换为整数
+    if (typeof value === "string") {
+        value = parseInt(value, 10); // 使用基数10以确保是十进制转换
+    }
     if (value === workflow_type.query) {
         return workflow_type.query_display
     }
@@ -73,6 +77,10 @@ function workflow_type_formatter(value) {
 }
 
 function workflow_status_formatter(value) {
+    // 检查value是否为字符串，并将其转换为整数
+    if (typeof value === "string") {
+        value = parseInt(value, 10); // 使用基数10以确保是十进制转换
+    }
     if (value === workflow_status.audit_wait) {
         return "<span class='label label-info'>" + workflow_status.audit_wait_display + " </span>"
     }


### PR DESCRIPTION
增强js workflow_type_formatter和workflow_status_formatter方法兼容性。
1. 方法的value参数值来自于bootstrap table。bootstrap-table在新版本会返回string类型，不再是int类型。

原因：
[bootstrap-table修复安全问题说明](https://github.com/wenzhixin/bootstrap-table/pull/5941)
因需要修复安全问题，修改了escapeHTML方法，导致都返回了string类型。


其他说明：
1.archery以后可能会升级bootstrap-table，我先提前兼容一下代码。
2. 假如升级bootstrap-table，后端返回为数组，显示会有问题。 比如redis的 info keyspace。
3. 假如升级bootstrap-table，会解决很早的bug， excel导出时，时间类型值的错误问题。
4. 模拟安全问题示例， 可以提交一个mongo工单，内容如下，提交后。页面会弹框。
`db.tab.insert({name:["Hello World! <img src='' onerror='alert(1)' />","Hello World! <img src='' onerror='alert(2)' />"]});`

