### PR TITLE
fixed mongo connect error

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -795,15 +795,25 @@ class MongoEngine(EngineBase):
     def get_connection(self, db_name=None):
         self.db_name = db_name or self.instance.db_name or "admin"
         auth_db = self.instance.db_name or "admin"
-        self.conn = pymongo.MongoClient(
-            self.host,
-            self.port,
-            authSource=auth_db,
-            connect=True,
-            connectTimeoutMS=10000,
-        )
+
         if self.user and self.password:
-            self.conn[self.db_name].authenticate(self.user, self.password, auth_db)
+            self.conn = pymongo.MongoClient(
+                self.host,
+                self.port,
+                username=self.user,
+                password=self.password,
+                authSource=auth_db,
+                connect=True,
+                connectTimeoutMS=10000,
+            )
+        else:
+            self.conn = pymongo.MongoClient(
+                self.host,
+                self.port,
+                authSource=auth_db,
+                connect=True,
+                connectTimeoutMS=10000,
+            )
         return self.conn
 
     def close(self):


### PR DESCRIPTION
修复因升级pymongo4.x导致的mongo连接报错
```
'Collection' object is not callable. If you meant to call the 'insert_one' method on a 'Collection' object it is failing because no such method exists.
```
参见pymongo4.x官方文档
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/455f3ffa-5fa1-411e-80e7-ae2e7175b64c">
