### PR TITLE
slave获取报错bug修复

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -368,7 +368,7 @@ class MongoEngine(EngineBase):
         else:
             cmd_template = (
                 "{mongo} --quiet {auth_options} {host}:{port}/{auth_db} <<\\EOF\n"
-                "db=db.getSiblingDB('{db_name}');{slave_ok}printjson({sql})\nEOF"
+                "db=db.getSiblingDB('{db_name}');{slave_ok}{sql}\nEOF"
             )
             # 长度不超限直接mongo shell，无需临时文件
             common_params["sql"] = sql
@@ -397,7 +397,7 @@ class MongoEngine(EngineBase):
 
         sql = """var host=""; rs.status().members.forEach(function(item) {i=1; if (item.stateStr =="SECONDARY") \
         {host=item.name } }); print(host);"""
-        slave_msg = self.exec_cmd(sql)
+        slave_msg = self.exec_cmd(sql,db_name=self.db_name)
         # 如果是阿里云的云mongodb，会获取不到备节点真实的ip和端口，那就干脆不获取，直接用主节点来执行sql
         # 如果是自建mongodb，获取到备节点的ip是192.168.1.33:27019这样的值；但如果是阿里云mongodb，获取到的备节点ip是SECONDARY、hiddenNode这样的值
         # 所以，为了使代码更加通用，通过有无冒号来判断自建Mongod还是阿里云mongdb；没有冒号就判定为阿里云mongodb，直接返回false；

--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -534,8 +534,8 @@ class MongoEngine(EngineBase):
         # 执行语句
         for check_sql in sp_sql:
             alert = ""  # 警告信息
+            check_sql = check_sql.strip()
             if not check_sql == "" and check_sql != "\n":
-                check_sql = check_sql.strip()
                 # check_sql = f'''{check_sql}'''
                 # check_sql = check_sql.replace('\n', '') #处理成一行
                 # 支持的命令列表

--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -397,7 +397,7 @@ class MongoEngine(EngineBase):
 
         sql = """var host=""; rs.status().members.forEach(function(item) {i=1; if (item.stateStr =="SECONDARY") \
         {host=item.name } }); print(host);"""
-        slave_msg = self.exec_cmd(sql,db_name=self.db_name)
+        slave_msg = self.exec_cmd(sql, db_name=self.db_name)
         # 如果是阿里云的云mongodb，会获取不到备节点真实的ip和端口，那就干脆不获取，直接用主节点来执行sql
         # 如果是自建mongodb，获取到备节点的ip是192.168.1.33:27019这样的值；但如果是阿里云mongodb，获取到的备节点ip是SECONDARY、hiddenNode这样的值
         # 所以，为了使代码更加通用，通过有无冒号来判断自建Mongod还是阿里云mongdb；没有冒号就判定为阿里云mongodb，直接返回false；

--- a/sql/engines/test_mongo.py
+++ b/sql/engines/test_mongo.py
@@ -48,7 +48,7 @@ def test_build_cmd_without_load(mongo_engine):
     # Expected command template
     expected_cmd = (
         "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-        "db=db.getSiblingDB('test_db');rs.slaveOk();printjson(db.test_collection.find())\nEOF"
+        "db=db.getSiblingDB('test_db');rs.slaveOk();db.test_collection.find()\nEOF"
     )
 
     # Assertions
@@ -72,7 +72,7 @@ def test_build_cmd_without_auth(mongo_engine):
     # Expected command template
     expected_cmd = (
         "mongo --quiet  localhost:27017/admin <<\\EOF\n"
-        "db=db.getSiblingDB('test_db');rs.slaveOk();printjson(db.test_collection.find())\nEOF"
+        "db=db.getSiblingDB('test_db');rs.slaveOk();db.test_collection.find()\nEOF"
     )
 
     # Assertions


### PR DESCRIPTION
1. 修改slaveok为secondaryok
2. 去除printjson方法，在printjson方法中使用 var host会报错
 [thread1] SyntaxError: expected expression, got keyword 'var' @(shell):1:55
导致无法获取从节点，导致多条语句执行过程中从节点获取出错。