### PR TITLE
优化(oracle.py):Oracle数据字典-表信息-添加索引字段展示-修改列名排序

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -271,7 +271,7 @@ class OracleEngine(EngineBase):
                         WHERE
                             bcs.OWNER=:db_name
                             AND bcs.TABLE_NAME=:tb_name
-                        ORDER BY bcs.COLUMN_NAME"""
+                        ORDER BY bcs.COLUMN_ID"""
         _desc_data = self.query(
             db_name=db_name,
             sql=desc_sql,

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -283,6 +283,7 @@ class OracleEngine(EngineBase):
         """获取表格索引信息"""
         index_sql = f""" SELECT ais.INDEX_NAME "索引名称",
                                 ais.uniqueness "唯一性",
+                                cols.column_names "索引列名",
                                 ais.index_type "索引类型",
                                 ais.compression "压缩属性",
                                 ais.tablespace_name "表空间",
@@ -295,6 +296,20 @@ class OracleEngine(EngineBase):
                             left join DBA_PART_INDEXES pis
                                 on ais.owner = pis.owner
                                 and ais.index_name = pis.index_name
+                            left JOIN (SELECT 
+                                    ics.index_owner,
+                                    ics.index_name,
+                                    LISTAGG(ics.column_name, ', ') WITHIN GROUP (ORDER BY ics.column_position) AS column_names
+                                FROM 
+                                    dba_ind_columns ics
+                                GROUP BY 
+                                    ics.index_owner, ics.index_name
+                                    UNION ALL
+                                    select lobs.owner, lobs.index_name, lobs.column_name
+                                      from dba_lobs lobs
+                                    ) cols
+                                ON ais.owner = cols.index_owner
+                                AND ais.index_name = cols.index_name
                             WHERE
                                 ais.owner = :db_name
                                 AND ais.table_name = :tb_name"""

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1687,6 +1687,53 @@ end;"""
         r = new_engine.lock_info()
         self.assertIsInstance(r, ResultSet)
 
+    @patch("sql.engines.oracle.OracleEngine.query")
+    def test_get_table_desc_data(self, _query):
+        """测试获取表格字段信息方法"""
+        new_engine = OracleEngine(instance=self.ins)
+
+        # 模拟查询返回结果
+        mock_result = ResultSet()
+        mock_result.column_list = ["列名", "列注释", "字段类型", "字段默认值", "是否为空", "所属索引", "约束类型"]
+        mock_result.rows = [("ID", "主键ID", "NUMBER(10)", "1", " NOT NULL", "PK_USER", "P")]
+        _query.return_value = mock_result
+
+        # 调用被测试方法
+        result = new_engine.get_table_desc_data(db_name="TEST_SCHEMA", tb_name="USERS")
+
+        # 验证结果结构
+        self.assertIsInstance(result, dict)
+        self.assertIn("column_list", result)
+        self.assertIn("rows", result)
+        self.assertIsInstance(result["column_list"], list)
+        self.assertIsInstance(result["rows"], list)
+
+        # 验证query方法被正确调用
+        _query.assert_called_once()
+
+    @patch("sql.engines.oracle.OracleEngine.query")
+    def test_get_table_index_data(self, _query):
+        """测试获取表格索引信息方法"""
+        new_engine = OracleEngine(instance=self.ins)
+
+        # 模拟查询返回结果
+        mock_result = ResultSet()
+        mock_result.column_list = ["索引名称", "唯一性", "索引类型", "压缩属性", "表空间", "状态", "分区"]
+        mock_result.rows = [("PK_USERS", "UNIQUE", "NORMAL", "DISABLED", "USERS_TBS", "VALID", "NO")]
+        _query.return_value = mock_result
+
+        # 调用被测试方法
+        result = new_engine.get_table_index_data(db_name="TEST_SCHEMA", tb_name="USERS")
+
+        # 验证结果结构
+        self.assertIsInstance(result, dict)
+        self.assertIn("column_list", result)
+        self.assertIn("rows", result)
+        self.assertIsInstance(result["column_list"], list)
+        self.assertIsInstance(result["rows"], list)
+
+        # 验证query方法被正确调用
+        _query.assert_called_once()
 
 class MongoTest(TestCase):
     def setUp(self) -> None:

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1694,8 +1694,18 @@ end;"""
 
         # 模拟查询返回结果
         mock_result = ResultSet()
-        mock_result.column_list = ["列名", "列注释", "字段类型", "字段默认值", "是否为空", "所属索引", "约束类型"]
-        mock_result.rows = [("ID", "主键ID", "NUMBER(10)", "1", " NOT NULL", "PK_USER", "P")]
+        mock_result.column_list = [
+            "列名",
+            "列注释",
+            "字段类型",
+            "字段默认值",
+            "是否为空",
+            "所属索引",
+            "约束类型",
+        ]
+        mock_result.rows = [
+            ("ID", "主键ID", "NUMBER(10)", "1", " NOT NULL", "PK_USER", "P")
+        ]
         _query.return_value = mock_result
 
         # 调用被测试方法
@@ -1718,8 +1728,18 @@ end;"""
 
         # 模拟查询返回结果
         mock_result = ResultSet()
-        mock_result.column_list = ["索引名称", "唯一性", "索引类型", "压缩属性", "表空间", "状态", "分区"]
-        mock_result.rows = [("PK_USERS", "UNIQUE", "NORMAL", "DISABLED", "USERS_TBS", "VALID", "NO")]
+        mock_result.column_list = [
+            "索引名称",
+            "唯一性",
+            "索引类型",
+            "压缩属性",
+            "表空间",
+            "状态",
+            "分区",
+        ]
+        mock_result.rows = [
+            ("PK_USERS", "UNIQUE", "NORMAL", "DISABLED", "USERS_TBS", "VALID", "NO")
+        ]
         _query.return_value = mock_result
 
         # 调用被测试方法
@@ -1734,6 +1754,7 @@ end;"""
 
         # 验证query方法被正确调用
         _query.assert_called_once()
+
 
 class MongoTest(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
问题：
原列信息中的所属索引无法展示复合索引顺序，字段多的时候也不好直观展示索引字段。
原列信息按列名排序。
修复：
1，在索引信息中添加索引对应的索引字段，复合索引字段按顺序展示。
2，列信息按列id排序。
<img width="866" height="673" alt="Oracle表信息-索引列名" src="https://github.com/user-attachments/assets/eafafa0b-8a80-415d-9eab-bcb228b5d5be" />

