### PR TITLE
新增密码仓库的初步支持

### DIFF
--- a/archery/settings.py
+++ b/archery/settings.py
@@ -71,6 +71,7 @@ env = environ.Env(
         ],
     ),
     CURRENT_AUDITOR=(str, "sql.utils.workflow_audit:AuditV2"),
+    PASSWORD_MIXIN_PATH=(str, "sql.plugins.password:DummyMixin"),
 )
 
 # SECURITY WARNING: keep the secret key used in production secret!
@@ -112,6 +113,8 @@ ENABLED_NOTIFIERS = env("ENABLED_NOTIFIERS")
 ENABLED_ENGINES = env("ENABLED_ENGINES")
 
 CURRENT_AUDITOR = env("CURRENT_AUDITOR")
+
+PASSWORD_MIXIN_PATH = env("PASSWORD_MIXIN_PATH")
 
 # Application definition
 INSTALLED_APPS = (

--- a/sql/engines/__init__.py
+++ b/sql/engines/__init__.py
@@ -24,8 +24,7 @@ class EngineBase:
             self.instance_name = instance.instance_name
             self.host = instance.host
             self.port = int(instance.port)
-            self.user = instance.user
-            self.password = instance.password
+            self.user, self.password = self.instance.get_username_password()
             self.db_name = instance.db_name
             self.mode = instance.mode
 

--- a/sql/models.py
+++ b/sql/models.py
@@ -20,9 +20,12 @@ try:
     password_module = importlib.import_module(file)
     PasswordMixin = getattr(password_module, _class)
 except (ImportError, AttributeError) as e:
-    logger.error(f"failed to import password minxin {settings.PASSWORD_MIXIN_PATH}, {str(e)}")
+    logger.error(
+        f"failed to import password minxin {settings.PASSWORD_MIXIN_PATH}, {str(e)}"
+    )
     logger.error(f"falling back to dummy mixin")
     from sql.plugins.password import DummyMixin
+
     PasswordMixin = DummyMixin
 
 
@@ -39,9 +42,7 @@ class ResourceGroup(models.Model):
     ding_webhook = models.CharField("钉钉webhook地址", max_length=255, blank=True)
     feishu_webhook = models.CharField("飞书webhook地址", max_length=255, blank=True)
     qywx_webhook = models.CharField("企业微信webhook地址", max_length=255, blank=True)
-    is_deleted = models.IntegerField(
-        "是否删除", choices=((0, "否"), (1, "是")), default=0
-    )
+    is_deleted = models.IntegerField("是否删除", choices=((0, "否"), (1, "是")), default=0)
     create_time = models.DateTimeField(auto_now_add=True)
     sys_time = models.DateTimeField(auto_now=True)
 
@@ -65,9 +66,7 @@ class Users(AbstractUser):
     wx_user_id = models.CharField("企业微信UserID", max_length=64, blank=True)
     feishu_open_id = models.CharField("飞书OpenID", max_length=64, blank=True)
     failed_login_count = models.IntegerField("失败计数", default=0)
-    last_login_failed_at = models.DateTimeField(
-        "上次失败登录时间", blank=True, null=True
-    )
+    last_login_failed_at = models.DateTimeField("上次失败登录时间", blank=True, null=True)
     resource_group = models.ManyToManyField(
         ResourceGroup, verbose_name="资源组", blank=True
     )
@@ -246,9 +245,7 @@ class Instance(models.Model, PasswordMixin):
     resource_group = models.ManyToManyField(
         ResourceGroup, verbose_name="资源组", blank=True
     )
-    instance_tag = models.ManyToManyField(
-        InstanceTag, verbose_name="实例标签", blank=True
-    )
+    instance_tag = models.ManyToManyField(InstanceTag, verbose_name="实例标签", blank=True)
     tunnel = models.ForeignKey(
         Tunnel,
         verbose_name="连接隧道",
@@ -344,9 +341,7 @@ class SqlWorkflow(models.Model, WorkflowAuditMixin):
     run_date_end = models.DateTimeField("可执行结束时间", null=True, blank=True)
     create_time = models.DateTimeField("创建时间", auto_now_add=True)
     finish_time = models.DateTimeField("结束时间", null=True, blank=True)
-    is_manual = models.IntegerField(
-        "是否原生执行", choices=((0, "否"), (1, "是")), default=0
-    )
+    is_manual = models.IntegerField("是否原生执行", choices=((0, "否"), (1, "是")), default=0)
 
     def __str__(self):
         return self.workflow_name
@@ -390,9 +385,7 @@ class WorkflowAudit(models.Model):
     workflow_id = models.BigIntegerField("关联业务id")
     workflow_type = models.IntegerField("申请类型", choices=WorkflowType.choices)
     workflow_title = models.CharField("申请标题", max_length=50)
-    workflow_remark = models.CharField(
-        "申请备注", default="", max_length=140, blank=True
-    )
+    workflow_remark = models.CharField("申请备注", default="", max_length=140, blank=True)
     audit_auth_groups = models.CharField("审批权限组列表", max_length=255)
     current_audit = models.CharField("当前审批权限组", max_length=20)
     next_audit = models.CharField("下级审批权限组", max_length=20)
@@ -479,9 +472,7 @@ class WorkflowLog(models.Model):
 
     id = models.AutoField(primary_key=True)
     audit_id = models.IntegerField("工单审批id", db_index=True)
-    operation_type = models.SmallIntegerField(
-        "操作类型", choices=WorkflowAction.choices
-    )
+    operation_type = models.SmallIntegerField("操作类型", choices=WorkflowAction.choices)
     # operation_type_desc 字段实际无意义
     operation_type_desc = models.CharField("操作类型描述", max_length=10)
     operation_info = models.CharField("操作信息", max_length=1000)
@@ -651,16 +642,12 @@ class DataMaskingColumns(models.Model):
         choices=rule_type_choices,
         help_text="三段式通用脱敏规则：根据字段长度自动分成三份，中间段脱敏。",
     )
-    active = models.BooleanField(
-        "激活状态", choices=((False, "未激活"), (True, "激活"))
-    )
+    active = models.BooleanField("激活状态", choices=((False, "未激活"), (True, "激活")))
     instance = models.ForeignKey(Instance, on_delete=models.CASCADE)
     table_schema = models.CharField("字段所在库名", max_length=64)
     table_name = models.CharField("字段所在表名", max_length=64)
     column_name = models.CharField("字段名", max_length=64)
-    column_comment = models.CharField(
-        "字段描述", max_length=1024, default="", blank=True
-    )
+    column_comment = models.CharField("字段描述", max_length=1024, default="", blank=True)
     create_time = models.DateTimeField(auto_now_add=True)
     sys_time = models.DateTimeField(auto_now=True)
 
@@ -699,12 +686,8 @@ class InstanceAccount(models.Model):
 
     instance = models.ForeignKey(Instance, on_delete=models.CASCADE)
     user = fields.EncryptedCharField(verbose_name="账号", max_length=128)
-    host = models.CharField(
-        verbose_name="主机", max_length=64
-    )  # mysql数据库存储主机信息
-    db_name = models.CharField(
-        verbose_name="数据库名称", max_length=128
-    )  # mongo数据库存储数据库名称
+    host = models.CharField(verbose_name="主机", max_length=64)  # mysql数据库存储主机信息
+    db_name = models.CharField(verbose_name="数据库名称", max_length=128)  # mongo数据库存储数据库名称
     password = fields.EncryptedCharField(
         verbose_name="密码", max_length=128, default="", blank=True
     )
@@ -727,9 +710,7 @@ class InstanceDatabase(models.Model):
     instance = models.ForeignKey(Instance, on_delete=models.CASCADE)
     db_name = models.CharField("数据库名", max_length=128)
     owner = models.CharField("负责人", max_length=50, default="", blank=True)
-    owner_display = models.CharField(
-        "负责人中文名", max_length=50, default="", blank=True
-    )
+    owner_display = models.CharField("负责人中文名", max_length=50, default="", blank=True)
     remark = models.CharField("备注", max_length=255, default="", blank=True)
     sys_time = models.DateTimeField("系统修改时间", auto_now=True)
 
@@ -822,9 +803,7 @@ class ArchiveConfig(models.Model, WorkflowAuditMixin):
     )
     state = models.BooleanField("是否启用归档", default=True)
     user_name = models.CharField("申请人", max_length=30, blank=True, default="")
