### PR TITLE
修复开启自动审批后无法自动驳回错误语句的问题

### DIFF
--- a/sql/utils/test_workflow_audit.py
+++ b/sql/utils/test_workflow_audit.py
@@ -598,10 +598,9 @@ def test_get_review_info_auto_pass(
     assert "无需审批" in response.content.decode("utf-8")
 
 
-@patch("sql.utils.workflow_audit.AuditV2.is_auto_reject")
-def test_auto_review_with_auto_reject(sql_workflow, mock_is_auto_reject):
+def test_auto_review_with_auto_reject(sql_workflow, mocker: MockFixture):
     """自动审和不通过时无法自动审批"""
-    mock_is_auto_reject.return_value = True
+    mocker.patch.object(AuditV2, "is_auto_reject").return_value = True
     audit = AuditV2(workflow=sql_workflow)
     assert audit.is_auto_review() is False
 

--- a/sql/utils/test_workflow_audit.py
+++ b/sql/utils/test_workflow_audit.py
@@ -611,3 +611,41 @@ def test_get_review_info_auto_pass(
     response = admin_client.get(f"/queryapplydetail/{sql_query_apply.apply_id}/")
     assert response.status_code == 200
     assert "无需审批" in response.content.decode("utf-8")
+
+
+@patch("sql.utils.workflow_audit.AuditV2.is_auto_reject")
+def test_auto_review_with_auto_reject(sql_workflow, mock_is_auto_reject):
+    """自动审和不通过时无法自动审批"""
+    mock_is_auto_reject.return_value = True
+    audit = AuditV2(workflow=sql_workflow)
+    assert audit.is_auto_review() is False
+
+
+def test_auto_reject_non_sql_review(sql_query_apply):
+    """当前自动审核仅对 SQL 上线工单生效"""
+    audit = AuditV2(workflow=sql_query_apply)
+    assert audit.is_auto_reject() is False
+
+
+def test_auto_reject_not_applicable(sql_workflow, setup_sys_config):
+    """测试自动拒绝场景"""
+    sql_workflow, _ = sql_workflow
+    audit = AuditV2(workflow=sql_workflow, sys_config=setup_sys_config)
+    # warning_count > 0 and auto_review_wrong == "1",
+    audit.sys_config.set("auto_review_wrong", "1")
+    audit.workflow.sqlworkflowcontent.review_content = json.dumps([{"errlevel": 1}])
+    audit.workflow.sqlworkflowcontent.save()
+    assert audit.is_auto_reject() is True
+    # error_count > 0 and auto_review_wrong in ("", "1", "2")
+    audit.workflow.sqlworkflowcontent.review_content = json.dumps([{"errlevel": 2}])
+    audit.workflow.sqlworkflowcontent.save()
+    audit.sys_config.set("auto_review_wrong", "")
+    assert audit.is_auto_reject() is True
+    audit.sys_config.set("auto_review_wrong", "1")
+    assert audit.is_auto_reject() is True
+    audit.sys_config.set("auto_review_wrong", "2")
+    assert audit.is_auto_reject() is True
+    # warning_count=0 error_count=0
+    audit.workflow.sqlworkflowcontent.review_content = json.dumps([{"errlevel": 0}])
+    audit.workflow.sqlworkflowcontent.save()
+    assert audit.is_auto_reject() is False

--- a/sql/utils/test_workflow_audit.py
+++ b/sql/utils/test_workflow_audit.py
@@ -445,21 +445,6 @@ def test_generate_audit_setting_empty_config(sql_query_apply):
     assert "未配置审流" in str(e.value)
 
 
-def test_generate_audit_setting_auto_review(
-    sql_workflow, setup_sys_config, mocker: MockFixture
-):
-    sql_workflow, _ = sql_workflow
-    setup_sys_config.set("auto_review", True)
-
-    audit = AuditV2(workflow=sql_workflow, sys_config=setup_sys_config)
-    mock_is_auto_review = mocker.patch.object(
-        audit, "is_auto_review", return_value=True
-    )
-    audit_setting = audit.generate_audit_setting()
-    assert audit_setting.auto_pass is True
-    mock_is_auto_review.assert_called()
-
-
 def test_get_workflow(
     archive_apply,
     sql_query_apply,

--- a/sql/utils/test_workflow_audit.py
+++ b/sql/utils/test_workflow_audit.py
@@ -601,6 +601,7 @@ def test_get_review_info_auto_pass(
 def test_auto_review_with_auto_reject(sql_workflow, mocker: MockFixture):
     """自动审和不通过时无法自动审批"""
     mocker.patch.object(AuditV2, "is_auto_reject").return_value = True
+    sql_workflow, _ = sql_workflow
     audit = AuditV2(workflow=sql_workflow)
     assert audit.is_auto_review() is False
 

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -432,7 +432,9 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
             logger.error(f"提交工单报错，错误信息：{traceback.format_exc()}")
             raise serializers.ValidationError({"errors": str(e)})
         # 有时候提交后自动审批通过, 在这里改写一下 workflow 状态
-        if auditor.audit.current_status == WorkflowStatus.PASSED:
+        if auditor.audit.current_status == WorkflowStatus.REJECTED:
+            auditor.workflow.status = "workflow_autoreviewwrong"
+        elif auditor.audit.current_status == WorkflowStatus.PASSED:
             auditor.workflow.status = "workflow_review_pass"
         auditor.workflow.save()
         return workflow_content

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -397,18 +397,8 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
         if not sys_config.get("enable_backup_switch") and check_engine.auto_backup:
             is_backup = True
 
-        # 按照系统配置确定是自动驳回还是放行
-        auto_review_wrong = sys_config.get(
-            "auto_review_wrong", ""
-        )  # 1表示出现警告就驳回，2和空表示出现错误才驳回
-        workflow_status = "workflow_manreviewing"
-        if check_result.warning_count > 0 and auto_review_wrong == "1":
-            workflow_status = "workflow_autoreviewwrong"
-        elif check_result.error_count > 0 and auto_review_wrong in ("", "1", "2"):
-            workflow_status = "workflow_autoreviewwrong"
-
         workflow_data.update(
-            status=workflow_status,
+            status="workflow_manreviewing",
             is_backup=is_backup,
             is_manual=0,
             syntax_type=check_result.syntax_type,


### PR DESCRIPTION
#2699  #2643 解决两个问题

1. 开启自动审批后无法正常驳回异常语句
2. 自动驳回的在审批工单依然显示待审批

