### PR TITLE
删除 oracle engine 中 filter_sql 实现

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -644,14 +644,6 @@ class OracleEngine(EngineBase):
         return result
 
     def filter_sql(self, sql="", limit_num=0):
-        # sql_lower = sql.lower()
-        # # 对查询sql增加limit限制
-        # if re.match(r"^select|^with", sql_lower) and not (
-        #     re.match(r"^select\s+sql_audit.", sql_lower)
-        #     and sql_lower.find(" sql_audit where rownum <= ") != -1
-        # ):
-        #     sql = f"select sql_audit.* from ({sql.rstrip(';')}) sql_audit where rownum <= {limit_num}"
-        # return sql.strip()
         return sql
 
     def query(

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -643,9 +643,6 @@ class OracleEngine(EngineBase):
             result["msg"] = keyword_warning
         return result
 
-    def filter_sql(self, sql="", limit_num=0):
-        return sql
-
     def query(
         self,
         db_name=None,

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -644,14 +644,15 @@ class OracleEngine(EngineBase):
         return result
 
     def filter_sql(self, sql="", limit_num=0):
-        sql_lower = sql.lower()
-        # 对查询sql增加limit限制
-        if re.match(r"^select|^with", sql_lower) and not (
-            re.match(r"^select\s+sql_audit.", sql_lower)
-            and sql_lower.find(" sql_audit where rownum <= ") != -1
-        ):
-            sql = f"select sql_audit.* from ({sql.rstrip(';')}) sql_audit where rownum <= {limit_num}"
-        return sql.strip()
+        # sql_lower = sql.lower()
+        # # 对查询sql增加limit限制
+        # if re.match(r"^select|^with", sql_lower) and not (
+        #     re.match(r"^select\s+sql_audit.", sql_lower)
+        #     and sql_lower.find(" sql_audit where rownum <= ") != -1
+        # ):
+        #     sql = f"select sql_audit.* from ({sql.rstrip(';')}) sql_audit where rownum <= {limit_num}"
+        # return sql.strip()
+        return sql
 
     def query(
         self,

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1239,40 +1239,44 @@ class TestOracle(TestCase):
         )
 
     def test_filter_sql_with_delimiter(self):
-        sql = "select * from xx;"
-        new_engine = OracleEngine(instance=self.ins)
-        check_result = new_engine.filter_sql(sql=sql, limit_num=100)
-        self.assertEqual(
-            check_result,
-            "select sql_audit.* from (select * from xx) sql_audit where rownum <= 100",
-        )
+        # sql = "select * from xx;"
+        # new_engine = OracleEngine(instance=self.ins)
+        # check_result = new_engine.filter_sql(sql=sql, limit_num=100)
+        # self.assertEqual(
+        #     check_result,
+        #     "select sql_audit.* from (select * from xx) sql_audit where rownum <= 100",
+        # )
+        return
 
     def test_filter_sql_with_delimiter_and_where(self):
-        sql = "select * from xx where id>1;"
-        new_engine = OracleEngine(instance=self.ins)
-        check_result = new_engine.filter_sql(sql=sql, limit_num=100)
-        self.assertEqual(
-            check_result,
-            "select sql_audit.* from (select * from xx where id>1) sql_audit where rownum <= 100",
-        )
+        # sql = "select * from xx where id>1;"
+        # new_engine = OracleEngine(instance=self.ins)
+        # check_result = new_engine.filter_sql(sql=sql, limit_num=100)
+        # self.assertEqual(
+        #     check_result,
+        #     "select sql_audit.* from (select * from xx where id>1) sql_audit where rownum <= 100",
+        # )
+        return
 
     def test_filter_sql_without_delimiter(self):
-        sql = "select * from xx;"
-        new_engine = OracleEngine(instance=self.ins)
-        check_result = new_engine.filter_sql(sql=sql, limit_num=100)
-        self.assertEqual(
-            check_result,
-            "select sql_audit.* from (select * from xx) sql_audit where rownum <= 100",
-        )
+        # sql = "select * from xx;"
+        # new_engine = OracleEngine(instance=self.ins)
+        # check_result = new_engine.filter_sql(sql=sql, limit_num=100)
+        # self.assertEqual(
+        #     check_result,
+        #     "select sql_audit.* from (select * from xx) sql_audit where rownum <= 100",
+        # )
+        return
 
     def test_filter_sql_with_limit(self):
-        sql = "select * from xx limit 10;"
-        new_engine = OracleEngine(instance=self.ins)
-        check_result = new_engine.filter_sql(sql=sql, limit_num=1)
-        self.assertEqual(
-            check_result,
-            "select sql_audit.* from (select * from xx limit 10) sql_audit where rownum <= 1",
-        )
+        # sql = "select * from xx limit 10;"
+        # new_engine = OracleEngine(instance=self.ins)
+        # check_result = new_engine.filter_sql(sql=sql, limit_num=1)
+        # self.assertEqual(
+        #     check_result,
+        #     "select sql_audit.* from (select * from xx limit 10) sql_audit where rownum <= 1",
+        # )
+        return
 
     def test_query_masking(self):
         query_result = ResultSet()

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1239,43 +1239,15 @@ class TestOracle(TestCase):
         )
 
     def test_filter_sql_with_delimiter(self):
-        # sql = "select * from xx;"
-        # new_engine = OracleEngine(instance=self.ins)
-        # check_result = new_engine.filter_sql(sql=sql, limit_num=100)
-        # self.assertEqual(
-        #     check_result,
-        #     "select sql_audit.* from (select * from xx) sql_audit where rownum <= 100",
-        # )
         return
 
     def test_filter_sql_with_delimiter_and_where(self):
-        # sql = "select * from xx where id>1;"
-        # new_engine = OracleEngine(instance=self.ins)
-        # check_result = new_engine.filter_sql(sql=sql, limit_num=100)
-        # self.assertEqual(
-        #     check_result,
-        #     "select sql_audit.* from (select * from xx where id>1) sql_audit where rownum <= 100",
-        # )
         return
 
     def test_filter_sql_without_delimiter(self):
-        # sql = "select * from xx;"
-        # new_engine = OracleEngine(instance=self.ins)
-        # check_result = new_engine.filter_sql(sql=sql, limit_num=100)
-        # self.assertEqual(
-        #     check_result,
-        #     "select sql_audit.* from (select * from xx) sql_audit where rownum <= 100",
-        # )
         return
 
     def test_filter_sql_with_limit(self):
-        # sql = "select * from xx limit 10;"
-        # new_engine = OracleEngine(instance=self.ins)
-        # check_result = new_engine.filter_sql(sql=sql, limit_num=1)
-        # self.assertEqual(
-        #     check_result,
-        #     "select sql_audit.* from (select * from xx limit 10) sql_audit where rownum <= 1",
-        # )
         return
 
     def test_query_masking(self):

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1238,18 +1238,6 @@ class TestOracle(TestCase):
             },
         )
 
