### PR TITLE
fix:fingerprint is not under an aggregate function and not in GROUP BY key.

### DIFF
--- a/sql/slowlog.py
+++ b/sql/slowlog.py
@@ -68,7 +68,7 @@ def slowquery_review(request):
                 fingerprint__icontains=search,
                 **filter_kwargs
             )
-            .annotate(SQLText=F("fingerprint"), SQLId=F("checksum"))
+            .annotate(SQLText=Max("fingerprint"), SQLId=F("checksum"))
             .values("SQLText", "SQLId")
             .annotate(
                 CreateTime=Max("slowqueryhistory__ts_max"),


### PR DESCRIPTION
在mysql的ONLY_FULL_GROUP_BY模式下，必须基于分组键（key expressions），或者对非分组键（包括普通列）使用聚合函数进行group by计算