### PR TITLE
在pgsql数据库查询时，仅检查当前选中的库的权限

### DIFF
--- a/sql/query_privileges.py
+++ b/sql/query_privileges.py
@@ -98,8 +98,8 @@ def query_priv_check(user, instance, db_name, sql_content, limit_num):
             result["msg"] = f"无法校验查询语句权限，请联系管理员，错误信息：{msg}"
     # 其他类型实例仅校验库权限
     else:
-        # 先获取查询语句涉及的库，redis、mssql特殊处理，仅校验当前选择的库
-        if instance.db_type in ["redis", "mssql"]:
+        # 先获取查询语句涉及的库，redis、mssql、pgsql特殊处理，仅校验当前选择的库
+        if instance.db_type in ["redis", "mssql", "pgsql"]:
             dbs = [db_name]
         else:
             dbs = [

--- a/sql/test_query_privileges.py
+++ b/sql/test_query_privileges.py
@@ -537,6 +537,8 @@ class TestQueryPrivilegesCheck(TestCase):
             },
         )
 
+
+
     @patch(
         "sql.query_privileges._table_ref",
         return_value=[{"schema": "archery", "name": "sql_users"}],
@@ -610,6 +612,30 @@ class TestQueryPrivilegesCheck(TestCase):
             },
         )
 
+    @patch("sql.query_privileges._db_priv",return_value=False)
+    def test_query_priv_check_with_pgsql_db_priv(self, __db_priv):
+        """
+        测试用户权限校验,pgsql实例、普通用户
+        """
+        pgsql_instance = Instance(
+            instance_name="pgsql",
+            type="master",
+            db_type="pgsql",
+            host="some_host",
+            port=5432,
+            user="some_user",
+            password="some_str",
+        )
+        r = sql.query_privileges.query_priv_check(
+            user=self.user,
+            instance=pgsql_instance,
+            db_name=self.db_name,
+            sql_content="select * from should_not_used.sql_users;",
+            limit_num=100,
+        )
+        __db_priv.assert_called_with(self.user, pgsql_instance,self.db_name)
+        
+
     @patch("sql.query_privileges._db_priv", return_value=1000)
     def test_query_priv_check_not_mysql_db_priv_exist(self, __db_priv):
         """
@@ -637,6 +663,7 @@ class TestQueryPrivilegesCheck(TestCase):
             {"data": {"limit_num": 100, "priv_check": True}, "msg": "ok", "status": 0},
         )
 
+    
     @patch("sql.query_privileges._db_priv", return_value=False)
     def test_query_priv_check_not_mysql_db_priv_not_exist(self, __db_priv):
         """

--- a/sql/test_query_privileges.py
+++ b/sql/test_query_privileges.py
@@ -537,8 +537,6 @@ class TestQueryPrivilegesCheck(TestCase):
             },
         )
 
-
-
     @patch(
         "sql.query_privileges._table_ref",
         return_value=[{"schema": "archery", "name": "sql_users"}],
@@ -612,7 +610,7 @@ class TestQueryPrivilegesCheck(TestCase):
             },
         )
 
-    @patch("sql.query_privileges._db_priv",return_value=False)
+    @patch("sql.query_privileges._db_priv", return_value=False)
     def test_query_priv_check_with_pgsql_db_priv(self, __db_priv):
         """
         测试用户权限校验,pgsql实例、普通用户
@@ -633,7 +631,7 @@ class TestQueryPrivilegesCheck(TestCase):
             sql_content="select * from should_not_used.sql_users;",
             limit_num=100,
         )
-        __db_priv.assert_called_with(self.user, pgsql_instance,self.db_name)
+        __db_priv.assert_called_with(self.user, pgsql_instance, self.db_name)
 
     @patch("sql.query_privileges._db_priv", return_value=1000)
     def test_query_priv_check_not_mysql_db_priv_exist(self, __db_priv):

--- a/sql/test_query_privileges.py
+++ b/sql/test_query_privileges.py
@@ -659,7 +659,6 @@ class TestQueryPrivilegesCheck(TestCase):
             r,
             {"data": {"limit_num": 100, "priv_check": True}, "msg": "ok", "status": 0},
         )
-
     
     @patch("sql.query_privileges._db_priv", return_value=False)
     def test_query_priv_check_not_mysql_db_priv_not_exist(self, __db_priv):

--- a/sql/test_query_privileges.py
+++ b/sql/test_query_privileges.py
@@ -659,7 +659,7 @@ class TestQueryPrivilegesCheck(TestCase):
             r,
             {"data": {"limit_num": 100, "priv_check": True}, "msg": "ok", "status": 0},
         )
-    
+
     @patch("sql.query_privileges._db_priv", return_value=False)
     def test_query_priv_check_not_mysql_db_priv_not_exist(self, __db_priv):
         """

--- a/sql/test_query_privileges.py
+++ b/sql/test_query_privileges.py
@@ -634,7 +634,6 @@ class TestQueryPrivilegesCheck(TestCase):
             limit_num=100,
         )
         __db_priv.assert_called_with(self.user, pgsql_instance,self.db_name)
-        
 
     @patch("sql.query_privileges._db_priv", return_value=1000)
     def test_query_priv_check_not_mysql_db_priv_exist(self, __db_priv):


### PR DESCRIPTION
pgsql数据库查询模式中，用户发出查询会在表名中带上schemaname，比如“select * from xxx.tb” 。archery在处理类似的查询语句时，会将"xxx"作为数据库名来检查权限，也就是按照mysql模式来处理。

但这种处理方式在 pgsql 中会出错, 因此将 pgsql 加入特例中.