### PR TITLE
修复mongodb无法上线

### DIFF
--- a/src/docker/setup.sh
+++ b/src/docker/setup.sh
@@ -21,7 +21,8 @@ chmod +x /usr/local/bin/mongo
 rm -rf /opt/mongodb*
 curl -L -q -o openssl-1.0.1e.tar.gz https://www.openssl.org/source/old/1.0.1/openssl-1.0.1e.tar.gz
 tar -xvf openssl-1.0.1e.tar.gz
-cd openssl-1.0.1e && ./config shared zlib-dynamic && make
+cd /opt/openssl-1.0.1e && ./config shared zlib-dynamic && make
+cd /opt
 cp /opt/openssl-1.0.1e/libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.10
 cp /opt/openssl-1.0.1e/libssl.so.1.0.0 /lib/x86_64-linux-gnu/libssl.so.10
 rm -rf /opt/openssl-1.0.1e*

--- a/src/docker/setup.sh
+++ b/src/docker/setup.sh
@@ -19,6 +19,13 @@ tar -xvf mongodb-linux-x86_64-rhel70-3.6.20.tgz
 mv /opt/mongodb-linux-x86_64-rhel70-3.6.20/bin/mongo /usr/local/bin/
 chmod +x /usr/local/bin/mongo
 rm -rf /opt/mongodb*
+curl -L -q -o openssl-1.0.1e https://www.openssl.org/source/old/1.0.1/openssl-1.0.1e.tar.gz
+tar -xvf openssl-1.0.1e.tar.gz
+cd openssl-1.0.1e && ./config shared zlib-dynamic && make
+cp /opt/openssl-1.0.1e/libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.10
+cp /opt/openssl-1.0.1e/libssl.so.1.0.0 /lib/x86_64-linux-gnu/libssl.so.10
+rm -rf /opt/openssl-1.0.1e*
+
 #msodbc
 curl -q -L https://packages.microsoft.com/keys/microsoft.asc -o /etc/apt/trusted.gpg.d/microsoft.asc
 curl -q -L https://packages.microsoft.com/config/debian/11/prod.list -o /etc/apt/sources.list.d/mssql-release.list

--- a/src/docker/setup.sh
+++ b/src/docker/setup.sh
@@ -19,7 +19,7 @@ tar -xvf mongodb-linux-x86_64-rhel70-3.6.20.tgz
 mv /opt/mongodb-linux-x86_64-rhel70-3.6.20/bin/mongo /usr/local/bin/
 chmod +x /usr/local/bin/mongo
 rm -rf /opt/mongodb*
-curl -L -q -o openssl-1.0.1e https://www.openssl.org/source/old/1.0.1/openssl-1.0.1e.tar.gz
+curl -L -q -o openssl-1.0.1e.tar.gz https://www.openssl.org/source/old/1.0.1/openssl-1.0.1e.tar.gz
 tar -xvf openssl-1.0.1e.tar.gz
 cd openssl-1.0.1e && ./config shared zlib-dynamic && make
 cp /opt/openssl-1.0.1e/libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.10


### PR DESCRIPTION
fix #2648 
mongo实例无法上线，报错
错误信息Traceback (most recent call last):
  File "/Users/lanjx/WorkSpace/bakend/python/archery/sql/engines/mongo.py", line 482, in execute
    actual_affected_rows = r.get("nModified", 0)
AttributeError: 'str' object has no attribute 'get'
经过排查，确少文件
<img width="897" alt="image" src="https://github.com/hhyo/Archery/assets/52522047/48fce6fd-0ceb-4bf8-8dbe-f06f3b490d09">
现在给基础镜像下载openssl，编译后补充缺失文件