### PR TITLE
fix get_instance_users_summary IndexError

### DIFF
--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -392,17 +392,23 @@ class MysqlEngine(EngineBase):
                 user_priv = self.query(
                     "mysql", "show grants for {};".format(user_host), close_conn=False
                 ).rows
+                if (
+                    self.server_fork_type == MysqlForkType.MARIADB
+                    and server_version >= (10, 4, 2)
+                ) or (
+                    self.server_fork_type == MysqlForkType.MYSQL
+                    and server_version >= (5, 7, 6)
+                ):
+                    is_locked = db_user[3]
+                else:
+                    is_locked = None
                 row = {
                     "user_host": user_host,
                     "user": db_user[1],
                     "host": db_user[2],
                     "privileges": user_priv,
                     "saved": False,
-                    "is_locked": (
-                        db_user[3]
-                        if server_version >= (5, 7, 6) or server_version >= (10, 4, 2)
-                        else None
-                    ),
+                    "is_locked": is_locked,
                 }
                 rows.append(row)
             query_result.rows = rows

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -398,7 +398,11 @@ class MysqlEngine(EngineBase):
                     "host": db_user[2],
                     "privileges": user_priv,
                     "saved": False,
-                    "is_locked": db_user[3] if server_version >= (5, 7, 6) else None,
+                    "is_locked": (
+                        db_user[3]
+                        if server_version >= (5, 7, 6) or server_version >= (10, 4, 2)
+                        else None
+                    ),
                 }
                 rows.append(row)
             query_result.rows = rows


### PR DESCRIPTION
```
File "/opt/archery/sql/engines/mysql.py", line 401, in get_instance_users_summary
    "is_locked": db_user[3] if server_version >= (5, 7, 6) else None,
IndexError: tuple index out of range
```
mariadb  < 10.4.2 时出现报错