-    def test_filter_sql_with_delimiter(self):
-        return
-
-    def test_filter_sql_with_delimiter_and_where(self):
-        return
-
-    def test_filter_sql_without_delimiter(self):
-        return
-
-    def test_filter_sql_with_limit(self):
-        return
-
     def test_query_masking(self):
         query_result = ResultSet()
         new_engine = OracleEngine(instance=self.ins)

--- a/sql/query.py
+++ b/sql/query.py
@@ -84,7 +84,8 @@ def query(request):
         limit_num = 0 if re.match(r"^explain", sql_content.lower()) else limit_num
 
         # 对查询sql增加limit限制或者改写语句
-        sql_content = query_engine.filter_sql(sql=sql_content, limit_num=limit_num)
+        if instance.db_type != "oracle":
+            sql_content = query_engine.filter_sql(sql=sql_content, limit_num=limit_num)
 
         # 先获取查询连接，用于后面查询复用连接以及终止会话
         query_engine.get_connection(db_name=db_name)

--- a/sql/query.py
+++ b/sql/query.py
@@ -84,8 +84,7 @@ def query(request):
         limit_num = 0 if re.match(r"^explain", sql_content.lower()) else limit_num
 
         # 对查询sql增加limit限制或者改写语句
-        if instance.db_type != "oracle":
-            sql_content = query_engine.filter_sql(sql=sql_content, limit_num=limit_num)
+        sql_content = query_engine.filter_sql(sql=sql_content, limit_num=limit_num)
 
         # 先获取查询连接，用于后面查询复用连接以及终止会话
         query_engine.get_connection(db_name=db_name)


### PR DESCRIPTION
1. oracle.py646行filter_sql函数作用是限制查询返回行数。如果查询SQL的查询字段列表包含同名列，经过filter_sql函数处理之后的SQL，
由于查询字段列表` sql_audit.* `中存在同名列，在Oracle数据库中执行会报错` ORA-00918:未明确定义列`。原查询SQL的查询字段列表虽然也包含同名列，
但因为有不同的表别名作区分，因此在数据库中执行不会报错。例如原SQL：

```
select a.*,b.* from a,b where a.custid=b.custid;

```

该SQL在Oracle数据库中可以正常执行，但在archery平台上执行会报错。

2. oracle.py中689行cursor.fetchmany(int(limit_num))已经有限制查询返回行数的作用，所以不必通过oracle.py646行的filter_sql函数来再次限制查询返回行数