### PR TITLE
当前审批节点用户列表显示异常

### DIFF
--- a/sql/templates/workflow_display.html
+++ b/sql/templates/workflow_display.html
@@ -8,7 +8,7 @@
     <!-- 当前节点 -->
         <u class="text-danger">
             {{ n.group.name }}(
-            {% for u in n.group.user_set.all %}
+            {% for u in n.filtered_user_set %}
             <span class="text-primary">{{ u.username }}</span>
             {% endfor %})
         </u>

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -598,6 +598,8 @@ class AuditV2:
                 )
                 continue
             group_in_db = Group.objects.get(id=g)
+            current_audit_users = auth_group_users([group_in_db.name], self.resource_group_id)
+            group_in_db.user_set.set(current_audit_users)
             if self.audit.current_status != WorkflowStatus.WAITING:
                 # 总体状态不是待审核, 不设置详细的属性
                 review_nodes.append(

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -44,6 +44,7 @@ class ReviewNodeType(Enum):
 @dataclass
 class ReviewNode:
     group: Optional[Group] = None
+    filtered_user_set: Optional[Users] = None
     node_type: ReviewNodeType = ReviewNodeType.GROUP
     is_current_node: bool = False
     is_passed_node: bool = False
@@ -597,14 +598,19 @@ class AuditV2:
                     )
                 )
                 continue
+            # 获取指定权限组名称
             group_in_db = Group.objects.get(id=g)
+            # 获取资源组内关联指定权限组的用户
             current_audit_users = auth_group_users([group_in_db.name], self.resource_group_id)
-            group_in_db.user_set.set(current_audit_users)
+            current_audit_user_ids = current_audit_users.values_list('id', flat=True)
+            # 过滤Group对象的user_set，只保留当前审核用户
+            group_filtered_user_set = group_in_db.user_set.filter(id__in=current_audit_user_ids)
             if self.audit.current_status != WorkflowStatus.WAITING:
                 # 总体状态不是待审核, 不设置详细的属性
                 review_nodes.append(
                     ReviewNode(
                         group=group_in_db,
+                        filtered_user_set=group_filtered_user_set,
                     )
                 )
                 continue
@@ -614,6 +620,7 @@ class AuditV2:
                 review_nodes.append(
                     ReviewNode(
                         group=group_in_db,
+                        filtered_user_set=group_filtered_user_set,
                         is_current_node=True,
                         is_passed_node=False,
                     )
@@ -624,6 +631,7 @@ class AuditV2:
                 review_nodes.append(
                     ReviewNode(
                         group=group_in_db,
+                        filtered_user_set=group_filtered_user_set,
                         is_passed_node=False,
                     )
                 )
@@ -632,6 +640,7 @@ class AuditV2:
             review_nodes.append(
                 ReviewNode(
                     group=group_in_db,
+                    filtered_user_set=group_filtered_user_set,
                     is_passed_node=True,
                 )
             )

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -601,10 +601,14 @@ class AuditV2:
             # 获取指定权限组名称
             group_in_db = Group.objects.get(id=g)
             # 获取资源组内关联指定权限组的用户
-            current_audit_users = auth_group_users([group_in_db.name], self.resource_group_id)
-            current_audit_user_ids = current_audit_users.values_list('id', flat=True)
+            current_audit_users = auth_group_users(
+                [group_in_db.name], self.resource_group_id
+            )
+            current_audit_user_ids = current_audit_users.values_list("id", flat=True)
             # 过滤Group对象的user_set，只保留当前审核用户
-            group_filtered_user_set = group_in_db.user_set.filter(id__in=current_audit_user_ids)
+            group_filtered_user_set = group_in_db.user_set.filter(
+                id__in=current_audit_user_ids
+            )
             if self.audit.current_status != WorkflowStatus.WAITING:
                 # 总体状态不是待审核, 不设置详细的属性
                 review_nodes.append(


### PR DESCRIPTION
在获取当前审批用户列表时，增加根据当前工单所在组筛选用户列表的逻辑
[讨论详情](https://github.com/hhyo/Archery/discussions/2827)