### PR TITLE
修复mongo上线问题

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -351,7 +351,7 @@ class MongoEngine(EngineBase):
     ):
         # 提取公共参数
         common_params = {
-            "mongo": mongo,
+            "mongo": "mongo",
             "host": self.host,
             "port": self.port,
             "db_name": db_name,
@@ -361,14 +361,14 @@ class MongoEngine(EngineBase):
         if is_load:
             cmd_template = (
                 "{mongo} --quiet {auth_options} {host}:{port}/{auth_db} <<\\EOF\n"
-                "db=db.getSiblingDB(\"{db_name}\");{slave_ok}load('{tempfile_}')\nEOF"
+                "db=db.getSiblingDB('{db_name}');{slave_ok}load('{tempfile_}')\nEOF"
             )
             # 长度超限使用loadjs的方式运行，使用临时文件
             common_params["tempfile_"] = tempfile_
         else:
             cmd_template = (
                 "{mongo} --quiet {auth_options} {host}:{port}/{auth_db} <<\\EOF\n"
-                'db=db.getSiblingDB("{db_name}");{slave_ok}printjson({sql})\nEOF'
+                "db=db.getSiblingDB('{db_name}');{slave_ok}printjson({sql})\nEOF"
             )
             # 长度不超限直接mongo shell，无需临时文件
             common_params["sql"] = sql

--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -307,7 +307,9 @@ class MongoEngine(EngineBase):
                         db_name, auth_db, slave_ok, fp.name, is_load=True
                     )
                     is_load = True  # 标记使用了load方法，用来在finally里面判断是否需要强制删除临时文件
-                elif not sql.startswith("var host=") and sql_len < 4000:  # 在master节点执行的情况， 如果sql长度小于4000,就直接用mongo shell执行，减少磁盘交换，节省性能
+                elif (
+                    not sql.startswith("var host=") and sql_len < 4000
+                ):  # 在master节点执行的情况， 如果sql长度小于4000,就直接用mongo shell执行，减少磁盘交换，节省性能
                     cmd = self._build_cmd(db_name, auth_db, slave_ok, sql=sql)
                 else:
                     cmd = self._build_cmd(
@@ -366,16 +368,14 @@ class MongoEngine(EngineBase):
         else:
             cmd_template = (
                 "{mongo} --quiet {auth_options} {host}:{port}/{auth_db} <<\\EOF\n"
-                "db=db.getSiblingDB(\"{db_name}\");{slave_ok}printjson({sql})\nEOF"
+                'db=db.getSiblingDB("{db_name}");{slave_ok}printjson({sql})\nEOF'
             )
             # 长度不超限直接mongo shell，无需临时文件
             common_params["sql"] = sql
         # 如果有账号密码，则添加选项
         if self.user and self.password:
-            common_params["auth_options"] = (
-                "-u {uname} -p '{password}'".format(
-                    uname=self.user, password=self.password
-                )
+            common_params["auth_options"] = "-u {uname} -p '{password}'".format(
+                uname=self.user, password=self.password
             )
         else:
             common_params["auth_options"] = ""

--- a/sql/engines/test_mongo.py
+++ b/sql/engines/test_mongo.py
@@ -1,0 +1,103 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from sql.engines.mongo import MongoEngine
+
+
+@pytest.fixture
+def mongo_engine():
+    engine = MongoEngine()
+    engine.host = "localhost"
+    engine.port = 27017
+    engine.user = "test_user"
+    engine.password = "test_password"
+    engine.instance = MagicMock()
+    engine.instance.db_name = "test_db"
+    return engine
+
+
+def test_build_cmd_with_load(mongo_engine):
+    # Call the method with is_load=True
+    cmd = mongo_engine._build_cmd(
+        db_name="test_db",
+        auth_db="admin",
+        slave_ok="rs.slaveOk();",
+        tempfile_="/tmp/test.js",
+        is_load=True,
+    )
+
+    # Expected command template
+    expected_cmd = (
+        "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
+        "db=db.getSiblingDB('test_db');rs.slaveOk();load('/tmp/test.js')\nEOF"
+    )
+
+    # Assertions
+    assert cmd == expected_cmd
+
+
+def test_build_cmd_without_load(mongo_engine):
+    # Call the method with is_load=False
+    cmd = mongo_engine._build_cmd(
+        db_name="test_db",
+        auth_db="admin",
+        slave_ok="rs.slaveOk();",
+        sql="db.test_collection.find()",
+        is_load=False,
+    )
+
+    # Expected command template
+    expected_cmd = (
+        "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
+        "db=db.getSiblingDB('test_db');rs.slaveOk();printjson(db.test_collection.find())\nEOF"
+    )
+
+    # Assertions
+    assert cmd == expected_cmd
+
+
+def test_build_cmd_without_auth(mongo_engine):
+    # Set user and password to None
+    mongo_engine.user = None
+    mongo_engine.password = None
+
+    # Call the method with is_load=False
+    cmd = mongo_engine._build_cmd(
+        db_name="test_db",
+        auth_db="admin",
+        slave_ok="rs.slaveOk();",
+        sql="db.test_collection.find()",
+        is_load=False,
+    )
+
+    # Expected command template
+    expected_cmd = (
+        "mongo --quiet  localhost:27017/admin <<\\EOF\n"
+        "db=db.getSiblingDB('test_db');rs.slaveOk();printjson(db.test_collection.find())\nEOF"
+    )
+
+    # Assertions
+    assert cmd == expected_cmd
+
+
+def test_build_cmd_with_load_without_auth(mongo_engine):
+    # Set user and password to None
+    mongo_engine.user = None
+    mongo_engine.password = None
+
+    # Call the method with is_load=True
+    cmd = mongo_engine._build_cmd(
+        db_name="test_db",
+        auth_db="admin",
+        slave_ok="rs.slaveOk();",
+        tempfile_="/tmp/test.js",
+        is_load=True,
+    )
+
+    # Expected command template
+    expected_cmd = (
+        "mongo --quiet  localhost:27017/admin <<\\EOF\n"
+        "db=db.getSiblingDB('test_db');rs.slaveOk();load('/tmp/test.js')\nEOF"
+    )
+
+    # Assertions
+    assert cmd == expected_cmd


### PR DESCRIPTION
在使用未开启密码认证的实例上，会出现mongo的上线报错，因为代码中强制使用了账号密码登录的方式
找到了之前的#1893，加入几个判断可以解决，我改好了提了个pr

fix #2789 