### PR TITLE
oracle工单提交中带有双引号的schema_name或者没有from关键字的delete语句报错。

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -550,7 +550,7 @@ class OracleEngine(EngineBase):
             else:
                 return False
         elif re.match(r"^delete", sql):
-            table_name = re.match(r"^delete\s+from\s+([\w-]+)\s*", sql, re.M).group(1)
+            table_name = re.match(r"^delete\s(.+?)\s", sql, re.M).group(1)
             if "." not in table_name:
                 table_name = f"{schema_name}.{table_name}"
             table_name = table_name.upper()


### PR DESCRIPTION
oracle工单提交中带有双引号的schema_name或者没有from关键字的delete语句
(例：
delete from "TEMPMAN".test_20250523 where id = 1;
delete "TEMPMAN".test_20250523 where id = 1;
delete tempman.test_20250523 where id = 1;
)
报错
AttributeError: 'NoneType' object has no attribute 'group'。 解决：修改正则表达式。