-    user_display = models.CharField(
-        "申请人中文名", max_length=50, blank=True, default=""
-    )
+    user_display = models.CharField("申请人中文名", max_length=50, blank=True, default="")
     create_time = models.DateTimeField("创建时间", auto_now_add=True)
     last_archive_time = models.DateTimeField("最近归档时间", blank=True, null=True)
     sys_time = models.DateTimeField("系统时间修改", auto_now=True)

--- a/sql/models.py
+++ b/sql/models.py
@@ -42,7 +42,9 @@ class ResourceGroup(models.Model):
     ding_webhook = models.CharField("钉钉webhook地址", max_length=255, blank=True)
     feishu_webhook = models.CharField("飞书webhook地址", max_length=255, blank=True)
     qywx_webhook = models.CharField("企业微信webhook地址", max_length=255, blank=True)
-    is_deleted = models.IntegerField("是否删除", choices=((0, "否"), (1, "是")), default=0)
+    is_deleted = models.IntegerField(
+        "是否删除", choices=((0, "否"), (1, "是")), default=0
+    )
     create_time = models.DateTimeField(auto_now_add=True)
     sys_time = models.DateTimeField(auto_now=True)
 
@@ -66,7 +68,9 @@ class Users(AbstractUser):
     wx_user_id = models.CharField("企业微信UserID", max_length=64, blank=True)
     feishu_open_id = models.CharField("飞书OpenID", max_length=64, blank=True)
     failed_login_count = models.IntegerField("失败计数", default=0)
