### PR TITLE
mongodb comment 检测问题修复

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -534,8 +534,8 @@ class MongoEngine(EngineBase):
         # 执行语句
         for check_sql in sp_sql:
             alert = ""  # 警告信息
+            check_sql = check_sql.strip()
             if not check_sql == "" and check_sql != "\n":
-                check_sql = check_sql.strip()
                 # check_sql = f'''{check_sql}'''
                 # check_sql = check_sql.replace('\n', '') #处理成一行
                 # 支持的命令列表


### PR DESCRIPTION
mongodb comment被replace后可能还有空行 会检测不通过
语句最后一行是空行也检测不通过