### PR TITLE
修复pgsql数据库下执行计划查看

### DIFF
--- a/sql/engines/pgsql.py
+++ b/sql/engines/pgsql.py
@@ -164,12 +164,14 @@ class PgSQLEngine(EngineBase):
         except IndexError:
             result["bad_query"] = True
             result["msg"] = "没有有效的SQL语句"
-        if re.match(r"^select", sql, re.I) is None:
+        if re.match(r"^select|^explain", sql, re.I) is None:
             result["bad_query"] = True
             result["msg"] = "不支持的查询语法类型!"
-        if "*" in sql:
-            result["has_star"] = True
-            result["msg"] = "SQL语句中含有 * "
+        archery_config = SysConfig()
+        if archery_config.get("disable_star") :
+            if "*" in sql :
+                result["has_star"] = True
+                result["msg"] = "SQL语句中含有 * "
         return result
 
     def query(

--- a/sql/engines/pgsql.py
+++ b/sql/engines/pgsql.py
@@ -168,8 +168,8 @@ class PgSQLEngine(EngineBase):
             result["bad_query"] = True
             result["msg"] = "不支持的查询语法类型!"
         archery_config = SysConfig()
-        if archery_config.get("disable_star") :
-            if "*" in sql :
+        if archery_config.get("disable_star"):
+            if "*" in sql:
                 result["has_star"] = True
                 result["msg"] = "SQL语句中含有 * "
         return result

--- a/sql/engines/pgsql.py
+++ b/sql/engines/pgsql.py
@@ -167,11 +167,9 @@ class PgSQLEngine(EngineBase):
         if re.match(r"^select|^explain", sql, re.I) is None:
             result["bad_query"] = True
             result["msg"] = "不支持的查询语法类型!"
-        archery_config = SysConfig()
-        if archery_config.get("disable_star"):
-            if "*" in sql:
-                result["has_star"] = True
-                result["msg"] = "SQL语句中含有 * "
+        if "*" in sql:
+            result["has_star"] = True
+            result["msg"] += "SQL语句中含有 * "
         return result
 
     def query(

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -617,7 +617,7 @@ class TestPgSQL(TestCase):
         self.assertDictEqual(
             check_result,
             {
-                "msg":"",
+                "msg": "",
                 "bad_query": False,
                 "filtered_sql": sql.strip(),
                 "has_star": False,

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -610,6 +610,20 @@ class TestPgSQL(TestCase):
             },
         )
 
+    def test_query_check_explain(self):
+        sql = "explain select x from xx "
+        new_engine = PgSQLEngine(instance=self.ins)
+        check_result = new_engine.query_check(db_name="archery", sql=sql)
+        self.assertDictEqual(
+            check_result,
+            {
+                "msg":"",
+                "bad_query": False,
+                "filtered_sql": sql.strip(),
+                "has_star": False,
+            },
+        )
+
     def test_filter_sql_with_delimiter(self):
         sql = "select * from xx;"
         new_engine = PgSQLEngine(instance=self.ins)

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -970,7 +970,7 @@
                 else if (sql === 'show create table') {
                     sqlContent = "desc " + $("#table_name").val() + ";"
                 }
-            } else if (optgroup === "MySQL") {
+            } else if (optgroup === "MySQL" || optgroup === "PgSQL" ) {
                 //查看执行计划
                 if (sql === 'explain') {
                     sqlContent = 'explain ' + sqlContent


### PR DESCRIPTION
在pgsql模式下，在线查询功能的执行计划错误的执行了SQL，没有显示执行计划；仅在配置了disable_star下，才禁止带*查询