### PR TITLE
[Fix] Fix ssh tunnel always return 127.0.0.1

### DIFF
--- a/sql/utils/ssh_tunnel.py
+++ b/sql/utils/ssh_tunnel.py
@@ -63,10 +63,14 @@ class SSHConnection(object):
         self.server.close()
 
     def get_local_ip(self):
-        """
-        动态获取本地IP地址
-        """
-        return socket.gethostbyname(socket.gethostname())
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            # 连接一个公网地址（不需要实际发送数据）
+            s.connect(('8.8.8.8', 80))
+            ip = s.getsockname()[0]
+        finally:
+            s.close()
+        return ip
 
     def get_ssh(self):
         """

--- a/sql/utils/ssh_tunnel.py
+++ b/sql/utils/ssh_tunnel.py
@@ -8,6 +8,7 @@
 from sshtunnel import SSHTunnelForwarder
 from paramiko import RSAKey
 import io
+import socket
 
 
 class SSHConnection(object):
@@ -55,13 +56,20 @@ class SSHConnection(object):
             )
         self.server.start()
 
+        # 动态获取本地IP
+        self.local_ip = self.get_local_ip()
+
     def __del__(self):
         self.server.close()
 
+    def get_local_ip(self):
+        """
+        动态获取本地IP地址
+        """
+        return socket.gethostbyname(socket.gethostname())
+
     def get_ssh(self):
         """
-        获取ssh映射的端口
-        :param request:
-        :return:
+        获取ssh映射的本地IP和端口
         """
-        return "127.0.0.1", self.server.local_bind_port
+        return self.local_ip, self.server.local_bind_port

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -39,6 +39,7 @@ from sql.utils.sql_utils import *
 from sql.utils.execute_sql import execute, execute_callback
 from sql.utils.tasks import add_sql_schedule, del_schedule, task_info
 from sql.utils.data_masking import data_masking, brute_mask, simple_column_mask
+from sql.utils.ssh_tunnel import SSHConnection
 
 User = Users
 __author__ = "hhyo"
@@ -1512,3 +1513,8 @@ class TestResourceGroup(TestCase):
             auth_group_names=[self.agp.name], group_id=self.rgp1.group_id
         )
         self.assertIn(self.user, users)
+
+# ssh tunnel tests
+def test_get_local_ip():
+  tunnel = SSHConnection("mysql", 3306, "tunnel", 22, "root", "password", "", "")
+  assert tunnel.get_local_ip() != "127.0.0.1"

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -1516,5 +1516,5 @@ class TestResourceGroup(TestCase):
 
 # ssh tunnel tests
 def test_get_local_ip():
-  tunnel = SSHConnection("mysql", 3306, "tunnel", 22, "root", "password", "", "")
-  assert tunnel.get_local_ip() != "127.0.0.1"
+    tunnel = SSHConnection("mysql", 3306, "tunnel", 22, "root", "password", "", "")
+    assert tunnel.get_local_ip() != "127.0.0.1"

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -9,7 +9,6 @@
 import datetime
 import json
 from unittest.mock import patch, MagicMock
-from pytest_mock import MockerFixture
 
 from django.conf import settings
 from django.contrib.auth.models import Permission, Group
@@ -1517,10 +1516,6 @@ class TestResourceGroup(TestCase):
 
 
 # ssh tunnel tests
-def test_get_local_ip(mocker: MockerFixture):
-    from sql.utils.ssh_tunnel import SSHTunnelForwarder
-
-    mock_start = mocker.patch.object(SSHTunnelForwarder, "start")
-    tunnel = SSHConnection("mysql", 3306, "tunnel", 22, "root", "password", "", "")
-    assert tunnel.get_local_ip() != "127.0.0.1"
-    assert mock_start.assert_called_once()
+def test_get_local_ip():
+  tunnel = SSHConnection("mysql", 3306, "tunnel", 22, "root", "password", "", "")
+  assert tunnel.get_local_ip() != "127.0.0.1"

--- a/sql/utils/tests.py
+++ b/sql/utils/tests.py
@@ -9,6 +9,7 @@
 import datetime
 import json
 from unittest.mock import patch, MagicMock
+from pytest_mock import MockerFixture
 
 from django.conf import settings
 from django.contrib.auth.models import Permission, Group
@@ -1514,7 +1515,12 @@ class TestResourceGroup(TestCase):
         )
         self.assertIn(self.user, users)
 
+
 # ssh tunnel tests
-def test_get_local_ip():
+def test_get_local_ip(mocker: MockerFixture):
+    from sql.utils.ssh_tunnel import SSHTunnelForwarder
+
+    mock_start = mocker.patch.object(SSHTunnelForwarder, "start")
     tunnel = SSHConnection("mysql", 3306, "tunnel", 22, "root", "password", "", "")
     assert tunnel.get_local_ip() != "127.0.0.1"
+    assert mock_start.assert_called_once()


### PR DESCRIPTION
修复ssh隧道始终返回127.0.0.1，改为动态获取本地地址