-    last_login_failed_at = models.DateTimeField("上次失败登录时间", blank=True, null=True)
+    last_login_failed_at = models.DateTimeField(
+        "上次失败登录时间", blank=True, null=True
+    )
     resource_group = models.ManyToManyField(
         ResourceGroup, verbose_name="资源组", blank=True
     )
@@ -245,7 +249,9 @@ class Instance(models.Model, PasswordMixin):
     resource_group = models.ManyToManyField(
         ResourceGroup, verbose_name="资源组", blank=True
     )
-    instance_tag = models.ManyToManyField(InstanceTag, verbose_name="实例标签", blank=True)
+    instance_tag = models.ManyToManyField(
+        InstanceTag, verbose_name="实例标签", blank=True
+    )
     tunnel = models.ForeignKey(
         Tunnel,
         verbose_name="连接隧道",
@@ -341,7 +347,9 @@ class SqlWorkflow(models.Model, WorkflowAuditMixin):
     run_date_end = models.DateTimeField("可执行结束时间", null=True, blank=True)
     create_time = models.DateTimeField("创建时间", auto_now_add=True)
     finish_time = models.DateTimeField("结束时间", null=True, blank=True)
-    is_manual = models.IntegerField("是否原生执行", choices=((0, "否"), (1, "是")), default=0)
+    is_manual = models.IntegerField(
+        "是否原生执行", choices=((0, "否"), (1, "是")), default=0
+    )
 
     def __str__(self):
         return self.workflow_name
@@ -385,7 +393,9 @@ class WorkflowAudit(models.Model):
     workflow_id = models.BigIntegerField("关联业务id")
     workflow_type = models.IntegerField("申请类型", choices=WorkflowType.choices)
     workflow_title = models.CharField("申请标题", max_length=50)
-    workflow_remark = models.CharField("申请备注", default="", max_length=140, blank=True)
+    workflow_remark = models.CharField(
+        "申请备注", default="", max_length=140, blank=True
+    )
     audit_auth_groups = models.CharField("审批权限组列表", max_length=255)
     current_audit = models.CharField("当前审批权限组", max_length=20)
     next_audit = models.CharField("下级审批权限组", max_length=20)
@@ -472,7 +482,9 @@ class WorkflowLog(models.Model):
 
     id = models.AutoField(primary_key=True)
     audit_id = models.IntegerField("工单审批id", db_index=True)
-    operation_type = models.SmallIntegerField("操作类型", choices=WorkflowAction.choices)
+    operation_type = models.SmallIntegerField(
+        "操作类型", choices=WorkflowAction.choices
+    )
     # operation_type_desc 字段实际无意义
     operation_type_desc = models.CharField("操作类型描述", max_length=10)
     operation_info = models.CharField("操作信息", max_length=1000)
@@ -642,12 +654,16 @@ class DataMaskingColumns(models.Model):
         choices=rule_type_choices,
         help_text="三段式通用脱敏规则：根据字段长度自动分成三份，中间段脱敏。",
     )
