### PR TITLE
fix(mssql): 数据导出工单-检查SQL Server行数统计相关问题

### DIFF
--- a/sql/offlinedownload.py
+++ b/sql/offlinedownload.py
@@ -143,12 +143,16 @@ class OffLineDownLoad(EngineBase):
                 # 替换 select distinct
                 pattern = r"(^\s*select\s+distinct)\b"
                 replacement = r"\1 top 100 percent"
-                sql, n = re.subn(pattern, replacement, sql, count=1, flags=re.IGNORECASE)
+                sql, n = re.subn(
+                    pattern, replacement, sql, count=1, flags=re.IGNORECASE
+                )
                 if n == 0:
                     # 替换 select
                     pattern = r"(^\s*select)\b"
                     replacement = r"\1 top 100 percent"
-                    sql = re.sub(pattern, replacement, sql, count=1, flags=re.IGNORECASE)
+                    sql = re.sub(
+                        pattern, replacement, sql, count=1, flags=re.IGNORECASE
+                    )
 
         count_sql = f"SELECT COUNT(*) FROM ({sql.rstrip(';')}) t"
         clean_sql = sql.strip().lower()

--- a/sql/templates/sqlexportsubmit.html
+++ b/sql/templates/sqlexportsubmit.html
@@ -531,11 +531,14 @@
             if (optgroup === 'MsSQL') {
                 // 检查是否以select开头（不区分大小写）
                 if (/^\s*select\s+/i.test(sqlContent)) {
-                    // 检查是否是select distinct
-                    if (/^\s*select\s+distinct\s+/i.test(sqlContent)) {
-                        sqlContent = sqlContent.replace(/^(\s*select\s+distinct\s+)/i, '$1top 100 percent ');
-                    } else {
-                        sqlContent = sqlContent.replace(/^(\s*select\s+)/i, '$1top 100 percent ');
+                    // 检查select/select distinct之后是否已经有top
+                    if (!/^\s*select\s+(distinct\s+)?top\s/i.test(sqlContent)) {
+                        // 检查是否是select distinct
+                        if (/^\s*select\s+distinct\s+/i.test(sqlContent)) {
+                            sqlContent = sqlContent.replace(/^(\s*select\s+distinct\s+)/i, '$1top 100 percent ');
+                        } else {
+                            sqlContent = sqlContent.replace(/^(\s*select\s+)/i, '$1top 100 percent ');
+                        }
                     }
                 }
             }

--- a/sql/templates/sqlexportsubmit.html
+++ b/sql/templates/sqlexportsubmit.html
@@ -527,6 +527,18 @@
             }
 
             var sqlContent = sqlContent.trim().replace(/;$/, '');
+            // 如果是mssql数据库，需要在select后添加top 100 percent以应对子查询语法错误
+            if (optgroup === 'MsSQL') {
+                // 检查是否以select开头（不区分大小写）
+                if (/^\s*select\s+/i.test(sqlContent)) {
+                    // 检查是否是select distinct
+                    if (/^\s*select\s+distinct\s+/i.test(sqlContent)) {
+                        sqlContent = sqlContent.replace(/^(\s*select\s+distinct\s+)/i, '$1top 100 percent ');
+                    } else {
+                        sqlContent = sqlContent.replace(/^(\s*select\s+)/i, '$1top 100 percent ');
+                    }
+                }
+            }
             var sqlContent = 'select count(1) from (' + sqlContent + '\n) t'
              
             //提交请求
@@ -603,12 +615,18 @@
                     $("#btn-submitsql").prop("disabled", true);
                 }
             } else {
+                let errorMessage = data.msg;
+                // 检查错误消息是否包含特定错误代码(SqlServer的8155错误)
+                if (errorMessage && (errorMessage.includes('42000') && errorMessage.includes('8155'))) {
+                    errorMessage = '请为使用表达式、常量或函数的列设置列名(别名)';
+                }
+
                 showStatusNotice({
                     noticeIconClass: 'icon-error',
                     statusClass: 'status-error',
                     title: '校验失败',
                     message: '错误：{msg}',
-                    params: { msg: data.msg },
+                    params: { msg: errorMessage },
                     delay: 5000
                 });
             }

--- a/sql/test_offlinedownload.py
+++ b/sql/test_offlinedownload.py
@@ -97,6 +97,7 @@ class TestOfflineDownload(TestCase):
         offline_download = OffLineDownLoad()
         # 修改workflow的sql_content以匹配测试
         self.workflow.sql_content = "SELECT * FROM test_table"
+        self.workflow.db_type = "mysql"
         result = offline_download.pre_count_check(self.workflow)
 
         # 验证结果
@@ -122,6 +123,7 @@ class TestOfflineDownload(TestCase):
         # 执行测试
         offline_download = OffLineDownLoad()
         self.workflow.sql_content = "SELECT * FROM test_table"
+        self.workflow.db_type = "mysql"
         result = offline_download.pre_count_check(self.workflow)
 
         # 验证结果
@@ -141,6 +143,7 @@ class TestOfflineDownload(TestCase):
 
         offline_download = OffLineDownLoad()
         self.workflow.sql_content = "DELETE FROM test_table"
+        self.workflow.db_type = "mysql"
         result = offline_download.pre_count_check(self.workflow)
 
         # 验证结果


### PR DESCRIPTION
1.在SQL Server查询中添加top 100 percent以解决包含ORDER BY的子查询统计问题。
2.优化错误提示，为特定SQL Server错误(8155)提供更友好的错误信息，以处理表达式、常量或函数的未设置列名导致count统计的报错。