-    active = models.BooleanField("激活状态", choices=((False, "未激活"), (True, "激活")))
+    active = models.BooleanField(
+        "激活状态", choices=((False, "未激活"), (True, "激活"))
+    )
     instance = models.ForeignKey(Instance, on_delete=models.CASCADE)
     table_schema = models.CharField("字段所在库名", max_length=64)
     table_name = models.CharField("字段所在表名", max_length=64)
     column_name = models.CharField("字段名", max_length=64)
-    column_comment = models.CharField("字段描述", max_length=1024, default="", blank=True)
+    column_comment = models.CharField(
+        "字段描述", max_length=1024, default="", blank=True
+    )
     create_time = models.DateTimeField(auto_now_add=True)
     sys_time = models.DateTimeField(auto_now=True)
 
@@ -686,8 +702,12 @@ class InstanceAccount(models.Model):
 
     instance = models.ForeignKey(Instance, on_delete=models.CASCADE)
     user = fields.EncryptedCharField(verbose_name="账号", max_length=128)
-    host = models.CharField(verbose_name="主机", max_length=64)  # mysql数据库存储主机信息
-    db_name = models.CharField(verbose_name="数据库名称", max_length=128)  # mongo数据库存储数据库名称
+    host = models.CharField(
+        verbose_name="主机", max_length=64
+    )  # mysql数据库存储主机信息
+    db_name = models.CharField(
+        verbose_name="数据库名称", max_length=128
+    )  # mongo数据库存储数据库名称
     password = fields.EncryptedCharField(
         verbose_name="密码", max_length=128, default="", blank=True
     )
@@ -710,7 +730,9 @@ class InstanceDatabase(models.Model):
     instance = models.ForeignKey(Instance, on_delete=models.CASCADE)
     db_name = models.CharField("数据库名", max_length=128)
     owner = models.CharField("负责人", max_length=50, default="", blank=True)
-    owner_display = models.CharField("负责人中文名", max_length=50, default="", blank=True)
+    owner_display = models.CharField(
+        "负责人中文名", max_length=50, default="", blank=True
+    )
     remark = models.CharField("备注", max_length=255, default="", blank=True)
     sys_time = models.DateTimeField("系统修改时间", auto_now=True)
 
@@ -803,7 +825,9 @@ class ArchiveConfig(models.Model, WorkflowAuditMixin):
     )
     state = models.BooleanField("是否启用归档", default=True)
     user_name = models.CharField("申请人", max_length=30, blank=True, default="")
-    user_display = models.CharField("申请人中文名", max_length=50, blank=True, default="")
+    user_display = models.CharField(
+        "申请人中文名", max_length=50, blank=True, default=""
+    )
     create_time = models.DateTimeField("创建时间", auto_now_add=True)
     last_archive_time = models.DateTimeField("最近归档时间", blank=True, null=True)
     sys_time = models.DateTimeField("系统时间修改", auto_now=True)

--- a/sql/models.py
+++ b/sql/models.py
@@ -1,13 +1,29 @@
 # -*- coding: UTF-8 -*-
+import importlib
+import logging
 from typing import Optional
 
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 from mirage import fields
 from django.utils.translation import gettext as _
+from django.conf import settings
 from mirage.crypto import Crypto
 
 from common.utils.const import WorkflowStatus, WorkflowType, WorkflowAction
+
+
+logger = logging.getLogger("default")
+file, _class = settings.PASSWORD_MIXIN_PATH.split(":")
+
+try:
+    password_module = importlib.import_module(file)
+    PasswordMixin = getattr(password_module, _class)
+except (ImportError, AttributeError) as e:
+    logger.error(f"failed to import password minxin {settings.PASSWORD_MIXIN_PATH}, {str(e)}")
+    logger.error(f"falling back to dummy mixin")
+    from sql.plugins.password import DummyMixin
+    PasswordMixin = DummyMixin
 
 
 class ResourceGroup(models.Model):
@@ -179,7 +195,7 @@ class Tunnel(models.Model):
         verbose_name_plural = "隧道配置"
 
 
-class Instance(models.Model):
+class Instance(models.Model, PasswordMixin):
     """
     各个线上实例配置
     """

--- a/sql/plugins/password.py
+++ b/sql/plugins/password.py
@@ -14,6 +14,7 @@ class DummyMixin:
     """mixin 模板, 用于提供一些基础的方法, 给其他 mixin 继承
     默认从schema 中直接提取 username 和 password
     """
+
     def get_username_password(self):
         return self.user, self.password
 
@@ -22,7 +23,7 @@ password_cache = {
     "instance_name": {
         "username": "username",
         "password": "password",
-        "expires_at": "1740557906.15272"
+        "expires_at": "1740557906.15272",
     }
 }
 
@@ -34,21 +35,28 @@ class VaultMixin(DummyMixin):
     不使用任何 token, 适合 vault-proxy 部署方式, 如需其他部署方式, 可继承后修改配置
     使用的是 static secret, 如需其他获取方式, 可继承后修改配置
     """
+
     vault_server = "localhost:8200"
     vault_token = ""
+
     def get_username_password(self):
         if self.instance_name in password_cache:
-            if password_cache[self.instance_name]['expires_at'] > time.time():
-                return password_cache[self.instance_name]['username'], password_cache[self.instance_name]['password']
+            if password_cache[self.instance_name]["expires_at"] > time.time():
+                return (
+                    password_cache[self.instance_name]["username"],
+                    password_cache[self.instance_name]["password"],
+                )
 
-        vault_role = f"{self.instance_name}-archery-rw" 
-        response = requests.get(f"http://{self.vault_server}/v1/database/static-creds/{vault_role}",
-                                headers={"X-Vault-Token": self.vault_token})
+        vault_role = f"{self.instance_name}-archery-rw"
+        response = requests.get(
+            f"http://{self.vault_server}/v1/database/static-creds/{vault_role}",
+            headers={"X-Vault-Token": self.vault_token},
+        )
         response.raise_for_status()
-        data = response.json()['data']
+        data = response.json()["data"]
         password_cache[self.instance_name] = {
-            "username": data['username'],
-            "password": data['password'],
-            "expires_at": time.time() + data['ttl'] - 60
+            "username": data["username"],
+            "password": data["password"],
+            "expires_at": time.time() + data["ttl"] - 60,
         }
-        return data['username'], data['password']
+        return data["username"], data["password"]

--- a/sql/plugins/password.py
+++ b/sql/plugins/password.py
@@ -6,6 +6,7 @@
 
 包括名字, 类型, 等等. 通过这些信息, 插件可以获取数据库的用户名和密码
 """
+
 import time
 import requests
 

--- a/sql/plugins/password.py
+++ b/sql/plugins/password.py
@@ -1,0 +1,54 @@
+"""
+本文件存放一些和密码相关的插件
+
+插件提供两个方法, 获取用户名和密码, 用于连接数据库
+插件在使用时, 会和 Instance 一起使用, 可以用 self 对象获取 instance 的各种信息
+
+包括名字, 类型, 等等. 通过这些信息, 插件可以获取数据库的用户名和密码
+"""
+import time
+import requests
+
+
+class DummyMixin:
+    """mixin 模板, 用于提供一些基础的方法, 给其他 mixin 继承
+    默认从schema 中直接提取 username 和 password
+    """
+    def get_username_password(self):
+        return self.user, self.password
+
+
+password_cache = {
+    "instance_name": {
+        "username": "username",
+        "password": "password",
+        "expires_at": "1740557906.15272"
+    }
+}
+
+
+class VaultMixin(DummyMixin):
+    """
+    和 sqlinstance 搭配使用
+    从 vault 中获取用户名和密码, 调用的是 localhost 8000 端口的 vault 服务
+    不使用任何 token, 适合 vault-proxy 部署方式, 如需其他部署方式, 可继承后修改配置
+    使用的是 static secret, 如需其他获取方式, 可继承后修改配置
+    """
+    vault_server = "localhost:8200"
+    vault_token = ""
+    def get_username_password(self):
+        if self.instance_name in password_cache:
+            if password_cache[self.instance_name]['expires_at'] > time.time():
+                return password_cache[self.instance_name]['username'], password_cache[self.instance_name]['password']
+
+        vault_role = f"{self.instance_name}-archery-rw" 
+        response = requests.get(f"http://{self.vault_server}/v1/database/static-creds/{vault_role}",
+                                headers={"X-Vault-Token": self.vault_token})
+        response.raise_for_status()
+        data = response.json()['data']
+        password_cache[self.instance_name] = {
+            "username": data['username'],
+            "password": data['password'],
+            "expires_at": time.time() + data['ttl'] - 60
+        }
+        return data['username'], data['password']

--- a/sql/plugins/tests.py
+++ b/sql/plugins/tests.py
@@ -1,5 +1,5 @@
 # -*- coding: UTF-8 -*-
-""" 
+"""
 @author: hhyo
 @license: Apache Licence
 @file: tests.py
@@ -340,14 +340,16 @@ class TestSoar(TestCase):
 
 def test_password_mixin(mocker: MockerFixture):
     from sql.plugins.password import requests
+
     class MockReponse(Mock):
         def json(self):
             return {"data": {"username": "test", "password": "test", "ttl": 360}}
+
     mocker.patch.object(requests, "get", return_value=MockReponse())
-    
+
     class DummyInstance:
         instance_name = "dummy"
-    
+
     class CompondInstance(DummyInstance, VaultMixin):
         pass
 

--- a/sql/test_model.py
+++ b/sql/test_model.py
@@ -1,4 +1,5 @@
 """models.py 的补充测试"""
+
 from django.conf import settings
 from sql.models import InstanceTag
 
@@ -12,4 +13,5 @@ def test_instance_tag_str():
 def test_password_mixin_import_error():
     settings.PASSWORD_MIXIN_PATH = "sql.not_found:ErrorMixin"
     from sql.models import PasswordMixin
+
     assert PasswordMixin.__name__ == "DummyMixin"

--- a/sql/test_model.py
+++ b/sql/test_model.py
@@ -1,5 +1,5 @@
 """models.py 的补充测试"""
-
+from django.conf import settings
 from sql.models import InstanceTag
 
 
@@ -7,3 +7,9 @@ def test_instance_tag_str():
     i = InstanceTag(tag_name="test")
 
     assert str(i) == "test"
+
+
+def test_password_mixin_import_error():
+    settings.PASSWORD_MIXIN_PATH = "sql.not_found:ErrorMixin"
+    from sql.models import PasswordMixin
+    assert PasswordMixin.__name__ == "DummyMixin"


### PR DESCRIPTION
有些云厂商或公司内部设置了密码自动轮换, 保证安全, archery 的密码只能是静态的, 只能通过外挂程序来更新数据库内的密码, 本PR带来一个新的功能, 可以在 engine 初始化时自动去请求数据库的账号名和密码, 达到相对的安全.

同时提供了对应的配置项, 供高级使用者提供自己的密码管理器实现, 其中的实现可以完全自己掌控

1. 新增 DummyMixin , 作为base
2. 新增 VaultMixin, 作为范例
3. 配置项中新增 `PASSWORD_MIXIN_PATH`, 供需要的用户覆盖内置的密码管理器, 替代为自行实现的KMS, 如各大云厂商提供的KMS.

replace #2212